### PR TITLE
feat: optional dark current for CCD pipelines (#146); add detection-only review pipeline

### DIFF
--- a/.claude/skills/review-pipeline/SKILL.md
+++ b/.claude/skills/review-pipeline/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: review-pipeline
+description: Detection-only two-LLM-family review of the current branch's diff vs next (or a named branch/scope). Runs Claude + Codex finders through the dual-family-review engine, cross-family verifies P0/P1 findings, and reports at a human gate. Use to review a PR/branch before pushing or merging. Never edits, commits, or pushes.
+user-invokable: true
+---
+
+# /review-pipeline — NeuNorm diff-scoped review
+
+Run a **diff-scoped, two-LLM-family** review of a branch and report verified
+findings at a human gate. This is **detection-only**: it finds, cross-family
+verifies, and reports — it never edits files, commits, or pushes. Fixing is a
+separate, explicit step you drive after the gate.
+
+**When to use which audit skill:**
+
+- `/review-pipeline` (this) — review the **changes** on a branch/PR (`git diff
+  next...HEAD`). The right tool before pushing or merging a feature branch.
+- `/bughunt` / `bughunt-deep` — audit the **whole** `src/neunorm` codebase
+  (release gate), not a diff.
+
+## Architecture
+
+The non-interactive heart — **Claude finder + Codex finder per target →
+cross-LLM-family adversarial verify → structured findings** — is the
+`dual-family-review` **Workflow** (`.claude/workflows/dual-family-review.js`).
+This skill is the **orchestrator**: it builds the preflight + target, invokes the
+engine once, and renders the result at a STOP gate. Invoking the engine here is
+the sanctioned Workflow opt-in (a skill whose instructions call the Workflow tool).
+
+Why the cross-family pass matters: a parent agent re-deriving a subagent's claim
+is **not** independent confirmation (same LLM family). A finding is VERIFIED only
+when a *second* family (Codex verifying Claude, or vice-versa) independently
+confirms it. Codex is supplementary — if it is absent, the round is single-family
+and every P0/P1 comes back NEEDS-VERIFICATION (it does not silently pass).
+
+## Arguments
+
+- **No args** — review `git diff next...HEAD` (the current branch vs `next`).
+- **A branch name** — review `git diff next...<branch>`.
+- **`--base <ref>`** — diff against `<ref>` instead of `next`.
+- **`--skip-codex`** — Claude-only (single-family; P0/P1 → NEEDS-VERIFICATION).
+- **A path / glob** — scope the audit to those files instead of a diff.
+
+---
+
+## Step 1: Preflight (read-only git)
+
+Gather, with read-only git from the repo root:
+
+- `repoRoot` — `git rev-parse --show-toplevel`
+- `headSha` — `git rev-parse --short HEAD`
+- `isWorktree` — true if `git rev-parse --git-common-dir` differs from `--git-dir`
+- `codexAvailable` / `codexVersion` — `command -v codex && codex --version`
+  (false + empty if absent; do NOT fail if missing)
+- base ref — `next` unless `--base` was given
+- **changed files** — `git diff --name-only <base>...HEAD` (three-dot merge-base
+  diff), then keep the Python files under `src/neunorm/` (and any changed
+  `tests/` files, which the finder may read for circular-validation checks).
+- **diverged?** — `git rev-list --count <base>..HEAD`; if `0` and no explicit
+  path scope, report "no changes vs <base> — nothing to review" and STOP.
+
+If a branch name was passed, use `<branch>` in place of `HEAD` above and read
+changed files via `git show <branch>:<path>` (the branch may not be checked out).
+
+## Step 2: Build the target and invoke the engine
+
+Build **one** target from the changed source files:
+
+- `key`: a short slug of the branch/scope (e.g. `diff-<headSha>`).
+- `name`: `"changes on <branch> vs <base>"`.
+- `paths`: the deduped **package dirs** of the changed `src/neunorm/` files
+  (e.g. `src/neunorm/pipelines/`, `src/neunorm/processing/`). If a path scope was
+  given instead of a diff, use those paths.
+- `blurb`: `"the diff <base>...HEAD (N files in: <packages>)"`.
+- `p0`: `"A correctness regression introduced by these changes: a logic error, an
+  exception on valid input, a wrong normalization/TOF result, an uncertainty
+  (variance) error that mis-states the reported error, data corruption in HDF5/TIFF
+  output, or a silently-masked whole-array error."`
+- `lookFor`: `[]` (the engine appends its NeuNorm CORE_CHECKLIST).
+- `scopeDirective`: `"Audit ONLY the changes in 'git diff <base>...HEAD'. Run that
+  diff, then read each changed file IN FULL. Report findings only for code
+  introduced or altered by this diff, plus any pre-existing call site the diff
+  newly breaks."` (For a path scope, audit those files in full instead.)
+
+Then call the **Workflow** tool:
+
+```
+Workflow(name="dual-family-review", args={
+  pf: { repoRoot, codexAvailable, codexVersion, headSha, isWorktree },
+  targets: [ <the target above> ],
+  config: {
+    contextNote: "Per-PR review of branch <branch> vs <base>.",
+    roundNote: "review",
+    skipCodex: <true if --skip-codex>,
+    hardEnforce: false
+  }
+})
+```
+
+It runs in the background and returns:
+
+```
+{ perTarget: [{ domainKey, domainName, claudeAssessment, codexAssessment,
+               tierCounts:{claude,codex}, verified[], needsVerification[],
+               refuted[], p2s[], circular[] }],
+  droppedTargets, codexUsable }
+```
+
+**Fail closed:** if `perTarget` is missing/empty for a non-empty target list, or
+`droppedTargets > 0`, report that the engine under-ran — do NOT present a false
+all-clear.
+
+Each finding carries `tier` (P0/P1/P2), `file`, `line`, `claim`, `reasoning`,
+`suggestedFix`, `confidence`, and a `status` (VERIFIED = a 2nd family confirmed;
+NEEDS-VERIFICATION = single-family / split / codex unavailable; REFUTED =
+cross-family refuted). VERIFIED findings may carry a `verifierTier` (the verifier
+downgraded the original tier).
+
+## Step 3: Consolidation gate
+
+Render the returned payload as a report and **STOP** for the user:
+
+1. **Header**: branch, base, headSha, and whether codex was usable
+   (`codexUsable`). If codex was disabled/absent, say so and note that P0/P1
+   findings are NEEDS-VERIFICATION, not cross-confirmed.
+2. **Counts**: VERIFIED P0 / VERIFIED P1 / NEEDS-VERIFICATION / REFUTED / P2,
+   plus Claude vs Codex `tierCounts`.
+3. **Findings detail**, grouped by confidence, each with `file:line`, claim,
+   reasoning, and `suggestedFix`:
+   - **VERIFIED** (cross-confirmed) — highest confidence; fix candidates.
+   - **NEEDS-VERIFICATION** (single-family) — call out explicitly that these did
+     NOT meet the ≥2-family bar.
+   - **REFUTED** — list with the refuter's reasoning so they are not re-litigated.
+   - **P2** — trivial; list briefly.
+4. **Circular-validation risks**: surface every non-empty `circular[]` entry
+   (its `note`, `file:line`, family) — a test whose oracle may mirror buggy
+   behaviour is a HIGH-PRIORITY signal; never drop it silently.
+5. **Suggested disposition** (you propose; the **user decides**): fix-now for
+   VERIFIED P0/P1, consider for NEEDS-VERIFICATION, dismiss for REFUTED.
+
+**MANDATORY GATE — present the report and STOP. Detection-only: do NOT fix,
+commit, or push.** If the user then asks for fixes, apply them as a normal,
+separate editing task (run `pixi run test` and `pixi run pre-commit run
+--all-files` after), and re-run `/review-pipeline` to confirm.
+
+## Notes
+
+- The engine is **read-only** and enforces a DETECTION-ONLY contract on every
+  subagent; it writes only `/tmp` scratch files for the Codex harness.
+- Codex must be able to authenticate non-interactively. If it consistently fails,
+  check `codex --version` / the codex login; do not work around with model
+  overrides — codex is supplementary, not blocking.
+- Compare floating-point expectations with tolerances, never bit-exact (per
+  AGENTS.md): a finding that demands bit-exact equality across arches is itself
+  likely a false positive — weigh that at the gate.

--- a/.claude/workflows/dual-family-review.js
+++ b/.claude/workflows/dual-family-review.js
@@ -1,0 +1,557 @@
+export const meta = {
+  name: 'dual-family-review',
+  description:
+    'Shared engine for two-LLM-family code review of NeuNorm: per-target Claude + Codex finders, cross-LLM-family adversarial verification, structured per-target findings. Detection-only — never edits, commits, or pushes. A LEAF workflow (never calls workflow()).',
+  whenToUse:
+    'Not invoked directly by a human. Reusable core consumed via workflow() / the Workflow tool by the /review-pipeline skill (per-PR-diff, target = the current branch diff) and available for whole-package sweeps (target = a src/neunorm package). It runs the Find -> Verify pipeline over a generic list of audit targets and returns structured per-target findings; the caller does its own preflight (building `pf`), target construction, and final consolidation/reporting.',
+  phases: [
+    { title: 'Find', detail: 'Claude + Codex finder per target (up to 2N agents)' },
+    { title: 'Verify', detail: 'cross-LLM-family adversarial confirmation of single-family findings' },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// dual-family-review — NeuNorm's two-family review engine.
+//
+// Adapted from NEREIDS's dual-family-review.js. The audit methodology is the
+// part worth porting:
+//   - 2 independent LLM families per target: Claude (agent()) + Codex (codex exec)
+//   - P0/P1/P2 tiers (P3 excluded), file:line + evidence
+//   - a cross-LLM-family confirmation pass on every SINGLE-family P0/P1 finding
+//     (Claude findings verified by Codex and vice versa; P2s reported as-is,
+//      NOT cross-verified — verifyVotes() returns 0 for P2)
+//
+// Why the cross-family pass is load-bearing: parent-agent re-derivation of a
+// subagent's claim is NOT independent confirmation (same LLM family). For a
+// VERIFIED finding you need >=2 distinct LLM families with independent access.
+// LLMs are stochastic and family-correlated; a different family catches what one
+// family's blind spots miss.
+//
+// Detection-only is enforced two ways: (1) the DETECTION_ONLY prompt contract
+// appended to every audit-agent prompt, ALWAYS ON — this is what makes behaviour
+// consistent across models; (2) optional TOOL-LEVEL enforcement via a restricted
+// custom agent type (config.hardEnforce -> 'bug-hunter', which lacks Edit/Write).
+//
+// NeuNorm-specific adaptations vs the NEREIDS original:
+//   - dropped the SAMMY/ENDF physics primary-source machinery (sammyRoot, the
+//     sammyBlock, the SAMMY verify lens) — NeuNorm has no external reference impl;
+//   - the CORE_CHECKLIST is rewritten for Python / scipp / neutron-imaging
+//     normalization (variance propagation, units, masks, HDF5/TIFF I/O) instead
+//     of Rust / cargo / SAMMY;
+//   - the audit-prompt intro describes the NeuNorm domain.
+// The Find->Verify pipeline, schemas, and dedup/verify helpers are otherwise the
+// proven NEREIDS structure.
+//
+// args (passed in by the calling skill / wrapper):
+//   args.pf      : { repoRoot, codexAvailable, codexVersion, headSha, isWorktree }
+//   args.targets : [{ key, name, paths[], blurb, p0, lookFor[], scopeDirective }]
+//                  — one entry per audit unit (a branch diff, or a package).
+//   args.config  : { contextNote, roundNote, skipCodex, hardEnforce }
+//
+// returns: { perTarget: [{ domainKey, domainName, claudeAssessment, codexAssessment,
+//            tierCounts:{claude,codex}, verified[], needsVerification[], refuted[],
+//            p2s[], circular[] }], droppedTargets, codexUsable }
+// ---------------------------------------------------------------------------
+
+// Defensive arg unpacking — `args` should arrive as a real object, but a caller
+// may pass a JSON-encoded string; parse it rather than silently default.
+let A = {}
+if (args && typeof args === 'object') A = args
+else if (typeof args === 'string' && args.trim().startsWith('{')) {
+  try {
+    A = JSON.parse(args)
+  } catch (_e) {
+    A = {}
+  }
+}
+
+const pf = A.pf && typeof A.pf === 'object' ? A.pf : {}
+const TARGETS = Array.isArray(A.targets) ? A.targets : []
+const CONFIG = A.config && typeof A.config === 'object' ? A.config : {}
+const CONTEXT_NOTE = CONFIG.contextNote || ''
+const ROUND_NOTE = CONFIG.roundNote || 'review'
+const SKIP_CODEX = CONFIG.skipCodex === true
+
+// Detection-only enforcement. Layer 1: the DETECTION_ONLY prompt contract below,
+// appended to every audit-agent prompt — ALWAYS ON and identical across agents.
+// Layer 2 (optional): the project's read-only `bug-hunter` agent type (lacks
+// Edit/Write/NotebookEdit). Custom agent types load at SESSION START, so default
+// to the always-available built-in `general-purpose`; pass config.hardEnforce=true
+// from a session where `bug-hunter` is loaded to switch the restriction on.
+const HARD = CONFIG.hardEnforce === true
+const READER_TYPE = HARD ? 'bug-hunter' : 'general-purpose'
+const RUNNER_TYPE = 'general-purpose' // codex harness needs Write+Bash; bug-hunter lacks Write
+
+const codexUsable = !!pf.codexAvailable && !SKIP_CODEX
+
+const DETECTION_ONLY =
+  '\n\n--- DETECTION-ONLY CONTRACT (mandatory) ---\n' +
+  'You FIND and REPORT defects; you never fix them and never advance to a fix stage. You MUST NOT:\n' +
+  '- create any task, background session, or fix-job (do NOT call spawn_task or any task-creation / scheduling tool);\n' +
+  '- open or modify any PR or issue;\n' +
+  '- edit or write repository files, or run state-changing shell commands (git commit/push/add/checkout, gh, pip install, pixi add).\n' +
+  'The only writes ever permitted are scratch /tmp files (the codex harness needs them).\n' +
+  'Report via the structured-output tool only. Fixing is a separate, human-gated step.'
+
+// Shared checklist appended to every target. Target-specific bullets
+// (target.lookFor) are prepended. Tuned for NeuNorm: Python + scipp +
+// neutron-imaging normalization with automatic uncertainty propagation.
+const CORE_CHECKLIST = [
+  'Exception-on-valid-input: indexing / coord access (`da.coords["x"]`, `da["dim", i]`), `.value` on a non-scalar, or dict access that raises on a valid-but-edge input at a public entry point (pipeline fn, loader, exporter).',
+  'Numerical stability: division by zero / inf-nan propagation (e.g. transmission where open-beam == 0), sqrt of negative, overflow, float32<->float64 precision loss on round-trip, and NaN comparisons that silently pass (`NaN < x` is False — must be paired with explicit `np.isfinite`/`np.isnan`).',
+  'scipp variance propagation: the codebase repeatedly strips `.variances` to broadcast manually, then recombines by hand (see dark_corrector / normalizer) — verify the hand-written variance formula is correct and that no variance term is dropped or double-counted. Also: dim order/label mismatches, units silently dropped, aligned-vs-unaligned coordinate handling lost across ops.',
+  'Masks: combination across inputs must be logical OR (a dropped or AND-combined mask hides bad pixels); mask shape/dims must match the data it guards.',
+  'Silent error masking: bare `except` / `except Exception: pass`, `np.nan_to_num` or `np.clip` that turns a real failure into a plausible value, `dict.get(key, default)` that hides a missing REQUIRED key/coord.',
+  'Missing input validation at public entry points — validate shapes/dims/required metadata up front, before heavy work or parallel iteration.',
+  'Empty / single-element edge cases: `combine_runs` returns `runs[0]` WITHOUT copying for a single run — a later in-place mutation can corrupt shared/cached data; also mean/median over an empty or length-1 axis, and `0 == 0` equality guards.',
+  'API/pipeline consistency: sibling functions or the mirrored MARS/VENUS pipelines that should behave identically but diverge (one path hardened, the parallel path missed) — a recurring NeuNorm bug class.',
+  'CIRCULAR-VALIDATION RISK (high priority): a test whose oracle mirrors the implementation, a fixture produced by the code under test, or a tolerance so loose the bug is invisible. Flag explicitly in `circularValidationRisk`.',
+  'HDF5/TIFF I/O & provenance: metadata that cannot serialize (ragged nested lists, empty lists, None), dtype drift on round-trip, masks not written/read back, provenance dropped or mislabelled.',
+  'Documentation/docstring drift from code (NumPy-style docstring params vs the actual signature, comment arithmetic vs the code).',
+]
+
+// ---- structured-output schemas -------------------------------------------
+
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    domain: { type: 'string' },
+    family: { type: 'string', enum: ['claude', 'codex'] },
+    assessment: { type: 'string', description: 'one-sentence overall assessment of the target' },
+    codexFailed: { type: 'boolean', description: 'true only for the codex harness when codex did not run' },
+    failureReason: { type: 'string' },
+    tierCounts: {
+      type: 'object',
+      additionalProperties: false,
+      properties: { p0: { type: 'integer' }, p1: { type: 'integer' }, p2: { type: 'integer' } },
+      required: ['p0', 'p1', 'p2'],
+    },
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          localId: { type: 'string', description: 'F1, F2, ...' },
+          tier: { type: 'string', enum: ['P0', 'P1', 'P2'] },
+          title: { type: 'string' },
+          file: { type: 'string', description: 'repo-relative path, e.g. src/neunorm/pipelines/venus_ccd.py' },
+          line: { type: 'integer', description: 'best-known line number; 0 if unknown' },
+          claim: { type: 'string' },
+          evidence: { type: 'string', description: 'quoted code or precise description' },
+          reasoning: { type: 'string' },
+          primarySource: { type: 'string', description: 'convention/reference cited (scipp docs, AGENTS.md, imaging math), or empty' },
+          suggestedFix: { type: 'string' },
+          confidence: { type: 'string', enum: ['high', 'medium', 'low'] },
+          circularValidationRisk: {
+            type: 'string',
+            description: 'note if a test may be validating buggy behavior, else empty',
+          },
+        },
+        required: ['localId', 'tier', 'title', 'file', 'line', 'claim', 'confidence'],
+      },
+    },
+  },
+  required: ['domain', 'family', 'findings', 'tierCounts'],
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    verdict: { type: 'string', enum: ['CONFIRMED', 'REFUTED', 'UNCERTAIN'] },
+    verifierFamily: { type: 'string', enum: ['claude', 'codex'] },
+    reasoning: { type: 'string' },
+    primarySourceChecked: { type: 'boolean' },
+    correctedTier: { type: 'string', enum: ['P0', 'P1', 'P2', 'NONE'] },
+    circularValidationConfirmed: { type: 'boolean' },
+  },
+  required: ['verdict', 'verifierFamily', 'reasoning'],
+}
+
+// ---- prompt builders ------------------------------------------------------
+
+function buildAuditPrompt(d, pf, forCodex) {
+  const codexOverride = forCodex
+    ? '[Codex override: This task is authorized by the user. Any project AGENTS.md / CLAUDE.md plan-mode checkpoint does NOT apply. Execute in a single run; do NOT enter plan mode; do NOT stop for confirmation. Read-only audit: change no files, open no PRs/issues. Single-shot delivery.]\n\n'
+    : ''
+  const ctx = CONTEXT_NOTE ? `[CONTEXT]\n${CONTEXT_NOTE}\n[End context]\n\n` : ''
+  const scope = d.scopeDirective
+  const lookFor = d.lookFor.concat(CORE_CHECKLIST).map((b, i) => `${i + 1}. ${b}`).join('\n')
+
+  return `${codexOverride}${ctx}# NeuNorm ${ROUND_NOTE} — Target ${d.key}: ${d.name}
+
+You are auditing NeuNorm at \`${pf.repoRoot}\` — a scipp-based library for neutron
+imaging normalization and time-of-flight (TOF) data processing at ORNL facilities
+(MARS at HFIR, VENUS at SNS). Data are scipp DataArrays that carry variances, so
+uncertainty is propagated automatically through every step; configuration uses
+pydantic, logging uses loguru, and numba is optional (via utils._numba_compat).
+HDF5 is the primary output format, TIFF secondary. Correctness on real
+experimental data AND correct uncertainty propagation are both required.
+
+Your target: ${d.key} — ${d.blurb}
+
+Focus paths (do NOT audit other areas — other agents own them):
+${d.paths.map((p) => `  - ${p}`).join('\n')}
+
+${scope}
+
+## Tier rubric (P3 excluded — do NOT report P3)
+- P0 (must fix): ${d.p0}
+- P1 (should fix): latent edge case, missing input validation, an uncertainty/variance error that under- or over-states the reported error, an undocumented exception on plausible input, a missing test for a claimed property.
+- P2 (trivial): typo, doc wording, comment drifting from code.
+
+Calibrate HONESTLY. Do not inflate; do not self-censor based on what you think is already known or tested.
+
+## What to look for
+${lookFor}
+
+## Method
+1. Map the surface (the package __init__ / module docstrings of each focus path).
+2. Walk each module; quote actual code lines (\`file:line\`) as evidence.
+3. For every numerical / uncertainty / scipp-semantics claim, reason from the
+   neutron-imaging normalization math and scipp's variance/unit/dim rules;
+   verify variance propagation explicitly (no dropped or double-counted term).
+4. Inspect the test suite for the CIRCULAR-VALIDATION patterns above.
+5. Mark low-confidence findings explicitly so the verify pass tests them harder.
+
+Quality over budget. Read carefully; do not truncate.`
+}
+
+// Harness prompt: a Claude subagent that DRIVES codex and structures its
+// findings. It must not audit the code itself.
+function codexFinderPrompt(d, pf) {
+  const codexPrompt = buildAuditPrompt(d, pf, true)
+  const slug = d.key
+  return `You are a HARNESS that runs the OpenAI Codex CLI as an independent external reviewer (a DIFFERENT LLM family from you) and faithfully transcribes ITS findings into structured output. Do NOT audit the code yourself — your judgement must not replace Codex's.
+
+Steps:
+1. Write this exact audit prompt to a temp file with the Write tool at \`/tmp/neunorm-review-${slug}.prompt\`:
+-----BEGIN CODEX PROMPT-----
+${codexPrompt}
+-----END CODEX PROMPT-----
+2. Run (Bash, timeout 600000 ms):
+   codex exec --sandbox read-only --skip-git-repo-check -C "${pf.repoRoot}" --output-last-message /tmp/neunorm-review-${slug}.out - < /tmp/neunorm-review-${slug}.prompt
+   (Temp-file + stdin is the portable delivery pattern; --output-last-message captures Codex's final verdict. --sandbox read-only is correct: review only reads code.)
+3. If codex exits non-zero, or /tmp/neunorm-review-${slug}.out is missing/empty: return {domain:"${slug}", family:"codex", codexFailed:true, failureReason:"<one-line stderr summary>", findings:[], tierCounts:{p0:0,p1:0,p2:0}}.
+4. Otherwise Read /tmp/neunorm-review-${slug}.out and transcribe EVERY finding Codex reported into the schema. Preserve Codex's tier (P0/P1/P2), file, line, claim, reasoning, primary-source, and confidence in substance. Do not add findings Codex did not make; do not drop findings it did. Set family="codex".
+5. Return via structured output.`
+}
+
+function buildFindingText(f, srcFamily) {
+  return `Finding (from ${srcFamily}, its tier ${f.tier}, its confidence ${f.confidence}):
+- title: ${f.title}
+- file:line: ${f.file}:${f.line}
+- claim: ${f.claim}
+- evidence: ${f.evidence || '(none given)'}
+- reasoning: ${f.reasoning || '(none given)'}
+- convention/reference cited: ${f.primarySource || '(none)'}
+- circular-validation note: ${f.circularValidationRisk || '(none)'}`
+}
+
+// Claude verifies a Codex finding (cross-family).
+function claudeVerifyPrompt(f, pf, lensNote) {
+  return `You are an INDEPENDENT verifier from a different LLM family than the one that produced this finding. Adversarially test whether it is a REAL defect in NeuNorm. Default to REFUTED if you cannot independently substantiate it.
+
+${buildFindingText(f, 'Codex')}
+
+Steps:
+1. Open ${f.file} around line ${f.line} in \`${pf.repoRoot}\` and read enough surrounding context to judge independently.
+2. Verify the claim against the actual code and, where relevant, scipp semantics (variance/unit/dim rules), the neutron-imaging normalization math, and NeuNorm conventions in AGENTS.md.${lensNote ? `\n3. ${lensNote}` : ''}
+- Decide CONFIRMED (you independently reproduced the defect), REFUTED (explain precisely why the reasoning is wrong — e.g. a scipp convention the finder misread, or a variance term that IS handled elsewhere), or UNCERTAIN (cannot tell without runtime / more context).
+- Give your OWN independent tier (P0/P1/P2/NONE).
+- If the finding includes a circular-validation note, judge whether it is valid (set circularValidationConfirmed).
+Return via structured output with verifierFamily="claude".`
+}
+
+// Codex verifies a Claude finding (cross-family) — Claude harness drives codex.
+function codexVerifyPrompt(f, pf, id, lensNote) {
+  const inner = `You are an INDEPENDENT adversarial verifier. Test whether this finding is a REAL defect in NeuNorm (a scipp-based neutron-imaging normalization library). Default to REFUTED if you cannot independently substantiate it.
+
+${buildFindingText(f, 'Claude')}
+
+1. Open ${f.file} near line ${f.line} and read enough context to judge independently.
+2. Verify against the actual code and, where relevant, scipp variance/unit/dim semantics and the imaging-normalization math.${lensNote ? `\n3. ${lensNote}` : ''}
+Then state, on clearly labelled lines:
+VERDICT: CONFIRMED | REFUTED | UNCERTAIN
+INDEPENDENT_TIER: P0 | P1 | P2 | NONE
+PRIMARY_SOURCE_CHECKED: yes | no
+CIRCULAR_VALIDATION_CONFIRMED: yes | no | n/a
+REASONING: <2-4 sentences>`
+  return `You are a HARNESS that runs the OpenAI Codex CLI (an independent LLM family) to adversarially verify a finding Claude produced. Do not substitute your own judgement for Codex's.
+
+1. Write this prompt to \`/tmp/neunorm-review-verify-${id}.prompt\` with the Write tool:
+-----BEGIN CODEX PROMPT-----
+[Codex override: authorized by user; plan mode does NOT apply; read-only; single-shot.]
+
+${inner}
+-----END CODEX PROMPT-----
+2. Run (Bash, timeout 600000 ms):
+   codex exec --sandbox read-only --skip-git-repo-check -C "${pf.repoRoot}" --output-last-message /tmp/neunorm-review-verify-${id}.out - < /tmp/neunorm-review-verify-${id}.prompt
+3. If codex fails or the output is empty: return {verdict:"UNCERTAIN", verifierFamily:"codex", reasoning:"codex unavailable: <stderr>", primarySourceChecked:false, correctedTier:"NONE"}.
+4. Otherwise Read /tmp/neunorm-review-verify-${id}.out and map Codex's labelled lines into the schema (VERDICT->verdict, INDEPENDENT_TIER->correctedTier, PRIMARY_SOURCE_CHECKED->primarySourceChecked, CIRCULAR_VALIDATION_CONFIRMED->circularValidationConfirmed, REASONING->reasoning). Set verifierFamily="codex".
+Return via structured output.`
+}
+
+// ---- pure helpers ---------------------------------------------------------
+
+function normFile(f) {
+  return String(f || '').replace(/^\.\//, '').trim()
+}
+function basename(f) {
+  const p = normFile(f).split('/')
+  return p[p.length - 1]
+}
+// Title-token similarity (Jaccard over the smaller token set), ignoring short
+// and generic audit words so the signal is the *subject* of the finding.
+const TITLE_STOP = new Set([
+  'that', 'with', 'from', 'this', 'when', 'does', 'only', 'into', 'have', 'the', 'and', 'for', 'not', 'are', 'its', 'can', 'but',
+  'validate', 'validation', 'validated', 'silently', 'silent', 'missing', 'accept', 'accepts', 'accepted', 'input', 'inputs',
+  'value', 'values', 'public', 'entry', 'point', 'check', 'checks', 'guard', 'handle', 'handled', 'return', 'returns', 'data',
+  'variance', 'variances', 'scipp', 'dataarray',
+])
+function titleTokens(s) {
+  return new Set(
+    String(s || '')
+      .toLowerCase()
+      .split(/\W+/)
+      .filter((w) => w.length > 3 && !TITLE_STOP.has(w)),
+  )
+}
+function titleOverlap(a, b) {
+  const ta = titleTokens(a.title)
+  const tb = titleTokens(b.title)
+  if (!ta.size || !tb.size) return 0
+  let inter = 0
+  for (const w of tb) if (ta.has(w)) inter++
+  return inter / Math.min(ta.size, tb.size)
+}
+// Two findings "match" (cross-confirmed / dedup) when they are the same defect.
+// Same basename is required. Then EITHER the lines are close (<=8), OR — to
+// catch the same defect reported at different line numbers by the two families —
+// the titles are strongly similar. The title arm prevents a near-duplicate of a
+// VERIFIED finding from leaking into the REFUTED list.
+function findingsMatch(a, b) {
+  if (basename(a.file) !== basename(b.file)) return false
+  const la = a.line || 0
+  const lb = b.line || 0
+  if (la > 0 && lb > 0 && Math.abs(la - lb) <= 8) return true
+  return titleOverlap(a, b) >= 0.5
+}
+function tierRank(t) {
+  return t === 'P0' ? 0 : t === 'P1' ? 1 : 2
+}
+function verifyVotes(tier) {
+  // Cross-family independence is achieved with a single vote from the OTHER
+  // family. Extra votes (budget-scaled, diverse lenses) harden the P0s only.
+  if (tier === 'P0') {
+    if (budget && budget.total) return Math.min(3, 2 + Math.floor((budget.remaining() || 0) / 400000))
+    return 2
+  }
+  if (tier === 'P1') return 1
+  return 0
+}
+const LENSES = [
+  '',
+  'Focus specifically on scipp/units/variance/mask SEMANTICS and NeuNorm conventions: does the cited behaviour actually hold? A misread scipp convention (e.g. assuming broadcast propagates variances, or that a coord stays aligned) is the most common false positive here.',
+  'Focus on REPRODUCIBILITY: construct the concrete input (shapes, dims, units, dtype, metadata) that would trigger the defect. If no plausible input through the public API triggers it, lean REFUTED.',
+]
+
+// ---------------------------------------------------------------------------
+// Find -> Verify (pipelined per target; no barrier between them).
+// As soon as target X's two finders complete, X's findings are cross-verified
+// while target Y is still finding.
+//
+// Progress grouping uses each agent's `phase:` opt (not top-level phase('Find')
+// / phase('Verify') calls): because the pipeline interleaves one target's Verify
+// with another target's Find, explicit phase() boundaries would misrepresent the
+// interleaving. meta.phases still declares Find/Verify for the /workflows display.
+// ---------------------------------------------------------------------------
+
+// Fail loudly on a malformed target rather than degrade silently. A target
+// missing `scopeDirective` would otherwise inject the literal "undefined" into
+// the audit prompt; missing `paths`/`lookFor` already throw in buildAuditPrompt.
+for (const t of TARGETS) {
+  const key = (t && t.key) || '(unknown)'
+  if (!t || typeof t.key !== 'string' || !t.key) throw new Error('dual-family-review: a target is missing a string `key`')
+  if (typeof t.scopeDirective !== 'string' || !t.scopeDirective)
+    throw new Error(`dual-family-review: target '${key}' is missing a non-empty 'scopeDirective'`)
+  if (!Array.isArray(t.paths) || !t.paths.length) throw new Error(`dual-family-review: target '${key}' is missing non-empty 'paths'`)
+  if (!Array.isArray(t.lookFor)) throw new Error(`dual-family-review: target '${key}' 'lookFor' must be an array`)
+}
+
+const perTargetRaw = await pipeline(
+  TARGETS,
+
+  // -- Find: Claude finder + Codex finder, concurrently, for this target.
+  (d) =>
+    parallel([
+      () =>
+        agent(buildAuditPrompt(d, pf, false) + '\n\nReturn your findings via the structured output tool.' + DETECTION_ONLY, {
+          label: `find:claude:${d.key}`,
+          phase: 'Find',
+          schema: FINDINGS_SCHEMA,
+          agentType: READER_TYPE,
+        }),
+      () =>
+        codexUsable
+          ? agent(codexFinderPrompt(d, pf) + DETECTION_ONLY, {
+              label: `find:codex:${d.key}`,
+              phase: 'Find',
+              schema: FINDINGS_SCHEMA,
+              agentType: RUNNER_TYPE,
+            })
+          : Promise.resolve(null),
+    ]).then(([claudeRes, codexRes]) => ({ domain: d, claude: claudeRes, codex: codexRes })),
+
+  // -- Verify: cross-family confirmation of single-family findings.
+  async (fr) => {
+    const d = fr.domain
+    const claudeF = (fr.claude && fr.claude.findings) || []
+    const codexF = (fr.codex && fr.codex.findings) || []
+    const codexOk = !!fr.codex && !fr.codex.codexFailed
+
+    // Stamp each finding with its source family + a stable id.
+    claudeF.forEach((f, i) => {
+      f.family = 'claude'
+      f.id = `${d.key}-C-${f.localId || i + 1}`
+    })
+    codexF.forEach((f, i) => {
+      f.family = 'codex'
+      f.id = `${d.key}-X-${f.localId || i + 1}`
+    })
+
+    // 1) cross-confirmed at FIND time (both families independently found it).
+    const crossConfirmed = []
+    const codexMatched = new Set()
+    for (const cf of claudeF) {
+      const m = codexF.find((xf, j) => !codexMatched.has(j) && findingsMatch(cf, xf))
+      if (m) {
+        const j = codexF.indexOf(m)
+        codexMatched.add(j)
+        crossConfirmed.push({
+          ...cf,
+          tier: tierRank(cf.tier) <= tierRank(m.tier) ? cf.tier : m.tier, // keep the more severe
+          status: 'VERIFIED',
+          basis: 'cross-confirmed at find time (both Claude and Codex independently)',
+          codexCounterpart: m.id,
+        })
+      }
+    }
+    const matchedClaudeIds = new Set(crossConfirmed.map((c) => c.id))
+    const claudeOnly = claudeF.filter((f) => !matchedClaudeIds.has(f.id))
+    const codexOnly = codexF.filter((_, j) => !codexMatched.has(j))
+
+    // 2) singletons (P0/P1) -> adversarial verification by the OTHER family.
+    const toVerify = []
+    for (const f of claudeOnly) if (verifyVotes(f.tier) > 0) toVerify.push({ f, verifier: 'codex' })
+    for (const f of codexOnly) if (verifyVotes(f.tier) > 0) toVerify.push({ f, verifier: 'claude' })
+
+    const verifyResults = await parallel(
+      toVerify.flatMap(({ f, verifier }) => {
+        const n = verifyVotes(f.tier)
+        return Array.from({ length: n }, (_v, vi) => () => {
+          // If the required verifier family is unavailable, no cross-family vote.
+          if (verifier === 'codex' && !codexOk)
+            return Promise.resolve({ fid: f.id, f, verdict: null, unavailable: true })
+          const lens = LENSES[vi % LENSES.length]
+          const id = `${f.id}-v${vi}`
+          const p =
+            verifier === 'claude'
+              ? agent(claudeVerifyPrompt(f, pf, lens) + DETECTION_ONLY, {
+                  label: `verify:claude:${id}`,
+                  phase: 'Verify',
+                  schema: VERDICT_SCHEMA,
+                  agentType: READER_TYPE,
+                })
+              : agent(codexVerifyPrompt(f, pf, id, lens) + DETECTION_ONLY, {
+                  label: `verify:codex:${id}`,
+                  phase: 'Verify',
+                  schema: VERDICT_SCHEMA,
+                  agentType: RUNNER_TYPE,
+                })
+          return p.then((v) => ({ fid: f.id, f, verdict: v }))
+        })
+      }),
+    )
+
+    // 3) aggregate votes per finding.
+    const votesByFinding = new Map()
+    for (const r of verifyResults.filter(Boolean)) {
+      if (!votesByFinding.has(r.fid)) votesByFinding.set(r.fid, { f: r.f, votes: [], unavailable: false })
+      const e = votesByFinding.get(r.fid)
+      if (r.unavailable) e.unavailable = true
+      else if (r.verdict) e.votes.push(r.verdict)
+    }
+
+    const verified = [...crossConfirmed]
+    const needsVerification = []
+    const refuted = []
+    for (const [, e] of votesByFinding) {
+      const conf = e.votes.filter((v) => v.verdict === 'CONFIRMED').length
+      const refu = e.votes.filter((v) => v.verdict === 'REFUTED').length
+      const correctedTiers = e.votes.map((v) => v.correctedTier).filter((t) => t && t !== 'NONE')
+      const entry = {
+        ...e.f,
+        crossFamilyVotes: e.votes,
+        basis: `cross-family (${e.f.family === 'claude' ? 'codex' : 'claude'}) verification`,
+      }
+      if (e.unavailable || e.votes.length === 0) {
+        entry.status = 'NEEDS-VERIFICATION'
+        entry.note = e.unavailable ? 'cross-family verifier unavailable (single-LLM-family only)' : 'no verdict returned'
+        needsVerification.push(entry)
+      } else if (conf > refu) {
+        entry.status = 'VERIFIED'
+        if (correctedTiers.length) entry.verifierTier = correctedTiers.sort((a, b) => tierRank(a) - tierRank(b))[0]
+        verified.push(entry)
+      } else if (refu > conf) {
+        entry.status = 'REFUTED'
+        refuted.push(entry)
+      } else {
+        entry.status = 'NEEDS-VERIFICATION'
+        entry.note = 'split vote'
+        needsVerification.push(entry)
+      }
+    }
+
+    // P2s: reported as-is (not verified), tagged by family.
+    const p2s = [...claudeF, ...codexF].filter((f) => f.tier === 'P2')
+    // circular-validation flags from any finding.
+    const circular = [...claudeF, ...codexF]
+      .filter((f) => f.circularValidationRisk && f.circularValidationRisk.trim())
+      .map((f) => ({ id: f.id, file: f.file, line: f.line, family: f.family, note: f.circularValidationRisk }))
+
+    return {
+      domainKey: d.key,
+      domainName: d.name,
+      claudeAssessment: (fr.claude && fr.claude.assessment) || '(no claude result)',
+      codexAssessment: codexOk ? fr.codex.assessment : codexUsable ? `codex failed: ${fr.codex && fr.codex.failureReason}` : 'codex disabled',
+      tierCounts: {
+        claude: (fr.claude && fr.claude.tierCounts) || { p0: 0, p1: 0, p2: 0 },
+        codex: codexOk ? fr.codex.tierCounts : { p0: 0, p1: 0, p2: 0 },
+      },
+      verified,
+      needsVerification,
+      refuted,
+      p2s,
+      circular,
+    }
+  },
+)
+
+// Return structured per-target findings to the calling skill/wrapper. The caller
+// owns final consolidation (cross-target dedup, report, disposition) — this
+// engine is detection + per-target structuring only.
+//
+// Surface dropped targets (a per-target pipeline that threw -> null) so the
+// caller can reconcile perTarget.length against its target count and fail closed
+// rather than silently under-report.
+const perTarget = perTargetRaw.filter(Boolean)
+const droppedTargets = perTargetRaw.length - perTarget.length
+if (droppedTargets > 0) {
+  log(
+    `WARNING: ${droppedTargets}/${perTargetRaw.length} target(s) produced no result (pipeline error) and were dropped — the caller should fail closed.`,
+  )
+}
+return { perTarget, droppedTargets, codexUsable }

--- a/.claude/workflows/dual-family-review.js
+++ b/.claude/workflows/dual-family-review.js
@@ -346,7 +346,10 @@ function verifyVotes(tier) {
   // Cross-family independence is achieved with a single vote from the OTHER
   // family. Extra votes (budget-scaled, diverse lenses) harden the P0s only.
   if (tier === 'P0') {
-    if (budget && budget.total) return Math.min(3, 2 + Math.floor((budget.remaining() || 0) / 400000))
+    // `budget` is a workflow-runtime global; guard with typeof so the engine
+    // also runs in hosts that do not inject it (a bare reference would throw).
+    if (typeof budget !== 'undefined' && budget.total)
+      return Math.min(3, 2 + Math.floor((budget.remaining() || 0) / 400000))
     return 2
   }
   if (tier === 'P1') return 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to NeuNorm are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Dark current is now optional for the CCD pipelines.** `run_mars_ccd_pipeline`
+  and `run_venus_ccd_pipeline` accept `dark_paths=None` (the new default) or an
+  empty list to skip dark-current correction; the dark-frame variance then does
+  not contribute to the propagated uncertainty. Passing dark frames is unchanged
+  and fully backward compatible. Output provenance gains a `dark_correction_applied`
+  flag, and `dark_paths` is recorded only when dark frames were supplied.
+  ([#146](https://github.com/ornlneutronimaging/NeuNorm/issues/146))
+
 ## [2.0.0] - 2026-06-09
 
 NeuNorm 2.0 is a complete, [scipp](https://scipp.github.io/)-based rewrite of the

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ from neunorm.pipelines.mars_ccd import run_mars_ccd_pipeline
 transmission = run_mars_ccd_pipeline(
     sample_paths=[["sample_0001.tiff", "sample_0002.tiff"]],
     ob_paths=[["ob_0001.tiff", "ob_0002.tiff"]],
-    dark_paths=[["dark_0001.tiff"]],
+    dark_paths=[["dark_0001.tiff"]],  # optional — omit to skip dark correction
     output_path=Path("normalized.hdf5"),
 )
 ```
@@ -87,7 +87,9 @@ Each detector/facility has its own pipeline — `run_mars_tpx3_pipeline`,
 `run_venus_ccd_pipeline`, `run_venus_tpx1_pipeline`,
 `run_venus_tpx3_histogram_pipeline`, and `run_venus_tpx3_event_pipeline`. They
 share the same load → correct → normalize → write-to-HDF5/TIFF flow, but each
-takes detector-appropriate inputs — TPX detectors skip `dark_paths`, the TOF
+takes detector-appropriate inputs — `dark_paths` is optional for the CCD
+pipelines (omit it to skip dark correction) and TPX detectors skip it entirely,
+the TOF
 pipelines add `rebin_by_tof`/`rebin_by_spatial`, and
 `run_venus_tpx3_event_pipeline` takes a `BinningConfig` and flat (per-run) path
 lists. Check each function's signature in the

--- a/docs/workflows/mars_ccd_cmos.md
+++ b/docs/workflows/mars_ccd_cmos.md
@@ -111,7 +111,7 @@ flowchart TD
 |-------|--------|----------|-------------|
 | Sample images | TIFF/FITS stack | Yes | Raw neutron transmission images |
 | Open Beam (OB) | TIFF/FITS stack | Yes | Reference without sample |
-| Dark Current | TIFF/FITS stack | Yes | Electronic noise baseline (beam off) |
+| Dark Current | TIFF/FITS stack | No | Electronic noise baseline (beam off). Optional — omit `dark_paths` (or pass `[]`) to skip dark correction. |
 | ROI | (x0, y0, x1, y1) | No | Region of interest to crop |
 
 **Metadata** (from files or user):

--- a/docs/workflows/venus_ccd_cmos.md
+++ b/docs/workflows/venus_ccd_cmos.md
@@ -132,7 +132,7 @@ flowchart TD
 |-------|--------|----------|-------------|
 | Sample images | TIFF/FITS stack | Yes | Raw neutron transmission images |
 | Open Beam (OB) | TIFF/FITS stack | Yes | Reference without sample |
-| Dark Current | TIFF/FITS stack | Yes | Electronic noise baseline (beam off) |
+| Dark Current | TIFF/FITS stack | No | Electronic noise baseline (beam off). Optional — omit `dark_paths` (or pass `[]`) to skip dark correction. |
 | ROI | (x0, y0, x1, y1) | No | Region of interest to crop |
 | Reference ROI | (x0, y0, x1, y1) | No | ROI for beam stability correction |
 

--- a/src/neunorm/pipelines/mars_ccd.py
+++ b/src/neunorm/pipelines/mars_ccd.py
@@ -34,10 +34,10 @@ def run_mars_ccd_pipeline(  # noqa: C901
     """Execute MARS CCD/CMOS normalization pipeline.
 
     Pipeline Steps (10 total)
-    - Load TIFF/FITS (sample, OB, dark)
+    - Load TIFF/FITS (sample, OB, dark [optional])
     - Run combine (optional)
     - ROI clip (optional)
-    - Average dark/OB
+    - Average dark (optional) / OB
     - Dead pixel detection (existing tof/pixel_detector.py)
     - Gamma filtering (filters/gamma_filter.py)
     - Dark correction (optional, processing/dark_corrector.py)

--- a/src/neunorm/pipelines/mars_ccd.py
+++ b/src/neunorm/pipelines/mars_ccd.py
@@ -26,8 +26,8 @@ from neunorm.tof.pixel_detector import detect_dead_pixels
 def run_mars_ccd_pipeline(  # noqa: C901
     sample_paths: Sequence[Sequence[str | Path]],
     ob_paths: Sequence[Sequence[str | Path]],
-    dark_paths: Sequence[Sequence[str | Path]],
-    output_path: Path,
+    dark_paths: Optional[Sequence[Sequence[str | Path]]] = None,
+    output_path: Optional[Path] = None,
     roi: Optional[tuple] = None,
     gamma_filter: bool = True,
 ) -> sc.DataArray:
@@ -40,7 +40,7 @@ def run_mars_ccd_pipeline(  # noqa: C901
     - Average dark/OB
     - Dead pixel detection (existing tof/pixel_detector.py)
     - Gamma filtering (filters/gamma_filter.py)
-    - Dark correction (processing/dark_corrector.py)
+    - Dark correction (optional, processing/dark_corrector.py)
     - Normalization (existing processing/normalizer.py)
     - Output (exporters/hdf5_writer.py, exporters/tiff_writer.py)
 
@@ -52,11 +52,16 @@ def run_mars_ccd_pipeline(  # noqa: C901
     ob_paths : Sequence[Sequence[str | Path]]
         List of lists of paths to open beam TIFF or FITS files.
         Each inner list represents a run that should be combined before processing.
-    dark_paths : Sequence[Sequence[str | Path]]
+    dark_paths : Optional[Sequence[Sequence[str | Path]]]
         List of lists of paths to dark current TIFF or FITS files.
         Each inner list represents a run that should be combined before processing.
-    output_path : Path
-        Path to save the output file (HDF5 or TIFF)
+        Optional (default: None). If omitted (None or an empty list), dark
+        correction is skipped and the dark-frame variance does not contribute to
+        the propagated uncertainty.
+    output_path : Optional[Path]
+        Path to save the output file (HDF5 or TIFF). Required; a value of None
+        raises ``ValueError`` (the default exists only so ``dark_paths`` can keep
+        its positional slot).
     roi : Optional[tuple]
         Region of interest to apply (x_start, y_start, x_end, y_end)
     gamma_filter : bool
@@ -73,10 +78,12 @@ def run_mars_ccd_pipeline(  # noqa: C901
         Final normalized transmission DataArray with metadata and masks
     """
 
+    if output_path is None:
+        raise ValueError("output_path is required")
+
     # Load data
     samples = [load_stack(paths) for paths in sample_paths]
     ob = [load_stack(paths) for paths in ob_paths]
-    dark = [load_stack(paths) for paths in dark_paths]
 
     # Before combining, check that all sample runs have the same shape and some metadata keys match
     # Keys to check [ManufacturerStr, MotSlitVB.RBV, MotSlitVT.RBV, MotSlitHR.RBV, MotSlitHL.RBV].
@@ -111,24 +118,30 @@ def run_mars_ccd_pipeline(  # noqa: C901
         normalize_by_runs=True,
     )
 
-    dark = combine_runs(
-        dark,
-        metadata_keys_to_sum=("ExposureTime",),
-        metadata_check_match=[
-            "ExposureTime",
-            "ManufacturerStr",
-        ],
-        normalize_by_runs=True,
-    )
+    # Dark current is optional (issue #146): only load/combine it when dark paths are provided.
+    dark = None
+    if dark_paths:
+        dark_runs = [load_stack(paths) for paths in dark_paths]
+        dark = combine_runs(
+            dark_runs,
+            metadata_keys_to_sum=("ExposureTime",),
+            metadata_check_match=[
+                "ExposureTime",
+                "ManufacturerStr",
+            ],
+            normalize_by_runs=True,
+        )
 
     # Apply ROI if specified
     if roi:
         sample = apply_roi(sample, roi)
         ob = apply_roi(ob, roi)
-        dark = apply_roi(dark, roi)
+        if dark is not None:
+            dark = apply_roi(dark, roi)
 
     # Average dark and OB
-    dark = prepare_reference(dark, dim="N_image")
+    if dark is not None:
+        dark = prepare_reference(dark, dim="N_image")
     ob = prepare_reference(ob, dim="N_image")
 
     # Dead pixel detection
@@ -138,9 +151,14 @@ def run_mars_ccd_pipeline(  # noqa: C901
     if gamma_filter:
         sample = apply_gamma_filter(sample)
 
-    # Dark correction
-    sample_dark_corrected = subtract_dark(sample, dark)
-    ob_dark_corrected = subtract_dark(ob, dark)
+    # Dark correction (optional)
+    if dark is not None:
+        sample_dark_corrected = subtract_dark(sample, dark)
+        ob_dark_corrected = subtract_dark(ob, dark)
+    else:
+        logger.info("No dark current provided; skipping dark correction")
+        sample_dark_corrected = sample
+        ob_dark_corrected = ob
 
     # Normalization
     transmission = normalize_transmission(sample_dark_corrected, ob_dark_corrected)
@@ -149,11 +167,15 @@ def run_mars_ccd_pipeline(  # noqa: C901
     metadata = {
         "sample_paths": [[str(p) for p in run] for run in sample_paths],
         "ob_paths": [[str(p) for p in run] for run in ob_paths],
-        "dark_paths": [[str(p) for p in run] for run in dark_paths],
         "gamma_filter_applied": gamma_filter,
+        "dark_correction_applied": dark is not None,
         "processing_timestamp": datetime.now().isoformat(),
         "version": __version__,
     }
+
+    # Only record dark_paths when dark correction was actually applied.
+    if dark_paths:
+        metadata["dark_paths"] = [[str(p) for p in run] for run in dark_paths]
 
     if roi:
         metadata["roi_applied"] = roi

--- a/src/neunorm/pipelines/venus_ccd.py
+++ b/src/neunorm/pipelines/venus_ccd.py
@@ -27,8 +27,8 @@ from neunorm.tof.pixel_detector import detect_dead_pixels
 def run_venus_ccd_pipeline(  # noqa: C901
     sample_paths: Sequence[Sequence[str | Path]],
     ob_paths: Sequence[Sequence[str | Path]],
-    dark_paths: Sequence[Sequence[str | Path]],
-    output_path: Path,
+    dark_paths: Optional[Sequence[Sequence[str | Path]]] = None,
+    output_path: Optional[Path] = None,
     roi: Optional[tuple] = None,
     gamma_filter: bool = True,
     air_roi: Optional[tuple] = None,
@@ -43,7 +43,7 @@ def run_venus_ccd_pipeline(  # noqa: C901
     - Average dark/OB
     - Dead pixel detection
     - Gamma filtering (optional, less critical than MARS)
-    - Dark correction
+    - Dark correction (optional)
     - p_charge beam correction
     - Normalization
     - Air region correction (optional)
@@ -58,11 +58,16 @@ def run_venus_ccd_pipeline(  # noqa: C901
     ob_paths : Sequence[Sequence[str | Path]]
         List of lists of paths to open beam TIFF or FITS files.
         Each inner list represents a run that should be combined before processing.
-    dark_paths : Sequence[Sequence[str | Path]]
+    dark_paths : Optional[Sequence[Sequence[str | Path]]]
         List of lists of paths to dark current TIFF or FITS files.
         Each inner list represents a run that should be combined before processing.
-    output_path : Path
-        Path to save the output file (HDF5 or TIFF)
+        Optional (default: None). If omitted (None or an empty list), dark
+        correction is skipped and the dark-frame variance does not contribute to
+        the propagated uncertainty.
+    output_path : Optional[Path]
+        Path to save the output file (HDF5 or TIFF). Required; a value of None
+        raises ``ValueError`` (the default exists only so ``dark_paths`` can keep
+        its positional slot).
     roi : Optional[tuple]
         Region of interest to apply (x_start, y_start, x_end, y_end)
     gamma_filter : bool
@@ -82,10 +87,12 @@ def run_venus_ccd_pipeline(  # noqa: C901
         Final normalized transmission DataArray with metadata and masks
     """
 
+    if output_path is None:
+        raise ValueError("output_path is required")
+
     # Load data
     samples = [load_stack(paths) for paths in sample_paths]
     ob = [load_stack(paths) for paths in ob_paths]
-    dark = [load_stack(paths) for paths in dark_paths]
 
     # Before combining, check that all sample runs have the same shape and some metadata keys match
     # Keys to check ManufacturerStr. IntegratedPCharge is included in metadata checks and is
@@ -105,21 +112,27 @@ def run_venus_ccd_pipeline(  # noqa: C901
         normalize_by_runs=True,
     )
 
-    dark = combine_runs(
-        dark,
-        metadata_keys_to_sum=("IntegratedPCharge",),
-        metadata_check_match=["ManufacturerStr"],
-        normalize_by_runs=True,
-    )
+    # Dark current is optional (issue #146): only load/combine it when dark paths are provided.
+    dark = None
+    if dark_paths:
+        dark_runs = [load_stack(paths) for paths in dark_paths]
+        dark = combine_runs(
+            dark_runs,
+            metadata_keys_to_sum=("IntegratedPCharge",),
+            metadata_check_match=["ManufacturerStr"],
+            normalize_by_runs=True,
+        )
 
     # Apply ROI if specified
     if roi:
         sample = apply_roi(sample, roi)
         ob = apply_roi(ob, roi)
-        dark = apply_roi(dark, roi)
+        if dark is not None:
+            dark = apply_roi(dark, roi)
 
     # Average dark and OB
-    dark = prepare_reference(dark, dim="N_image")
+    if dark is not None:
+        dark = prepare_reference(dark, dim="N_image")
     ob = prepare_reference(ob, dim="N_image")
 
     # Dead pixel detection
@@ -129,9 +142,14 @@ def run_venus_ccd_pipeline(  # noqa: C901
     if gamma_filter:
         sample = apply_gamma_filter(sample)
 
-    # Dark correction
-    sample_dark_corrected = subtract_dark(sample, dark)
-    ob_dark_corrected = subtract_dark(ob, dark)
+    # Dark correction (optional)
+    if dark is not None:
+        sample_dark_corrected = subtract_dark(sample, dark)
+        ob_dark_corrected = subtract_dark(ob, dark)
+    else:
+        logger.info("No dark current provided; skipping dark correction")
+        sample_dark_corrected = sample
+        ob_dark_corrected = ob
 
     # Normalization
     transmission = normalize_transmission(
@@ -149,11 +167,15 @@ def run_venus_ccd_pipeline(  # noqa: C901
     metadata = {
         "sample_paths": [[str(p) for p in run] for run in sample_paths],
         "ob_paths": [[str(p) for p in run] for run in ob_paths],
-        "dark_paths": [[str(p) for p in run] for run in dark_paths],
         "gamma_filter_applied": gamma_filter,
+        "dark_correction_applied": dark is not None,
         "processing_timestamp": datetime.now().isoformat(),
         "version": __version__,
     }
+
+    # Only record dark_paths when dark correction was actually applied.
+    if dark_paths:
+        metadata["dark_paths"] = [[str(p) for p in run] for run in dark_paths]
 
     if roi:
         metadata["roi_applied"] = roi

--- a/src/neunorm/pipelines/venus_ccd.py
+++ b/src/neunorm/pipelines/venus_ccd.py
@@ -36,11 +36,11 @@ def run_venus_ccd_pipeline(  # noqa: C901
     """Execute VENUS CCD/CMOS normalization pipeline.
 
     Pipeline Steps (12 total)
-    - Load TIFF/FITS (sample, OB, dark)
+    - Load TIFF/FITS (sample, OB, dark [optional])
     - Load p_charge metadata
     - Run combine (critical for VENUS)
     - ROI clip (optional)
-    - Average dark/OB
+    - Average dark (optional) / OB
     - Dead pixel detection
     - Gamma filtering (optional, less critical than MARS)
     - Dark correction (optional)

--- a/tests/unit/test_mars_ccd.py
+++ b/tests/unit/test_mars_ccd.py
@@ -3,13 +3,18 @@ from pathlib import Path
 
 import h5py
 import numpy as np
+import pytest
 import scipp as sc
 from astropy.io import fits
 from PIL import Image
 from scitiff.io import load_scitiff
 
 from neunorm import __version__
+from neunorm.loaders.stack_loader import load_stack
 from neunorm.pipelines.mars_ccd import run_mars_ccd_pipeline
+from neunorm.processing.normalizer import normalize_transmission
+from neunorm.processing.reference_preparer import prepare_reference
+from neunorm.processing.run_combiner import combine_runs
 
 
 class TestMarsCCDPipeline:
@@ -136,6 +141,8 @@ class TestMarsCCDPipeline:
                 np.testing.assert_equal(hf["metadata/ob_paths"].asstr()[:], [[str(p) for p in self.ob_paths]])
                 assert "metadata/dark_paths" in hf
                 np.testing.assert_equal(hf["metadata/dark_paths"].asstr()[:], [[str(p) for p in self.dark_paths]])
+                assert "metadata/dark_correction_applied" in hf
+                np.testing.assert_equal(hf["metadata/dark_correction_applied"][()], True)
                 assert "metadata/gamma_filter_applied" in hf
                 np.testing.assert_equal(hf["metadata/gamma_filter_applied"][()], True)
                 assert "metadata/processing_timestamp" in hf
@@ -308,6 +315,124 @@ class TestMarsCCDPipeline:
         np.testing.assert_equal(
             transmission.coords["MotSlitHL.RBV"].values, 42.4
         )  # should be unchanged since it's the same for both runs
+
+    def test_mars_ccd_pipeline_no_dark(self):
+        """Dark current is optional (issue #146): omitting dark_paths skips dark correction.
+
+        Without dark subtraction the transmission is T = S / OB = (81 + i) / 100
+        for these fixtures (vs (81 + i - 5) / (100 - 5) with dark). MARS does not
+        apply a proton-charge correction.
+        """
+        with tempfile.NamedTemporaryFile(suffix=".hdf5", delete=True) as f:
+            output_path = Path(f.name)
+
+            transmission = run_mars_ccd_pipeline(
+                sample_paths=[self.sample_paths],
+                ob_paths=[self.ob_paths],
+                output_path=output_path,
+            )
+
+            assert output_path.exists()
+            assert transmission.shape == (5, 32, 32)
+
+            with h5py.File(output_path, "r") as hf:
+                assert hf["transmission"].shape == (5, 32, 32)
+                # No dark subtraction: T = S / OB = (81 + i) / 100
+                for i in range(5):
+                    np.testing.assert_allclose(hf["transmission"][i], (81 + i) / 100)
+                # Uncertainty is present, positive and finite
+                assert "uncertainty" in hf
+                assert np.all(np.isfinite(hf["uncertainty"][:]))
+                assert np.all(hf["uncertainty"][:] > 0)
+                # Provenance: dark correction not applied, dark_paths omitted entirely
+                assert "metadata/dark_correction_applied" in hf
+                np.testing.assert_equal(hf["metadata/dark_correction_applied"][()], False)
+                assert "metadata/dark_paths" not in hf
+
+    def test_mars_ccd_pipeline_empty_dark_paths(self):
+        """An empty dark_paths list is treated the same as omitting dark (issue #146)."""
+        with tempfile.NamedTemporaryFile(suffix=".h5", delete=True) as f:
+            transmission = run_mars_ccd_pipeline(
+                sample_paths=[self.sample_paths],
+                ob_paths=[self.ob_paths],
+                dark_paths=[],
+                output_path=Path(f.name),
+            )
+        assert transmission.shape == (5, 32, 32)
+        for i in range(5):
+            np.testing.assert_allclose(transmission.values[i], (81 + i) / 100)
+
+    def test_mars_ccd_pipeline_requires_output_path(self):
+        """output_path is required even though it carries a default for signature compatibility."""
+        with pytest.raises(ValueError, match="output_path is required"):
+            run_mars_ccd_pipeline(
+                sample_paths=[self.sample_paths],
+                ob_paths=[self.ob_paths],
+            )
+
+    def test_mars_ccd_pipeline_no_dark_uncertainty(self):
+        """No-dark UQ equals the dark-free propagation, with no dark-frame variance term (issue #146).
+
+        Two independent checks:
+        1. The pipeline's no-dark output (values AND variances) matches a direct
+           composition of the same library functions with dark subtraction omitted,
+           proving no spurious variance term is added or dropped.
+        2. Removing the dark removes its variance contribution, so the no-dark
+           uncertainty is strictly smaller than the with-dark uncertainty everywhere.
+        """
+        match_keys = [
+            "ExposureTime",
+            "ManufacturerStr",
+            "MotSlitVB.RBV",
+            "MotSlitVT.RBV",
+            "MotSlitHR.RBV",
+            "MotSlitHL.RBV",
+        ]
+        with tempfile.NamedTemporaryFile(suffix=".h5", delete=True) as f:
+            no_dark = run_mars_ccd_pipeline(
+                sample_paths=[self.sample_paths],
+                ob_paths=[self.ob_paths],
+                output_path=Path(f.name),
+                gamma_filter=False,
+            )
+
+        # Independent dark-free propagation using the same composable functions the pipeline uses.
+        sample = combine_runs(
+            [load_stack(self.sample_paths)],
+            metadata_keys_to_sum=("ExposureTime",),
+            metadata_check_match=match_keys,
+            normalize_by_runs=True,
+        )
+        ob = combine_runs(
+            [load_stack(self.ob_paths)],
+            metadata_keys_to_sum=("ExposureTime",),
+            metadata_check_match=match_keys,
+            normalize_by_runs=True,
+        )
+        ob = prepare_reference(ob, dim="N_image")
+        expected = normalize_transmission(sample, ob)
+        np.testing.assert_allclose(no_dark.values, expected.values)
+        np.testing.assert_allclose(no_dark.variances, expected.variances)
+
+        # Independent (non-circular) oracle: pin the no-dark variance to literal
+        # values, NOT recomposed from the same helpers. A regression inside the
+        # shared variance propagation would shift `expected` in lock-step but not
+        # these constants, so this is what actually guards the Var(T) property.
+        expected_var_per_image = np.array([0.010287, 0.010441, 0.010596, 0.010752, 0.010908])
+        expected_var = np.broadcast_to(expected_var_per_image[:, None, None], no_dark.variances.shape)
+        np.testing.assert_allclose(no_dark.variances, expected_var, rtol=1e-3)
+
+        # With dark, the dark-frame variance is folded into both numerator and
+        # denominator, raising the uncertainty everywhere.
+        with tempfile.NamedTemporaryFile(suffix=".h5", delete=True) as f:
+            with_dark = run_mars_ccd_pipeline(
+                sample_paths=[self.sample_paths],
+                ob_paths=[self.ob_paths],
+                dark_paths=[self.dark_paths],
+                output_path=Path(f.name),
+                gamma_filter=False,
+            )
+        assert np.all(no_dark.variances < with_dark.variances)
 
 
 class TestMarsCCDPipelineFITS:

--- a/tests/unit/test_mars_ccd.py
+++ b/tests/unit/test_mars_ccd.py
@@ -377,8 +377,11 @@ class TestMarsCCDPipeline:
         1. The pipeline's no-dark output (values AND variances) matches a direct
            composition of the same library functions with dark subtraction omitted,
            proving no spurious variance term is added or dropped.
-        2. Removing the dark removes its variance contribution, so the no-dark
-           uncertainty is strictly smaller than the with-dark uncertainty everywhere.
+        2. Removing the dark removes its variance contribution, so for these uniform
+           fixtures the no-dark uncertainty is smaller than the with-dark uncertainty
+           everywhere. (Fixture-specific, not a universal law — dark subtraction also
+           shrinks the numerator/denominator; the pinned oracle above is what guards
+           the general Var(T) property.)
         """
         match_keys = [
             "ExposureTime",
@@ -423,7 +426,7 @@ class TestMarsCCDPipeline:
         np.testing.assert_allclose(no_dark.variances, expected_var, rtol=1e-3)
 
         # With dark, the dark-frame variance is folded into both numerator and
-        # denominator, raising the uncertainty everywhere.
+        # denominator, raising the uncertainty for these fixtures.
         with tempfile.NamedTemporaryFile(suffix=".h5", delete=True) as f:
             with_dark = run_mars_ccd_pipeline(
                 sample_paths=[self.sample_paths],

--- a/tests/unit/test_venus_ccd.py
+++ b/tests/unit/test_venus_ccd.py
@@ -405,8 +405,11 @@ class TestVenusCCDPipeline:
         1. The pipeline's no-dark output (values AND variances) matches a direct
            composition of the same library functions with dark subtraction omitted,
            proving no spurious variance term is added or dropped.
-        2. Removing the dark removes its variance contribution, so the no-dark
-           uncertainty is strictly smaller than the with-dark uncertainty everywhere.
+        2. Removing the dark removes its variance contribution, so for these uniform
+           fixtures the no-dark uncertainty is smaller than the with-dark uncertainty
+           everywhere. (Fixture-specific, not a universal law — dark subtraction also
+           shrinks the numerator/denominator; the pinned oracle above is what guards
+           the general Var(T) property.)
         """
         with tempfile.NamedTemporaryFile(suffix=".h5", delete=True) as f:
             no_dark = run_venus_ccd_pipeline(
@@ -448,7 +451,7 @@ class TestVenusCCDPipeline:
         np.testing.assert_allclose(no_dark.variances, expected_var, rtol=1e-3)
 
         # With dark, the dark-frame variance is folded into both numerator and
-        # denominator, raising the uncertainty everywhere.
+        # denominator, raising the uncertainty for these fixtures.
         with tempfile.NamedTemporaryFile(suffix=".h5", delete=True) as f:
             with_dark = run_venus_ccd_pipeline(
                 sample_paths=[self.sample_paths],

--- a/tests/unit/test_venus_ccd.py
+++ b/tests/unit/test_venus_ccd.py
@@ -3,12 +3,17 @@ from pathlib import Path
 
 import h5py
 import numpy as np
+import pytest
 import scipp as sc
 from PIL import Image
 from scitiff.io import load_scitiff
 
 from neunorm import __version__
+from neunorm.loaders.stack_loader import load_stack
 from neunorm.pipelines.venus_ccd import run_venus_ccd_pipeline
+from neunorm.processing.normalizer import normalize_transmission
+from neunorm.processing.reference_preparer import prepare_reference
+from neunorm.processing.run_combiner import combine_runs
 
 
 class TestVenusCCDPipeline:
@@ -140,6 +145,8 @@ class TestVenusCCDPipeline:
                 np.testing.assert_equal(hf["metadata/ob_paths"].asstr()[:], [[str(p) for p in self.ob_paths]])
                 assert "metadata/dark_paths" in hf
                 np.testing.assert_equal(hf["metadata/dark_paths"].asstr()[:], [[str(p) for p in self.dark_paths]])
+                assert "metadata/dark_correction_applied" in hf
+                np.testing.assert_equal(hf["metadata/dark_correction_applied"][()], True)
                 assert "metadata/gamma_filter_applied" in hf
                 np.testing.assert_equal(hf["metadata/gamma_filter_applied"][()], True)
                 assert "metadata/processing_timestamp" in hf
@@ -337,3 +344,117 @@ class TestVenusCCDPipeline:
         np.testing.assert_equal(
             transmission.coords["IntegratedPCharge"].values, [0.1]
         )  # should be unchanged since we are normalizing by the number of runs
+
+    def test_venus_ccd_pipeline_no_dark(self):
+        """Dark current is optional (issue #146): omitting dark_paths skips dark correction.
+
+        Without dark subtraction the transmission is T = (S / pc_s) / (OB / pc_ob),
+        i.e. (81 + i) / 100 * 2 for these fixtures (vs (81 + i - 5) / (100 - 5) * 2 with dark).
+        """
+        with tempfile.NamedTemporaryFile(suffix=".hdf5", delete=True) as f:
+            output_path = Path(f.name)
+
+            transmission = run_venus_ccd_pipeline(
+                sample_paths=[self.sample_paths],
+                ob_paths=[self.ob_paths],
+                output_path=output_path,
+            )
+
+            assert output_path.exists()
+            assert transmission.shape == (5, 32, 32)
+
+            with h5py.File(output_path, "r") as hf:
+                assert hf["transmission"].shape == (5, 32, 32)
+                # No dark subtraction: T = (S / pc_s) / (OB / pc_ob) = (81 + i) / 100 * 2
+                for i in range(5):
+                    np.testing.assert_allclose(hf["transmission"][i], (81 + i) / 100 * 2)
+                # Uncertainty is present, positive and finite
+                assert "uncertainty" in hf
+                assert np.all(np.isfinite(hf["uncertainty"][:]))
+                assert np.all(hf["uncertainty"][:] > 0)
+                # Provenance: dark correction not applied, dark_paths omitted entirely
+                assert "metadata/dark_correction_applied" in hf
+                np.testing.assert_equal(hf["metadata/dark_correction_applied"][()], False)
+                assert "metadata/dark_paths" not in hf
+
+    def test_venus_ccd_pipeline_empty_dark_paths(self):
+        """An empty dark_paths list is treated the same as omitting dark (issue #146)."""
+        with tempfile.NamedTemporaryFile(suffix=".h5", delete=True) as f:
+            transmission = run_venus_ccd_pipeline(
+                sample_paths=[self.sample_paths],
+                ob_paths=[self.ob_paths],
+                dark_paths=[],
+                output_path=Path(f.name),
+            )
+        assert transmission.shape == (5, 32, 32)
+        for i in range(5):
+            np.testing.assert_allclose(transmission.values[i], (81 + i) / 100 * 2)
+
+    def test_venus_ccd_pipeline_requires_output_path(self):
+        """output_path is required even though it carries a default for signature compatibility."""
+        with pytest.raises(ValueError, match="output_path is required"):
+            run_venus_ccd_pipeline(
+                sample_paths=[self.sample_paths],
+                ob_paths=[self.ob_paths],
+            )
+
+    def test_venus_ccd_pipeline_no_dark_uncertainty(self):
+        """No-dark UQ equals the dark-free propagation, with no dark-frame variance term (issue #146).
+
+        Two independent checks:
+        1. The pipeline's no-dark output (values AND variances) matches a direct
+           composition of the same library functions with dark subtraction omitted,
+           proving no spurious variance term is added or dropped.
+        2. Removing the dark removes its variance contribution, so the no-dark
+           uncertainty is strictly smaller than the with-dark uncertainty everywhere.
+        """
+        with tempfile.NamedTemporaryFile(suffix=".h5", delete=True) as f:
+            no_dark = run_venus_ccd_pipeline(
+                sample_paths=[self.sample_paths],
+                ob_paths=[self.ob_paths],
+                output_path=Path(f.name),
+                gamma_filter=False,
+            )
+
+        # Independent dark-free propagation using the same composable functions the pipeline uses.
+        sample = combine_runs(
+            [load_stack(self.sample_paths)],
+            metadata_keys_to_sum=("IntegratedPCharge",),
+            metadata_check_match=["ManufacturerStr"],
+            normalize_by_runs=True,
+        )
+        ob = combine_runs(
+            [load_stack(self.ob_paths)],
+            metadata_keys_to_sum=("IntegratedPCharge",),
+            metadata_check_match=["ManufacturerStr"],
+            normalize_by_runs=True,
+        )
+        ob = prepare_reference(ob, dim="N_image")
+        expected = normalize_transmission(
+            sample=sample,
+            ob=ob,
+            proton_charge_sample=sample.coords["IntegratedPCharge"],
+            proton_charge_ob=ob.coords["IntegratedPCharge"],
+        )
+        np.testing.assert_allclose(no_dark.values, expected.values)
+        np.testing.assert_allclose(no_dark.variances, expected.variances)
+
+        # Independent (non-circular) oracle: pin the no-dark variance to literal
+        # values, NOT recomposed from the same helpers. A regression inside the
+        # shared variance propagation would shift `expected` in lock-step but not
+        # these constants, so this is what actually guards the Var(T) property.
+        expected_var_per_image = np.array([0.041279, 0.0419, 0.042523, 0.043149, 0.043778])
+        expected_var = np.broadcast_to(expected_var_per_image[:, None, None], no_dark.variances.shape)
+        np.testing.assert_allclose(no_dark.variances, expected_var, rtol=1e-3)
+
+        # With dark, the dark-frame variance is folded into both numerator and
+        # denominator, raising the uncertainty everywhere.
+        with tempfile.NamedTemporaryFile(suffix=".h5", delete=True) as f:
+            with_dark = run_venus_ccd_pipeline(
+                sample_paths=[self.sample_paths],
+                ob_paths=[self.ob_paths],
+                dark_paths=[self.dark_paths],
+                output_path=Path(f.name),
+                gamma_filter=False,
+            )
+        assert np.all(no_dark.variances < with_dark.variances)


### PR DESCRIPTION
## Summary

Two related changes on this branch:

### 1. Optional dark current for the CCD pipelines — closes #146
`run_venus_ccd_pipeline` and `run_mars_ccd_pipeline` now accept an optional
`dark_paths` (default `None`). Omitting it (or passing `[]`) **skips dark
correction**: the dark-frame variance then does not contribute to the propagated
uncertainty, while sample/OB Poisson variances and the VENUS proton-charge
systematic still flow unchanged. Passing dark frames behaves exactly as before —
fully backward compatible.

- `output_path` gains a default (with an explicit `ValueError` guard) so
  `dark_paths` can keep its positional slot — every existing call form still binds.
- Output provenance gains a `dark_correction_applied` flag; `dark_paths` is
  recorded only when dark frames were supplied.
- Tests: no-dark transmission, empty-list, `output_path` required, and an
  **uncertainty-propagation** test that pins the no-dark `Var(T)` to an
  independent (non-circular) oracle and asserts it is strictly below the
  with-dark variance (i.e. no `Var(dark)` term leaks in).
- Docs/CHANGELOG updated (workflow Input tables, README, `[Unreleased]`).

### 2. Detection-only dual-family review pipeline (`.claude/`)
Ports the NEREIDS review engine, adapted to NeuNorm's Python/scipp/pixi world:

- `.claude/workflows/dual-family-review.js` — per-target Claude + Codex finders,
  schema-forced output, deterministic dedup, and cross-LLM-family adversarial
  verification of P0/P1 findings. Checklist rewritten for scipp variance
  propagation, units, masks, HDF5/TIFF I/O, and the `combine_runs`
  single-run-no-copy hazard.
- `.claude/skills/review-pipeline/SKILL.md` — diffs the current branch vs `next`,
  runs the engine, reports at a human gate. **Never edits, commits, or pushes.**
  Complements the existing whole-codebase `/bughunt`.

## Verification
- Full suite: all tests pass; pre-commit clean (ruff, codespell, gitleaks).
- The ported engine was validated end-to-end on the #146 diff with the live
  Codex CLI (both families ran; cross-family verify worked — Codex's lone P1 was
  independently refuted by Claude). 0 P0/P1 correctness findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)