### PR TITLE
docs: add CHANGELOG and 1.x→2.0 migration guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,9 @@ legacy API.
   with proton-charge correction, ROI clipping, run combination, air-region
   correction, spatial rebinning, and Poisson/systematic uncertainty helpers
   (`neunorm.processing`).
-- **HDF5 as the primary output format** (`neunorm.exporters.write_hdf5`), with
-  detector masks and provenance metadata; TIFF export retained as secondary
-  (`write_tiff_stack`, via scitiff).
+- **HDF5 as the primary output format** (`neunorm.exporters.hdf5_writer.write_hdf5`),
+  with detector masks and provenance metadata; TIFF export retained as secondary
+  (`neunorm.exporters.tiff_writer.write_tiff_stack`, via scitiff).
 - **Loaders** for TIFF, FITS, NeXus event, and NeXus metadata
   (`neunorm.loaders`), including shutter-count and TOF-spectra readers.
 - **Resonance / Bragg-edge analysis and TOF statistics** (`neunorm.tof.resonance`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,81 @@
+# Changelog
+
+All notable changes to NeuNorm are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+<!-- When cutting the release, replace "Unreleased" below with the tag date (YYYY-MM-DD). -->
+
+## [2.0.0] - Unreleased
+
+NeuNorm 2.0 is a complete, [scipp](https://scipp.github.io/)-based rewrite of the
+library. It is a **breaking change**: code written against the 1.x
+`NeuNorm.normalization.Normalization` API will not run unchanged. See the
+[1.x → 2.0 migration guide](docs/migration.md), and pin `NeuNorm<2` to stay on the
+legacy API.
+
+### Added
+
+- **Scipp-native processing.** All data are `scipp.DataArray` objects that carry
+  variances, so uncertainty is propagated automatically through every step.
+- **Time-of-flight (TOF) support** for the VENUS pulsed source — wavelength-resolved
+  (hyperspectral) transmission `T(λ, x, y)`, TOF binning, and histogram rebinning.
+- **Event-mode processing** for Timepix3 detectors: NeXus/HDF5 event loading and
+  pulse reconstruction (`neunorm.loaders.event_loader`, `neunorm.tof`).
+- **End-to-end detector pipelines** in `neunorm.pipelines`, one per
+  detector/facility combination: `run_mars_ccd_pipeline`, `run_mars_tpx3_pipeline`,
+  `run_venus_ccd_pipeline`, `run_venus_tpx1_pipeline`,
+  `run_venus_tpx3_histogram_pipeline`, and `run_venus_tpx3_event_pipeline`.
+- **Composable processing functions** for building custom workflows: dark
+  subtraction, reference (open-beam/dark) preparation, transmission normalization
+  with proton-charge correction, ROI clipping, run combination, air-region
+  correction, spatial rebinning, and Poisson/systematic uncertainty helpers
+  (`neunorm.processing`).
+- **HDF5 as the primary output format** (`neunorm.exporters.write_hdf5`), with
+  detector masks and provenance metadata; TIFF export retained as secondary
+  (`write_tiff_stack`, via scitiff).
+- **Loaders** for TIFF, FITS, NeXus event, and NeXus metadata
+  (`neunorm.loaders`), including shutter-count and TOF-spectra readers.
+- **Resonance / Bragg-edge analysis and TOF statistics** (`neunorm.tof.resonance`,
+  `neunorm.tof.statistics_analyzer`).
+- **Pydantic v2 configuration models** (e.g. `BinningConfig`, `EventData`) for
+  explicit, validated configuration.
+- **Sphinx + autodoc documentation** published at
+  [neunorm.readthedocs.io](https://neunorm.readthedocs.io), with per-workflow guides
+  and a full API reference.
+
+### Changed
+
+- **Import name is now `neunorm` (lowercase)**, not `NeuNorm`. The PyPI/conda
+  distribution name remains `NeuNorm`, so `pip install NeuNorm` is unchanged, but
+  `import NeuNorm` becomes `import neunorm`.
+- **Minimum Python is now 3.11.**
+- **Development uses [pixi](https://pixi.sh)** (`pyproject.toml` `[tool.pixi.*]` +
+  `pixi.lock`); the 1.x conda `environment.yml` / `conda.recipe` are retired and
+  archived under `archive/neunorm-1.x/`.
+- **Optional features are exposed as extras**: `viz` (plopp/matplotlib) and
+  `performance` (Numba acceleration); Numba is optional and degrades to a no-op
+  when absent.
+
+### Removed
+
+- **The entire 1.x stateful API**, including `NeuNorm.normalization.Normalization`
+  and `NeuNorm.roi.ROI`. There is no drop-in compatibility shim — the flat-field
+  normalization physics is preserved, but the API is new. The 1.x source is kept
+  for reference under `archive/neunorm-1.x/`.
+
+### Migration
+
+See the [1.x → 2.0 migration guide](docs/migration.md) for a step-by-step mapping
+from the legacy `Normalization` workflow to the 2.0 pipelines and composable
+functions.
+
+---
+
+NeuNorm 1.x release history predates this changelog. The 1.x source, tests, and
+documentation are archived under
+[`archive/neunorm-1.x/`](archive/neunorm-1.x/); released 1.x versions remain
+available on PyPI and the `conda-forge` channel (`pip install "NeuNorm<2"`).
+
+[2.0.0]: https://github.com/ornlneutronimaging/NeuNorm/releases/tag/v2.0.0

--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ for ORNL imaging facilities — MARS at HFIR and VENUS at SNS.
 
 > **NeuNorm 2.0 is a complete, scipp-based rewrite and a breaking change from the
 > 1.x series.** Code written against the 1.x `NeuNorm.normalization.Normalization`
-> API will not run unchanged on 2.0. Pin `NeuNorm<2` to keep using the legacy API —
-> see [NeuNorm 1.x (Legacy)](#neunorm-1x-legacy).
+> API will not run unchanged on 2.0. See the
+> [1.x → 2.0 migration guide](docs/migration.md) to port your code, or pin
+> `NeuNorm<2` to keep using the legacy API — see
+> [NeuNorm 1.x (Legacy)](#neunorm-1x-legacy).
 
 ---
 
@@ -188,7 +190,9 @@ This enables **hyperspectral imaging** with wavelength-resolved transmission T(�
 
 Full documentation — user guides plus an autodoc API reference — is hosted at
 [neunorm.readthedocs.io](https://neunorm.readthedocs.io). The per-workflow guides
-live under [`docs/workflows/`](docs/workflows/).
+live under [`docs/workflows/`](docs/workflows/). Release history is in
+[CHANGELOG.md](CHANGELOG.md), and the
+[1.x → 2.0 migration guide](docs/migration.md) covers porting legacy code.
 
 ---
 
@@ -206,6 +210,8 @@ the default development branch).
 NeuNorm 1.x — the `from NeuNorm.normalization import Normalization` API — is the
 previous stable line. To keep using it, pin `NeuNorm<2` in your environment.
 Archived 1.x documentation: [archive/neunorm-1.x/README.md](archive/neunorm-1.x/README.md).
+To port existing 1.x code to 2.0, see the
+[migration guide](docs/migration.md).
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,13 @@ Pin `NeuNorm<2` if you depend on the legacy API.
 ```
 
 ```{toctree}
+:maxdepth: 1
+:caption: Upgrading
+
+migration
+```
+
+```{toctree}
 :maxdepth: 2
 :caption: Workflows
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,149 @@
+# Migrating from NeuNorm 1.x to 2.0
+
+NeuNorm 2.0 is a complete, [scipp](https://scipp.github.io/)-based rewrite. It is a
+**breaking change**: code written against the 1.x
+`NeuNorm.normalization.Normalization` API will not run unchanged, and there is **no
+drop-in compatibility shim**. The flat-field normalization *physics* is preserved,
+but the *API* is new.
+
+```{note}
+If you are not ready to migrate, pin the legacy line: `pip install "NeuNorm<2"`.
+The 1.x source is archived under
+[`archive/neunorm-1.x/`](https://github.com/ornlneutronimaging/NeuNorm/tree/main/archive/neunorm-1.x).
+```
+
+## What changed at a glance
+
+| | 1.x | 2.0 |
+|---|---|---|
+| Import | `import NeuNorm` | `import neunorm` (lowercase) |
+| Distribution name | `NeuNorm` | `NeuNorm` (unchanged — `pip install NeuNorm`) |
+| Minimum Python | 2.7 / 3.x | **3.11+** |
+| Core data type | NumPy arrays | `scipp.DataArray` (carries variances) |
+| Uncertainty | not propagated | **propagated automatically** |
+| API style | one stateful `Normalization` object | **functions + per-detector pipelines** |
+| Primary output | TIFF | **HDF5** (TIFF secondary) |
+| TOF / event mode | none | **first-class** (VENUS, Timepix) |
+| Dev environment | conda `environment.yml` | **pixi** (`pixi.lock`) |
+
+## The fastest path: use a pipeline
+
+In 1.x you drove a stateful object through `load` → `normalization` → `export`.
+In 2.0 the equivalent is a single **pipeline** call for your detector/facility,
+which loads, corrects, normalizes, and writes the result (with uncertainty, masks,
+and provenance) to HDF5.
+
+**1.x**
+
+```python
+from NeuNorm.normalization import Normalization
+
+o_norm = Normalization()
+o_norm.load(file="sample.tif", data_type="sample")
+o_norm.load(folder="/data/ob/", data_type="ob")
+o_norm.load(folder="/data/df/", data_type="df")   # dark / "df" frames
+o_norm.normalization()
+o_norm.export(folder="/data/normalized/", data_type="normalized")
+normalized = o_norm.get_normalized_data()           # NumPy array
+```
+
+**2.0** (MARS CCD/CMOS — continuous source, the closest analogue to the 1.x CCD case)
+
+```python
+from pathlib import Path
+from neunorm.pipelines.mars_ccd import run_mars_ccd_pipeline
+
+# Each inner list is one acquisition "run" to combine before processing.
+transmission = run_mars_ccd_pipeline(
+    sample_paths=[["sample_0001.tif", "sample_0002.tif"]],
+    ob_paths=[["ob_0001.tif", "ob_0002.tif"]],
+    dark_paths=[["dark_0001.tif"]],
+    output_path=Path("/data/normalized.hdf5"),
+    roi=(x0, y0, x1, y1),   # optional
+    gamma_filter=True,      # on by default
+)
+
+# `transmission` is a scipp.DataArray; the NumPy values are transmission.values
+```
+
+Pick the pipeline that matches your detector and facility:
+
+| Pipeline | Detector | Facility | TOF |
+|---|---|---|---|
+| `run_mars_ccd_pipeline` | CCD/CMOS | MARS (HFIR) | no |
+| `run_mars_tpx3_pipeline` | Timepix3 | MARS (HFIR) | no |
+| `run_venus_ccd_pipeline` | CCD/CMOS | VENUS (SNS) | no |
+| `run_venus_tpx1_pipeline` | Timepix1 | VENUS (SNS) | yes |
+| `run_venus_tpx3_histogram_pipeline` | Timepix3 | VENUS (SNS) | yes |
+| `run_venus_tpx3_event_pipeline` | Timepix3 (event) | VENUS (SNS) | yes |
+
+These share the same *flow* but not the same *signature* — TPX detectors omit
+`dark_paths`, the TOF pipelines add `rebin_by_tof`/`rebin_by_spatial`, and
+`run_venus_tpx3_event_pipeline` takes a `BinningConfig` and flat (per-run) path
+lists. Check each function's signature in the {doc}`api` reference.
+
+## The composable path: build your own workflow
+
+If you need finer control than a pipeline offers, 2.0 exposes the individual steps
+as functions (the pipelines themselves are just compositions of these — read a
+pipeline's source for the exact ordering). The core operation is
+`normalize_transmission`:
+
+```python
+from neunorm.loaders.stack_loader import load_stack
+from neunorm.processing.normalizer import normalize_transmission
+
+sample = load_stack(["sample_0001.tif", "sample_0002.tif"])  # scipp.DataArray
+ob = load_stack(["ob_0001.tif", "ob_0002.tif"])
+
+transmission = normalize_transmission(sample, ob)  # T = sample / ob, variances tracked
+```
+
+## Method / concept mapping
+
+| 1.x | 2.0 |
+|---|---|
+| `Normalization()` (stateful object) | a `run_*_pipeline(...)` call, or composable functions |
+| `.load(..., data_type="sample"/"ob")` | pipeline `sample_paths` / `ob_paths`, or `neunorm.loaders.load_stack` / `load_tiff_stack` / `load_fits_stack` |
+| `.load(..., data_type="df")` (dark/"df") | pipeline `dark_paths`, or `neunorm.processing.subtract_dark(data, dark)` |
+| `.normalization(roi=...)` | `run_*_pipeline(..., roi=...)`, or `neunorm.processing.normalize_transmission(sample, ob, ...)` |
+| `.df_correction()` | `neunorm.processing.subtract_dark(data, dark)` |
+| `.crop(roi=ROI(...))` | `neunorm.processing.apply_roi(data, (x0, y0, x1, y1))` |
+| auto/manual gamma filtering on `load()` | `neunorm.filters.apply_gamma_filter(...)`, or pipeline `gamma_filter=True` |
+| `.export(folder=..., file_type="tif")` | `neunorm.exporters.write_hdf5(...)` (primary) or `write_tiff_stack(...)`; pipelines write automatically via `output_path` |
+| `.get_normalized_data()` | the pipeline **returns** a `scipp.DataArray`; use `.values` for the NumPy array |
+| `from NeuNorm.roi import ROI; ROI(x0, y0, x1, y1)` | a plain tuple `(x0, y0, x1, y1)` |
+| `NeuNorm.normalization.DataType` | not needed — inputs are explicit function arguments |
+
+## ROI
+
+1.x used an `ROI` object; 2.0 uses a 4-integer tuple in the same order:
+
+```python
+# 1.x
+from NeuNorm.roi import ROI
+roi = ROI(x0=10, y0=10, x1=110, y1=110)
+
+# 2.0
+roi = (10, 10, 110, 110)   # (x0, y0, x1, y1), pixel bounds
+```
+
+## Working with the result
+
+A 2.0 pipeline returns a `scipp.DataArray` instead of a NumPy array:
+
+```python
+transmission.values        # NumPy array of transmission values
+transmission.variances     # propagated variances (None in 1.x — not tracked)
+transmission.coords        # axis coordinates (e.g. wavelength for TOF data)
+transmission.masks         # detector masks (e.g. dead pixels)
+```
+
+The normalized result is also written to `output_path` as HDF5 (and optionally
+TIFF), so downstream tools can read it directly without re-running the pipeline.
+
+## Next steps
+
+- {doc}`api` — full API reference for every loader, processing function, and pipeline.
+- The per-workflow guides under {doc}`workflows/README` walk through each
+  detector/facility combination end to end.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -104,13 +104,13 @@ transmission = normalize_transmission(sample, ob)  # T = sample / ob, variances 
 | 1.x | 2.0 |
 |---|---|
 | `Normalization()` (stateful object) | a `run_*_pipeline(...)` call, or composable functions |
-| `.load(..., data_type="sample"/"ob")` | pipeline `sample_paths` / `ob_paths`, or `neunorm.loaders.load_stack` / `load_tiff_stack` / `load_fits_stack` |
-| `.load(..., data_type="df")` (dark/"df") | pipeline `dark_paths`, or `neunorm.processing.subtract_dark(data, dark)` |
-| `.normalization(roi=...)` | `run_*_pipeline(..., roi=...)`, or `neunorm.processing.normalize_transmission(sample, ob, ...)` |
-| `.df_correction()` | `neunorm.processing.subtract_dark(data, dark)` |
-| `.crop(roi=ROI(...))` | `neunorm.processing.apply_roi(data, (x0, y0, x1, y1))` |
-| auto/manual gamma filtering on `load()` | `neunorm.filters.apply_gamma_filter(...)`, or pipeline `gamma_filter=True` |
-| `.export(folder=..., file_type="tif")` | `neunorm.exporters.write_hdf5(...)` (primary) or `write_tiff_stack(...)`; pipelines write automatically via `output_path` |
+| `.load(..., data_type="sample"/"ob")` | pipeline `sample_paths` / `ob_paths`, or `neunorm.loaders.stack_loader.load_stack` / `tiff_loader.load_tiff_stack` / `fits_loader.load_fits_stack` |
+| `.load(..., data_type="df")` (dark/"df") | pipeline `dark_paths`, or `neunorm.processing.dark_corrector.subtract_dark(data, dark)` |
+| `.normalization(roi=...)` | `run_*_pipeline(..., roi=...)`, or `neunorm.processing.normalizer.normalize_transmission(sample, ob, ...)` |
+| `.df_correction()` | `neunorm.processing.dark_corrector.subtract_dark(data, dark)` |
+| `.crop(roi=ROI(...))` | `neunorm.processing.roi_clipper.apply_roi(data, (x0, y0, x1, y1))` |
+| auto/manual gamma filtering on `load()` | `neunorm.filters.gamma_filter.apply_gamma_filter(...)`, or pipeline `gamma_filter=True` |
+| `.export(folder=..., file_type="tif")` | `neunorm.exporters.hdf5_writer.write_hdf5(...)` (primary) or `tiff_writer.write_tiff_stack(...)`; pipelines write automatically via `output_path` |
 | `.get_normalized_data()` | the pipeline **returns** a `scipp.DataArray`; use `.values` for the NumPy array |
 | `from NeuNorm.roi import ROI; ROI(x0, y0, x1, y1)` | a plain tuple `(x0, y0, x1, y1)` |
 | `NeuNorm.normalization.DataType` | not needed — inputs are explicit function arguments |


### PR DESCRIPTION
Release prep (#15) — NeuNorm 2.0 ships with no prior changelog and no migration documentation for users on the 1.x stateful `Normalization` API. This adds both.

## What's in here

- **`CHANGELOG.md`** (new) — [Keep a Changelog](https://keepachangelog.com/) format. The `[2.0.0]` entry documents the scipp rewrite across **Added / Changed / Removed / Migration**. Marked `Unreleased`; the date is filled in when the `v2.0.0` tag is cut.
- **`docs/migration.md`** (new) — step-by-step **1.x → 2.0 migration guide**. It is honest that there is **no drop-in compatibility shim** (the flat-field physics is preserved, but the API is new), and maps the legacy `load → normalization → export → get_normalized_data` workflow onto:
  - the high-level `run_*_pipeline` functions (with a side-by-side example), and
  - the composable `neunorm.processing` / `neunorm.loaders` functions,
  - plus a method/concept mapping table, ROI changes (`ROI(...)` object → `(x0, y0, x1, y1)` tuple), and how to work with the returned `scipp.DataArray`.
- **`docs/index.md`** — migration page wired into the toctree under a new "Upgrading" caption (the `-W` build fails on orphan pages).
- **`README.md`** — link the migration guide from the breaking-change note + legacy section, and surface `CHANGELOG.md`.

## Accuracy

Every API reference was checked against the source (import name `NeuNorm`→`neunorm`, distribution name unchanged, Python ≥3.11, `data_type="df"`→`dark_paths`, ROI tuple order `(x0, y0, x1, y1)` per `roi_clipper.apply_roi`, the six pipeline signatures, `normalize_transmission`).

## Verification

- `pixi run build-docs` (which is `sphinx-build -W --keep-going`) — **succeeds with no warnings**, including the new page and cross-references.
- `pre-commit` on all changed files — pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)