### PR TITLE
Drop pip ecosystem from Dependabot (keep github-actions)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,3 @@ updates:
       all-actions:
         patterns:
           - "*" # bump all actions together in a single PR
-  - package-ecosystem: "pip" # [project.dependencies] floors in pyproject.toml
-    directory: "/"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
Removes the `pip` ecosystem from `dependabot.yml`, keeping github-actions.

**Why:** NeuNorm is a pixi project. Dependabot-pip only bumps the `[project.dependencies]` floors — which diverges them from the `[tool.pixi.*]` floors, over-constrains `pip install NeuNorm` (its initial batch proposed e.g. `numpy>=2.4.6`, excluding 2.0–2.3), and never touches `pixi.lock`. Dependency currency is already handled by the `update-lockfiles` workflow (the lock) plus the `[tool.pixi.*]` floors. The initial batch also flooded the code owners via CODEOWNERS.

The 5 initial pip PRs (#127–129, #131–132) are closed; the github-actions group (#130) stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)