### PR TITLE
chore: drop Codecov integration

### DIFF
--- a/.github/workflows/test_and_deploy.yaml
+++ b/.github/workflows/test_and_deploy.yaml
@@ -36,12 +36,6 @@ jobs:
       - name: Run unit tests
         run: pixi run test
 
-      - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v6
-        if: matrix.os == 'ubuntu-latest' && github.actor != 'dependabot[bot]'
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-
       - name: Dependency check
         if: matrix.os == 'ubuntu-latest'
         run: |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # NeuNorm 2.0 - Modern Neutron Imaging Normalization
 
 [![PyPI version](https://badge.fury.io/py/NeuNorm.svg)](https://badge.fury.io/py/NeuNorm)
-[![codecov](https://codecov.io/gh/ornlneutronimaging/NeuNorm/branch/next/graph/badge.svg)](https://codecov.io/gh/ornlneutronimaging/NeuNorm)
 [![Documentation Status](https://readthedocs.org/projects/neunorm/badge/?version=latest)](http://neunorm.readthedocs.io/en/latest/?badge=latest)
 [![DOI](https://zenodo.org/badge/97755175.svg)](https://zenodo.org/badge/latestdoi/97755175)
 [![DOI](http://joss.theoj.org/papers/10.21105/joss.00815/status.svg)](https://doi.org/10.21105/joss.00815)

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,8 +1,0 @@
-# Configuration file for codecov reporting code coverage
-
-codecov:
-  status:
-    project:
-      default:
-        # base on last build, but allow drop of upto this percent
-        threshold: 0.5%


### PR DESCRIPTION
Per discussion: Codecov was never activated for this repo, so the upload step never actually worked (codecov-action v4+ needs a real repo-scoped token; the previously committed token did nothing). Rather than stand up an external service + a secret to maintain, we drop it.

## Changes
- Remove the **`Upload coverage to codecov`** step from `test_and_deploy.yaml`.
- Remove the **codecov badge** from the README (it would render "unknown" on a release README).
- Delete **`codecov.yaml`**.

## Coverage is unaffected
`pytest --cov=neunorm --cov-report=term-missing` still runs in every CI job and locally (**~90%**), so coverage stays measured and visible — just not hosted externally.

## Resolves #3 (leaked Codecov token)
With no Codecov integration there's no `CODECOV_TOKEN` to rotate, and the token that was once committed is a dead credential for a non-activated repo. No security follow-up needed.

## Verification
- `test_and_deploy.yaml` validated as well-formed YAML (`.github/**` is excluded from pre-commit).
- pre-commit clean on README.
- No `codecov` references remain in the workflow or README.

## Follow-up (needs your OK — agent-config edit)
`.claude/skills/release/SKILL.md` still lists `CODECOV_TOKEN` as a pre-flight prerequisite. I was blocked from editing it (self-modification guard). Minor/harmless, but I can update it to drop the `CODECOV_TOKEN` mention if you want — just say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)