### PR TITLE
ci: retarget pre-commit-ci autoupdates to neunorm-2.0-base

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+ci:
+  autoupdate_branch: neunorm-2.0-base
+
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.5.0

--- a/src/NeuNorm/normalization.py
+++ b/src/NeuNorm/normalization.py
@@ -825,7 +825,7 @@ class Normalization:
         if data is None:
             return False
 
-        #metadata = self.data[data_type]["metadata"]
+        # metadata = self.data[data_type]["metadata"]
         metadata = self.data[DataType.sample]["metadata"]
 
         list_file_name_raw = self.data[data_type]["file_name"]


### PR DESCRIPTION
Active development has moved to `neunorm-2.0-base`. This retargets pre-commit-ci autoupdate PRs to that branch so they don't keep targeting `main` and getting closed weekly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)