### PR TITLE
feat: produce float32 normalized data in CCD pipelines (#147)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **CCD pipelines now compute in float32 end-to-end instead of float64.** The
+  TIFF/FITS loaders load image data as `float32`, so `run_mars_ccd_pipeline` and
+  `run_venus_ccd_pipeline` propagate, normalize, and return `float32` transmission
+  (values and variances), roughly halving the in-memory footprint of large image
+  stacks. float32 is sufficient for neutron imaging (16-bit detectors) and matches
+  the already-float32 event/TOF path. On-disk HDF5/TIFF output was already written
+  as float32, so **file dtypes are unchanged**; written values may differ from
+  before by up to ~1e-7 (now computed in float32 rather than rounded from float64).
+  ([#147](https://github.com/ornlneutronimaging/NeuNorm/issues/147))
 - **Dark current is now optional for the CCD pipelines.** `run_mars_ccd_pipeline`
   and `run_venus_ccd_pipeline` accept `dark_paths=None` (the new default) or an
   empty list to skip dark-current correction; the dark-frame variance then does

--- a/docs/workflows/mars_ccd_cmos.md
+++ b/docs/workflows/mars_ccd_cmos.md
@@ -250,6 +250,11 @@ flowchart TD
 | Dead Pixel Mask | (y, x) | bool | True = dead pixel |
 | Metadata | dict | - | Processing provenance |
 
+The pipeline computes in **float32 end-to-end** — TIFF/FITS images are loaded as
+float32 and all processing (combine, dark correction, normalization, uncertainty
+propagation) stays float32. float32 is sufficient for neutron imaging (16-bit
+detectors) and halves the in-memory footprint of large stacks.
+
 **Metadata contents**:
 - Input file paths
 - Processing timestamp

--- a/docs/workflows/venus_ccd_cmos.md
+++ b/docs/workflows/venus_ccd_cmos.md
@@ -303,6 +303,11 @@ flowchart TD
 | Dead Pixel Mask | (y, x) | bool | True = dead pixel |
 | Metadata | dict | - | Processing provenance |
 
+The pipeline computes in **float32 end-to-end** — TIFF/FITS images are loaded as
+float32 and all processing (combine, dark correction, normalization, uncertainty
+propagation) stays float32. float32 is sufficient for neutron imaging (16-bit
+detectors) and halves the in-memory footprint of large stacks.
+
 **Metadata contents**:
 - Input file paths
 - Processing timestamp

--- a/src/neunorm/loaders/fits_loader.py
+++ b/src/neunorm/loaders/fits_loader.py
@@ -57,8 +57,10 @@ def load_fits_stack(paths: Sequence[str | Path], tof_edges: Optional[np.ndarray]
                 hdul.info(output=info_buf)
                 logger.debug("FITS info for {}:\n{}", path, info_buf.getvalue().rstrip())
 
-                # Assume data is in primary HDU
-                arr = hdul[0].data.astype(np.float64)
+                # Assume data is in primary HDU. float32 is sufficient for neutron
+                # imaging (16-bit detectors) and halves the in-memory footprint of
+                # large stacks (issue #147).
+                arr = hdul[0].data.astype(np.float32)
                 data_list.append(arr)
 
                 # Store header from first file

--- a/src/neunorm/loaders/tiff_loader.py
+++ b/src/neunorm/loaders/tiff_loader.py
@@ -46,7 +46,9 @@ def load_tiff_stack(paths: Sequence[str | Path], tof_edges: Optional[np.ndarray]
     try:
         for path in paths:
             with Image.open(path) as img:
-                data_list.append(np.asanyarray(img, dtype=np.float64))
+                # float32 is sufficient for neutron imaging (16-bit detectors) and
+                # halves the in-memory footprint of large stacks (issue #147).
+                data_list.append(np.asanyarray(img, dtype=np.float32))
                 metadata_list.append(img.tag_v2)
     except Exception as e:
         logger.error("Error loading TIFF stack: {}", e)

--- a/src/neunorm/pipelines/mars_ccd.py
+++ b/src/neunorm/pipelines/mars_ccd.py
@@ -163,6 +163,12 @@ def run_mars_ccd_pipeline(  # noqa: C901
     # Normalization
     transmission = normalize_transmission(sample_dark_corrected, ob_dark_corrected)
 
+    # Guarantee a float32 normalized data product (issue #147), regardless of any
+    # intermediate dtype promotion. .astype converts values and variances. MARS has
+    # no proton-charge division, so this is already float32; the cast keeps the two
+    # CCD pipelines symmetric and is robust to future changes.
+    transmission = transmission.astype("float32")
+
     # Write output
     metadata = {
         "sample_paths": [[str(p) for p in run] for run in sample_paths],

--- a/src/neunorm/pipelines/venus_ccd.py
+++ b/src/neunorm/pipelines/venus_ccd.py
@@ -151,17 +151,23 @@ def run_venus_ccd_pipeline(  # noqa: C901
         sample_dark_corrected = sample
         ob_dark_corrected = ob
 
-    # Normalization
+    # Normalization. Cast the proton-charge coords to float32 so the division does
+    # not silently re-promote the float32 image data back to float64 (issue #147);
+    # the coord is float64 because metadata is parsed via float().
     transmission = normalize_transmission(
         sample=sample_dark_corrected,
         ob=ob_dark_corrected,
-        proton_charge_sample=sample.coords["IntegratedPCharge"],
-        proton_charge_ob=ob.coords["IntegratedPCharge"],
+        proton_charge_sample=sample.coords["IntegratedPCharge"].astype("float32"),
+        proton_charge_ob=ob.coords["IntegratedPCharge"].astype("float32"),
     )
 
     # Air region correction (optional)
     if air_roi is not None:
         transmission = apply_air_region_correction(transmission, air_roi)
+
+    # Guarantee a float32 normalized data product (issue #147), regardless of any
+    # intermediate dtype promotion. .astype converts values and variances.
+    transmission = transmission.astype("float32")
 
     # Write output
     metadata = {

--- a/tests/unit/test_fits_loader.py
+++ b/tests/unit/test_fits_loader.py
@@ -32,6 +32,10 @@ def test_load_fits_stack():
     assert da.variances.shape == (3, 5, 5)
     assert da.variances.max() == 5
 
+    # float32 is sufficient for neutron imaging; loading in float32 halves memory (issue #147)
+    assert da.values.dtype == np.float32
+    assert da.variances.dtype == np.float32
+
     assert len(da.coords) == 8
     assert "SIMPLE" in da.coords
 

--- a/tests/unit/test_mars_ccd.py
+++ b/tests/unit/test_mars_ccd.py
@@ -119,7 +119,7 @@ class TestMarsCCDPipeline:
                 # check that transmission values are correct based on the formula
                 # T = (S - AVERAGE(D)) / (AVERAGE(OB) - AVERAGE(D))
                 for i in range(5):
-                    np.testing.assert_allclose(hf["transmission"][i], (81 + i - 5) / (100 - 5))
+                    np.testing.assert_allclose(hf["transmission"][i], (81 + i - 5) / (100 - 5), rtol=1e-5)
                 assert hf["transmission"].attrs["units"] == "dimensionless"
                 assert hf["transmission"].dtype == np.float32
                 # Check uncertainty data exists and is reasonable
@@ -190,7 +190,7 @@ class TestMarsCCDPipeline:
         # check that transmission values are correct based on the formula
         # T = (S - AVERAGE(D)) / (AVERAGE(OB) - AVERAGE(D))
         for i in range(5):
-            np.testing.assert_allclose(image.values[i], (81 + i - 5) / (100 - 5))
+            np.testing.assert_allclose(image.values[i], (81 + i - 5) / (100 - 5), rtol=1e-5)
         # Check uncertainty data exists and is reasonable
         np.testing.assert_allclose(image.variances, 0.011, rtol=0.15)
         assert "scitiff-mask" in image.masks
@@ -239,7 +239,7 @@ class TestMarsCCDPipeline:
             expected_value = np.full((20, 20), (81 + i - 5) / (100 - 5))
             expected_value[22 - 5, 8 - 5] = 0  # dead pixel should be zero after dark subtraction and normalization
             # gamma spike should be replaced with the same values from that image
-            np.testing.assert_allclose(transmission.values[i], expected_value)
+            np.testing.assert_allclose(transmission.values[i], expected_value, rtol=1e-5)
 
         # check that the variances are higher for the gamma spike pixel and near zero for the dead pixel
         approximate_variances = np.full((5, 20, 20), 0.011)
@@ -281,7 +281,7 @@ class TestMarsCCDPipeline:
         # by the number of runs, so it should not change the final transmission values, just reduce the variance.
         for i in range(5):
             expected_value = np.full((20, 20), ((81 + i) - 5) / (100 - 5))
-            np.testing.assert_allclose(transmission.values[i], expected_value)
+            np.testing.assert_allclose(transmission.values[i], expected_value, rtol=1e-5)
 
         # check that the variances exist and are reasonable
         np.testing.assert_allclose(transmission.variances, 0.004, atol=0.002)
@@ -339,7 +339,7 @@ class TestMarsCCDPipeline:
                 assert hf["transmission"].shape == (5, 32, 32)
                 # No dark subtraction: T = S / OB = (81 + i) / 100
                 for i in range(5):
-                    np.testing.assert_allclose(hf["transmission"][i], (81 + i) / 100)
+                    np.testing.assert_allclose(hf["transmission"][i], (81 + i) / 100, rtol=1e-5)
                 # Uncertainty is present, positive and finite
                 assert "uncertainty" in hf
                 assert np.all(np.isfinite(hf["uncertainty"][:]))
@@ -360,7 +360,7 @@ class TestMarsCCDPipeline:
             )
         assert transmission.shape == (5, 32, 32)
         for i in range(5):
-            np.testing.assert_allclose(transmission.values[i], (81 + i) / 100)
+            np.testing.assert_allclose(transmission.values[i], (81 + i) / 100, rtol=1e-5)
 
     def test_mars_ccd_pipeline_requires_output_path(self):
         """output_path is required even though it carries a default for signature compatibility."""
@@ -414,6 +414,10 @@ class TestMarsCCDPipeline:
         )
         ob = prepare_reference(ob, dim="N_image")
         expected = normalize_transmission(sample, ob)
+        # The pipeline produces float32 normalized data end-to-end (issue #147). MARS
+        # has no proton-charge division, so loaders being float32 keeps the whole path
+        # float32 and this structural check stays bit-tight against the pipeline output.
+        assert no_dark.dtype == sc.DType.float32
         np.testing.assert_allclose(no_dark.values, expected.values)
         np.testing.assert_allclose(no_dark.variances, expected.variances)
 
@@ -435,6 +439,7 @@ class TestMarsCCDPipeline:
                 output_path=Path(f.name),
                 gamma_filter=False,
             )
+        assert with_dark.dtype == sc.DType.float32
         assert np.all(no_dark.variances < with_dark.variances)
 
 
@@ -507,7 +512,7 @@ class TestMarsCCDPipelineFITS:
                 # check that transmission values are correct based on the formula
                 # T = (S - AVERAGE(D)) / (AVERAGE(OB) - AVERAGE(D))
                 for i in range(5):
-                    np.testing.assert_allclose(hf["transmission"][i], (81 + i - 5) / (100 - 5))
+                    np.testing.assert_allclose(hf["transmission"][i], (81 + i - 5) / (100 - 5), rtol=1e-5)
                 assert hf["transmission"].attrs["units"] == "dimensionless"
                 assert hf["transmission"].dtype == np.float32
                 # Check uncertainty data exists and is reasonable

--- a/tests/unit/test_tiff_loader.py
+++ b/tests/unit/test_tiff_loader.py
@@ -31,6 +31,10 @@ def test_load_tiff_stack():
     assert da.variances.shape == (3, 5, 5)
     assert da.variances.max() == 5
 
+    # float32 is sufficient for neutron imaging; loading in float32 halves memory (issue #147)
+    assert da.values.dtype == np.float32
+    assert da.variances.dtype == np.float32
+
     assert len(da.coords) == 15
 
     assert "SampleFormat" in da.coords

--- a/tests/unit/test_venus_ccd.py
+++ b/tests/unit/test_venus_ccd.py
@@ -123,7 +123,8 @@ class TestVenusCCDPipeline:
                 # T = (S - AVERAGE(D)) / (AVERAGE(OB) - AVERAGE(D))
                 # but will be two times because of the difference proton charge between sample and OB
                 for i in range(5):
-                    np.testing.assert_allclose(hf["transmission"][i], (81 + i - 5) / (100 - 5) * 2)
+                    # rtol consistent with float32 compute precision (issue #147)
+                    np.testing.assert_allclose(hf["transmission"][i], (81 + i - 5) / (100 - 5) * 2, rtol=1e-5)
                 assert hf["transmission"].attrs["units"] == "dimensionless"
                 assert hf["transmission"].dtype == np.float32
                 # Check uncertainty data exists and is reasonable
@@ -192,7 +193,8 @@ class TestVenusCCDPipeline:
         # T = (S - AVERAGE(D)) / (AVERAGE(OB) - AVERAGE(D))
         # but will be two times because of the difference proton charge between sample and OB
         for i in range(5):
-            np.testing.assert_allclose(image.values[i], (81 + i - 5) / (100 - 5) * 2)
+            # rtol consistent with float32 compute precision (issue #147)
+            np.testing.assert_allclose(image.values[i], (81 + i - 5) / (100 - 5) * 2, rtol=1e-5)
         # Check uncertainty data exists and is reasonable
         np.testing.assert_allclose(image.variances, 0.047, rtol=0.1)
         assert "scitiff-mask" in image.masks
@@ -241,7 +243,7 @@ class TestVenusCCDPipeline:
             expected_value = np.full((20, 20), (81 + i - 5) / (100 - 5) * 2)
             expected_value[22 - 5, 8 - 5] = 0  # dead pixel should be zero after dark subtraction and normalization
             # gamma spike should be replaced with the same values from that image
-            np.testing.assert_allclose(transmission.values[i], expected_value)
+            np.testing.assert_allclose(transmission.values[i], expected_value, rtol=1e-5)
 
         # check that the variances are higher for the gamma spike pixel and near zero for the dead pixel
         approximate_variances = np.full((5, 20, 20), 0.047)
@@ -283,7 +285,7 @@ class TestVenusCCDPipeline:
         # by the number of runs, so it should not change the final transmission values, just reduce the variance.
         for i in range(5):
             expected_value = np.full((20, 20), ((81 + i) - 5) / (100 - 5) * 2)
-            np.testing.assert_allclose(transmission.values[i], expected_value)
+            np.testing.assert_allclose(transmission.values[i], expected_value, rtol=1e-5)
 
         # check that the variances exist and are reasonable
         np.testing.assert_allclose(transmission.variances, 0.018, atol=0.001)
@@ -322,13 +324,13 @@ class TestVenusCCDPipeline:
             assert output_path.exists()
 
         assert transmission.shape == (1, 32, 32)
-        # air region should equal 1.0
-        np.testing.assert_allclose(transmission.values[:, 6:11, 6:11], 1)
+        # air region should equal 1.0 (rtol consistent with float32 compute precision, issue #147)
+        np.testing.assert_allclose(transmission.values[:, 6:11, 6:11], 1, rtol=1e-5)
         # check all values
         expected_value = np.full((1, 32, 32), (80 - 5) / (100 - 5) * 2)
         expected_value[:, 6:11, 6:11] = (100 - 5) / (100 - 5) * 2  # air region which equals 2
         expected_value /= 2  # air region should be normalized to 1.0
-        np.testing.assert_allclose(transmission.values, expected_value)
+        np.testing.assert_allclose(transmission.values, expected_value, rtol=1e-5)
 
         # check that the variances exist and are reasonable
         expected_variances = np.full((1, 32, 32), 0.0168)
@@ -367,7 +369,7 @@ class TestVenusCCDPipeline:
                 assert hf["transmission"].shape == (5, 32, 32)
                 # No dark subtraction: T = (S / pc_s) / (OB / pc_ob) = (81 + i) / 100 * 2
                 for i in range(5):
-                    np.testing.assert_allclose(hf["transmission"][i], (81 + i) / 100 * 2)
+                    np.testing.assert_allclose(hf["transmission"][i], (81 + i) / 100 * 2, rtol=1e-5)
                 # Uncertainty is present, positive and finite
                 assert "uncertainty" in hf
                 assert np.all(np.isfinite(hf["uncertainty"][:]))
@@ -388,7 +390,7 @@ class TestVenusCCDPipeline:
             )
         assert transmission.shape == (5, 32, 32)
         for i in range(5):
-            np.testing.assert_allclose(transmission.values[i], (81 + i) / 100 * 2)
+            np.testing.assert_allclose(transmission.values[i], (81 + i) / 100 * 2, rtol=1e-5)
 
     def test_venus_ccd_pipeline_requires_output_path(self):
         """output_path is required even though it carries a default for signature compatibility."""
@@ -433,12 +435,17 @@ class TestVenusCCDPipeline:
             normalize_by_runs=True,
         )
         ob = prepare_reference(ob, dim="N_image")
+        # Mirror the pipeline's float32 handling (issue #147): cast the proton-charge
+        # coords to float32 and the result to float32, so this structural check stays
+        # bit-tight against the float32 pipeline output (the independent first-principles
+        # guard is the pinned-constant oracle below, at rtol=1e-3).
         expected = normalize_transmission(
             sample=sample,
             ob=ob,
-            proton_charge_sample=sample.coords["IntegratedPCharge"],
-            proton_charge_ob=ob.coords["IntegratedPCharge"],
-        )
+            proton_charge_sample=sample.coords["IntegratedPCharge"].astype("float32"),
+            proton_charge_ob=ob.coords["IntegratedPCharge"].astype("float32"),
+        ).astype("float32")
+        assert no_dark.dtype == sc.DType.float32
         np.testing.assert_allclose(no_dark.values, expected.values)
         np.testing.assert_allclose(no_dark.variances, expected.variances)
 
@@ -460,4 +467,7 @@ class TestVenusCCDPipeline:
                 output_path=Path(f.name),
                 gamma_filter=False,
             )
+        # The with-dark, proton-charge path is the one that would silently re-promote
+        # to float64 if the pc coord were not cast to float32 (issue #147).
+        assert with_dark.dtype == sc.DType.float32
         assert np.all(no_dark.variances < with_dark.variances)


### PR DESCRIPTION
## Summary

Closes #147 ("No need to produce float64 normalized data. float32 is sufficient.").

The CCD pipelines (`run_mars_ccd_pipeline`, `run_venus_ccd_pipeline`) computed the
entire normalization in **float64** and only downcast to float32 on write, doubling
the in-memory footprint of large image stacks for no benefit — neutron detectors are
16-bit and float32 (~7 significant figures) is more than sufficient. The event/TOF
path was already float32, so this was a CCD-only asymmetry.

Now the CCD path computes and returns **float32** end-to-end, roughly halving peak
memory on large stacks.

## Changes

- **Loaders → float32** — `loaders/tiff_loader.py`, `loaders/fits_loader.py` load
  image data as float32 (variances inherit float32), so the whole CCD path stays float32.
- **VENUS re-promotion fix** — `pipelines/venus_ccd.py` casts the `IntegratedPCharge`
  coords to float32 before `normalize_transmission`. The coord is float64 (parsed via
  `float()`), and scipp promotes `float32 / float64 → float64`, which would otherwise
  silently re-promote VENUS back to float64 at the proton-charge division.
- **Float32 guarantee** — both `venus_ccd.py` and `mars_ccd.py` cast the final
  transmission to float32 before write/return (robust, symmetric, `.astype` converts
  values *and* variances).
- **Docs/CHANGELOG** — `[Unreleased]/Changed` entry + a note in both CCD workflow docs.

## Uncertainty quantification

UQ is unchanged: scipp variances propagate identically, just in float32 — **no term
is added or dropped**. float32 matches float64 to ~7 significant figures in both
transmission **values and variances** (verified empirically and by the pinned-constant
oracles).

## Compatibility

No signature changes. On-disk HDF5/TIFF output was **already** float32, so **file
dtypes are unchanged**; written values may differ from before by up to ~1e-7 (now
computed in float32 rather than rounded from float64).

## Tests

- Loader-contract float32 assertions (values + variances) in `test_tiff_loader.py` /
  `test_fits_loader.py`.
- Pipeline-returns-float32 assertions for VENUS (**with-dark and no-dark** — the
  proton-charge path is the re-promotion case) and MARS.
- The no-dark UQ structural oracle now mirrors the pipeline's float32 handling; the
  independent pinned-constant oracle (rtol=1e-3) remains the first-principles guard.
- Pinned-value transmission assertions now use an explicit `rtol=1e-5` appropriate to
  float32 precision rather than the default 1e-7 (per AGENTS.md).
- Full suite green (363 passed); `pre-commit run --all-files` clean.

## Review

Reviewed with a detection-only **dual-LLM-family** (Claude + Codex) pass scoped to the
diff, with UQ correctness and silent float64 re-promotion as the focus: **0 P0/P1**.
One low-confidence P2 (tighten pre-existing default-tolerance float assertions) was
applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)