### PR TITLE
docs: add CITATION.cff and .zenodo.json for Zenodo archiving

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,39 @@
+{
+  "title": "NeuNorm: Neutron imaging normalization and time-of-flight data processing for ORNL facilities",
+  "description": "NeuNorm is a scipp-based Python library for neutron imaging normalization and time-of-flight (TOF) data processing at Oak Ridge National Laboratory imaging facilities (MARS at HFIR and VENUS at SNS). NeuNorm 2.0 is a complete, scipp-based rewrite of the original NeuNorm normalization library, adding HDF5 output, automatic uncertainty propagation, and TOF/event-mode processing.",
+  "upload_type": "software",
+  "access_right": "open",
+  "license": "BSD-3-Clause",
+  "creators": [
+    {
+      "name": "Whitfield, Ross",
+      "affiliation": "Oak Ridge National Laboratory"
+    },
+    {
+      "name": "Bilheux, Jean",
+      "affiliation": "Oak Ridge National Laboratory"
+    },
+    {
+      "name": "Zhang, Chen",
+      "affiliation": "Oak Ridge National Laboratory"
+    }
+  ],
+  "keywords": [
+    "neutron imaging",
+    "normalization",
+    "time-of-flight",
+    "scipp",
+    "MARS",
+    "VENUS",
+    "HFIR",
+    "SNS",
+    "neutron radiography"
+  ],
+  "related_identifiers": [
+    {
+      "identifier": "10.21105/joss.00815",
+      "relation": "isDocumentedBy",
+      "scheme": "doi"
+    }
+  ]
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,42 @@
+# This CITATION.cff describes how to cite the NeuNorm software.
+# The software DOI (minted by Zenodo on the first GitHub Release of this repo)
+# should be added below as `doi:` once the v2.0.0 release is archived.
+# ORCIDs are omitted; add `orcid: "https://orcid.org/0000-0000-0000-0000"` under
+# each author when available.
+cff-version: 1.2.0
+message: "If you use this software, please cite both the software itself and the accompanying paper (Bilheux, 2018)."
+title: "NeuNorm: Neutron imaging normalization and time-of-flight data processing for ORNL facilities"
+type: software
+authors:
+  - family-names: Whitfield
+    given-names: Ross
+    affiliation: "Oak Ridge National Laboratory"
+  - family-names: Bilheux
+    given-names: Jean
+    affiliation: "Oak Ridge National Laboratory"
+  - family-names: Zhang
+    given-names: Chen
+    affiliation: "Oak Ridge National Laboratory"
+repository-code: "https://github.com/ornlneutronimaging/NeuNorm"
+url: "https://neunorm.readthedocs.io"
+license: BSD-3-Clause
+keywords:
+  - neutron imaging
+  - normalization
+  - time-of-flight
+  - scipp
+  - MARS
+  - VENUS
+preferred-citation:
+  type: article
+  title: "NeuNorm: Neutron Imaging Normalization Library"
+  authors:
+    - family-names: Bilheux
+      given-names: Jean
+      affiliation: "Oak Ridge National Laboratory"
+  doi: 10.21105/joss.00815
+  journal: "Journal of Open Source Software"
+  year: 2018
+  volume: 3
+  issue: 29
+  start: 815


### PR DESCRIPTION
## Summary

Prepares correct citation/archival metadata ahead of the **v2.0.0 release**. Zenodo's GitHub integration is now enabled on `ornlneutronimaging/NeuNorm`, but Zenodo only mints a DOI when a GitHub Release is published, and it reads **`.zenodo.json`** from the repo at that moment to populate the archive metadata. Without it, Zenodo auto-guesses (typically a single "author" = the org), so this file must be in place before tagging 2.0.0.

### Context — why this came up
The README's Zenodo badge (`zenodo.org/badge/97755175`) resolves to **`scikit-beam/NeuNorm`** (the project's original 2017 home, DOI `10.5281/zenodo.1414282`) — it archives the *old* repo and won't capture releases from the current repo. The JOSS badge/DOI (`10.21105/joss.00815`, *NeuNorm, Bilheux 2018*) is correct and unchanged.

## Changes
- **`.zenodo.json`** — archive metadata: title, description, `BSD-3-Clause` license, keywords, and creators **Ross Whitfield, Jean Bilheux, Chen Zhang** (all ORNL; order per maintainer), with the JOSS paper linked as a related identifier.
- **`CITATION.cff`** — adds a GitHub "Cite this repository" button and sets the JOSS paper as the preferred citation. Author order matches `.zenodo.json`.

Author names/affiliations were taken from git history. **ORCIDs are intentionally omitted** (not derivable from git) — add under each author when available (the files note exactly where).

## Validation
- `.zenodo.json` parses as JSON; `CITATION.cff` parses (CFF 1.2.0); pre-commit clean.

## Follow-up (post-release, human)
1. Publish the `v2.0.0` GitHub Release → Zenodo mints the DOI.
2. Swap the README Zenodo badge to the new concept DOI (`zenodo.org/badge/DOI/10.5281/zenodo.<id>.svg`) and add the `doi:` to `CITATION.cff`. (Happy to do this once the DOI exists.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)