### PR TITLE
fix(hdf5): guard against ragged nested-list metadata (#140)

### DIFF
--- a/src/neunorm/exporters/hdf5_writer.py
+++ b/src/neunorm/exporters/hdf5_writer.py
@@ -95,6 +95,20 @@ def write_hdf5(  # noqa: C901
             for key, value in metadata.items():
                 if isinstance(value, str):
                     f.create_dataset(f"metadata/{key}", data=value, dtype=h5py.string_dtype(encoding="utf-8"))
+                elif isinstance(value, (list, tuple)) and any(isinstance(item, (list, tuple)) for item in value):
+                    # Nested (list-of-lists) metadata, e.g. per-run file paths. h5py cannot
+                    # store a ragged nested list and raises TypeError mid-write, which would
+                    # leave a corrupt, partially-written file. Until the proper fix (serialize
+                    # the nested provenance) lands, skip the key with a warning rather than
+                    # crash, so the array data and scalar metadata still write correctly.
+                    # See https://github.com/ornlneutronimaging/NeuNorm/issues/140
+                    logger.warning(
+                        "Skipping nested-list metadata '{}' in HDF5 output: h5py cannot store "
+                        "ragged per-run lists (would abort the write and corrupt the file). "
+                        "Array data and scalar metadata are still written. "
+                        "See https://github.com/ornlneutronimaging/NeuNorm/issues/140",
+                        key,
+                    )
                 else:
                     f.create_dataset(f"metadata/{key}", data=value)
 

--- a/src/neunorm/exporters/hdf5_writer.py
+++ b/src/neunorm/exporters/hdf5_writer.py
@@ -95,21 +95,29 @@ def write_hdf5(  # noqa: C901
             for key, value in metadata.items():
                 if isinstance(value, str):
                     f.create_dataset(f"metadata/{key}", data=value, dtype=h5py.string_dtype(encoding="utf-8"))
-                elif isinstance(value, (list, tuple)) and any(isinstance(item, (list, tuple)) for item in value):
-                    # Nested (list-of-lists) metadata, e.g. per-run file paths. h5py cannot
-                    # store a ragged nested list and raises TypeError mid-write, which would
-                    # leave a corrupt, partially-written file. Until the proper fix (serialize
-                    # the nested provenance) lands, skip the key with a warning rather than
-                    # crash, so the array data and scalar metadata still write correctly.
-                    # See https://github.com/ornlneutronimaging/NeuNorm/issues/140
-                    logger.warning(
-                        "Skipping nested-list metadata '{}' in HDF5 output: h5py cannot store "
-                        "ragged per-run lists (would abort the write and corrupt the file). "
-                        "Array data and scalar metadata are still written. "
-                        "See https://github.com/ornlneutronimaging/NeuNorm/issues/140",
-                        key,
-                    )
                 else:
-                    f.create_dataset(f"metadata/{key}", data=value)
+                    name = f"metadata/{key}"
+                    try:
+                        f.create_dataset(name, data=value)
+                    except (TypeError, ValueError) as exc:
+                        # h5py cannot store some values — notably a RAGGED nested list, e.g.
+                        # per-run file paths with unequal run sizes (sample_paths=[[...],[...]]).
+                        # Without this guard the error aborts the write *after* the bulk arrays
+                        # are written, leaving a corrupt, partial file. Rectangular nested lists
+                        # still write normally; only genuinely unstorable values are skipped here.
+                        # Note: h5py registers the dataset name before failing on the data, so a
+                        # malformed partial dataset is left behind — delete it before continuing.
+                        # Proper fix (serialize the nested provenance) is tracked in
+                        # https://github.com/ornlneutronimaging/NeuNorm/issues/140
+                        if name in f:
+                            del f[name]
+                        logger.warning(
+                            "Skipping metadata '{}' in HDF5 output: h5py cannot store this value "
+                            "(e.g. a ragged per-run list), which would otherwise abort the write and "
+                            "corrupt the file. Array data and other metadata are still written. "
+                            "See https://github.com/ornlneutronimaging/NeuNorm/issues/140 ({})",
+                            key,
+                            exc,
+                        )
 
     logger.info("HDF5 file written to {}", output_path)

--- a/tests/unit/test_hdf5_writer.py
+++ b/tests/unit/test_hdf5_writer.py
@@ -76,6 +76,48 @@ def test_write_hdf5():
             np.testing.assert_equal(f["metadata/software_version"].asstr()[()], "1.0.0")
 
 
+def test_write_hdf5_skips_ragged_nested_metadata():
+    """Ragged list-of-lists metadata (e.g. per-run file paths) must not crash the writer.
+
+    Regression for https://github.com/ornlneutronimaging/NeuNorm/issues/140: h5py raises
+    TypeError on a ragged nested list, which previously aborted write_hdf5 *after* the bulk
+    arrays were written, leaving a corrupt partial file. The guard skips such keys with a
+    warning so the array data and scalar metadata still write correctly.
+    """
+    from neunorm.exporters.hdf5_writer import write_hdf5
+
+    values = np.arange(3 * 5 * 5).reshape((3, 5, 5))
+    data = sc.DataArray(
+        data=sc.array(dims=["tof_edges", "x", "y"], values=values, unit="counts", dtype="float64"),
+        coords={
+            "tof_edges": sc.linspace("tof_edges", 1e5, 1e7, num=4, unit="ns"),
+            "y": sc.arange("y", 5, unit=None),
+            "x": sc.arange("x", 5, unit=None),
+        },
+    )
+    data.variances = values * 2.0
+
+    metadata = {
+        # Two runs with UNEQUAL file counts -> ragged nested list (the production shape).
+        "sample_paths": [["s_0001.tiff", "s_0002.tiff"], ["s_0003.tiff"]],
+        "num_runs_combined": 2,  # a normal scalar that must still be written
+    }
+
+    with tempfile.NamedTemporaryFile(suffix=".h5", delete=True) as f:
+        # Must NOT raise (previously TypeError on the ragged list).
+        write_hdf5(f.name, data, metadata=metadata)
+
+        with h5py.File(f.name, "r") as f:
+            # The bulk array was written (file is not a corrupt partial).
+            assert "transmission" in f
+            np.testing.assert_allclose(f["transmission"][:], values)
+            # The ragged nested key was skipped, not written.
+            assert "metadata/sample_paths" not in f
+            # Scalar metadata after it still wrote.
+            assert "metadata/num_runs_combined" in f
+            np.testing.assert_equal(f["metadata/num_runs_combined"], np.array(2))
+
+
 def test_write_hdf5_4d():
     """Test writing HDF5 file with 4D data (e.g. with TOF dimension)"""
     from neunorm.exporters.hdf5_writer import write_hdf5


### PR DESCRIPTION
Stopgap for #140 (filed from the pre-release bug-hunt).

## Problem
`write_hdf5` calls `h5py.create_dataset` on nested list-of-lists metadata — the pipelines pass per-run file paths as `sample_paths=[[...],[...]]`. When runs have **unequal file counts** (the normal multi-run case) the nested list is *ragged*, and h5py raises `TypeError` **after** the transmission/uncertainty/mask arrays are already written — leaving a **corrupt partial file** on the primary output format. (Reproduced with a real `TypeError`.)

## This PR (stopgap, not the full fix)
Detect nested-list metadata, **log a warning citing #140, and skip that key** instead of crashing — so the array data and scalar metadata still write correctly and the file is valid. Provenance for the skipped keys is omitted until the proper fix.

The **proper fix** (preserve the nested provenance, e.g. JSON-encode) is tracked in #140 and deferred to after the v2.0.0 release, per maintainer direction.

## Test
Adds `test_write_hdf5_skips_ragged_nested_metadata`: a ragged per-run list no longer raises, the `transmission` array is written, the ragged key is skipped, and a following scalar metadata key still writes. Full `test_hdf5_writer.py` suite: **8 passed**.

Refs #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)