### PR TITLE
fix np.NaN deprecation issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,4 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+src/NeuNorm/_version.py

--- a/src/NeuNorm/normalization.py
+++ b/src/NeuNorm/normalization.py
@@ -19,7 +19,7 @@ class Normalization:
     working_data_type = np.float32
 
     def __init__(self):
-        self.shape = {"width": np.NaN, "height": np.NaN}
+        self.shape = {"width": np.nan, "height": np.nan}
         self.dict_image = {
             "data": None,
             "oscilation": None,
@@ -43,7 +43,7 @@ class Normalization:
             "shape": copy.deepcopy(self.shape),
         }
 
-        __roi_dict = {"x0": np.NaN, "x1": np.NaN, "y0": np.NaN, "y1": np.NaN}
+        __roi_dict = {"x0": np.nan, "x1": np.nan, "y0": np.nan, "y1": np.nan}
         self.roi = {
             "normalization": copy.deepcopy(__roi_dict),
             "crop": copy.deepcopy(__roi_dict),
@@ -511,7 +511,7 @@ class Normalization:
 
                 self.data["ob"]["data_mean"] = _ob_corrected_normalized
                 _working_ob = copy.deepcopy(_ob_corrected_normalized)
-                _working_ob[_working_ob == 0] = np.NaN
+                _working_ob[_working_ob == 0] = np.nan
 
                 if notebook:
                     # turn on progress bar
@@ -556,7 +556,7 @@ class Normalization:
                 normalized_data = []
                 for _index, [_sample, _ob] in enumerate(sample_ob):
                     _working_ob = copy.deepcopy(_ob)
-                    _working_ob[_working_ob == 0] = np.NaN
+                    _working_ob[_working_ob == 0] = np.nan
                     _norm = np.divide(_sample, _working_ob)
                     _norm[np.isnan(_norm)] = 0
                     _norm[np.isinf(_norm)] = 0

--- a/src/NeuNorm/roi.py
+++ b/src/NeuNorm/roi.py
@@ -4,13 +4,13 @@ import numpy as np
 class ROI(object):
     """class that list the type of ROI available"""
 
-    x0 = np.NaN
-    y0 = np.NaN
-    x1 = np.NaN
-    y1 = np.NaN
+    x0 = np.nan
+    y0 = np.nan
+    x1 = np.nan
+    y1 = np.nan
 
     def __init__(
-        self, x0=np.NaN, y0=np.NaN, x1=np.NaN, y1=np.NaN, width=np.NaN, height=np.NaN
+        self, x0=np.nan, y0=np.nan, x1=np.nan, y1=np.nan, width=np.nan, height=np.nan
     ):
         if np.isnan(x0) or np.isnan(y0):
             raise ValueError("x0 and y0 must be provided!")

--- a/tests/NeuNorm/roi_test.py
+++ b/tests/NeuNorm/roi_test.py
@@ -32,7 +32,7 @@ class TestRoi(unittest.TestCase):
         y0 = 1
         x1 = 2
         y1 = 3
-        self.assertRaises(ValueError, ROI, np.NaN, y0, x1, y1)
+        self.assertRaises(ValueError, ROI, np.nan, y0, x1, y1)
 
         x0 = 1
         x1 = 2
@@ -44,12 +44,12 @@ class TestRoi(unittest.TestCase):
         x0 = 1
         y0 = 1
         y1 = 2
-        self.assertRaises(ValueError, ROI, x0, y0, np.NaN, y1)
+        self.assertRaises(ValueError, ROI, x0, y0, np.nan, y1)
 
         x0 = 1
         y0 = 2
         x1 = 3
-        self.assertRaises(ValueError, ROI, x0, y0, x1, np.NaN)
+        self.assertRaises(ValueError, ROI, x0, y0, x1, np.nan)
 
     def test_x_and_y_correctly_sorted(self):
         """assert x0 and y0 are always the smallest of the x and y values"""


### PR DESCRIPTION
This PR introduces the following changes:

- add version file to ignore list (it should be generated during packaging on the fly)
- fix deprecated `np.NaN` syntax issue (this is affecting downstream library)

> EWM item: [Task 7296](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=7296)