### PR TITLE
ci: re-add Codecov coverage reporting (#139)

### DIFF
--- a/.github/workflows/test_and_deploy.yaml
+++ b/.github/workflows/test_and_deploy.yaml
@@ -19,6 +19,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-14] # macos-14 = Apple Silicon (osx-arm64)
+    env:
+      # Scoped to this job so the upload step can gate on the secret's presence
+      # (secrets are withheld on fork PRs); avoids mapping it into other jobs.
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -35,6 +39,17 @@ jobs:
 
       - name: Run unit tests
         run: pixi run test
+
+      # Uploads coverage.xml (produced by --cov-report=xml) to Codecov. Skipped when
+      # CODECOV_TOKEN is absent (e.g. fork PRs, where secrets are withheld) so it does
+      # not emit warnings; fail_ci_if_error=false keeps CI green regardless. See #139.
+      - name: Upload coverage to codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        if: matrix.os == 'ubuntu-latest' && github.actor != 'dependabot[bot]' && env.CODECOV_TOKEN != ''
+        with:
+          token: ${{ env.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          fail_ci_if_error: false
 
   conda-build:
     name: Build conda package

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # NeuNorm 2.0 - Modern Neutron Imaging Normalization
 
 [![PyPI version](https://badge.fury.io/py/NeuNorm.svg)](https://badge.fury.io/py/NeuNorm)
+[![codecov](https://codecov.io/gh/ornlneutronimaging/NeuNorm/branch/next/graph/badge.svg)](https://codecov.io/gh/ornlneutronimaging/NeuNorm)
 [![Documentation Status](https://readthedocs.org/projects/neunorm/badge/?version=latest)](http://neunorm.readthedocs.io/en/latest/?badge=latest)
 [![DOI](https://zenodo.org/badge/97755175.svg)](https://zenodo.org/badge/latestdoi/97755175)
 [![DOI](http://joss.theoj.org/papers/10.21105/joss.00815/status.svg)](https://doi.org/10.21105/joss.00815)

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,8 @@
+# Configuration file for codecov reporting code coverage
+
+coverage:
+  status:
+    project:
+      default:
+        # based on the last build, but allow a drop of up to this percent
+        threshold: 0.5%

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -280,7 +280,7 @@ reset-toml = { cmd = "cp pyproject.toml.bak pyproject.toml; rm pyproject.toml.ba
 ##############
 
 [tool.pytest.ini_options]
-addopts = "-v --cov=neunorm --cov-report=term-missing"
+addopts = "-v --cov=neunorm --cov-report=term-missing --cov-report=xml"
 pythonpath = [".", "src"]
 testpaths = ["tests"]
 python_files = ["test*.py"]


### PR DESCRIPTION
## Summary

Implements #139 — restores the hosted-Codecov plumbing that was dropped in #138 (it had never been activated; the committed token did nothing). Coverage was still measured via `term-missing`; this adds the upload + config + badge back so hosted coverage works once the token is in place.

## Changes

- **`.github/workflows/test_and_deploy.yaml`** — re-add the *Upload coverage to codecov* step to the `tests` job, **SHA-pinned to `codecov/codecov-action` v7.0.0** (`fb8b358…`) per the workspace pin-to-SHA convention, guarded to `ubuntu-latest` and skipped for dependabot. `fail_ci_if_error: false` so CI stays green until the token exists.
- **`pyproject.toml`** — add `--cov-report=xml` so the suite emits `coverage.xml` for the upload; `term-missing` retained for local/CI-log visibility. (`coverage.xml` is already gitignored.)
- **`codecov.yaml`** — restored (project status `threshold: 0.5%`).
- **`README.md`** — re-add the codecov badge (`branch=next`).

## Verified

- Full suite green (363 passed, ~90% coverage); `coverage.xml` is produced (`line-rate 0.904`); both YAML files parse.

## ⚠️ Remaining human steps (cannot be automated)

Uploads will **no-op** (and the badge shows "unknown") until:
1. **Activate** `ornlneutronimaging/NeuNorm` on codecov.io (sign in with the GitHub org).
2. **Add `CODECOV_TOKEN`** as a GitHub Actions secret (repo or org level) — do **not** commit it.

After that, confirm an upload succeeds on a PR and the badge renders (issue #139 step 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)