### PR TITLE
fix: preserve nested HDF5 provenance as round-trippable JSON (#140)

### DIFF
--- a/src/neunorm/exporters/hdf5_writer.py
+++ b/src/neunorm/exporters/hdf5_writer.py
@@ -2,6 +2,7 @@
 HDF5 writer for Neunorm outputs, including provenance metadata.
 """
 
+import json
 import os
 from pathlib import Path
 from typing import Optional, Union
@@ -10,6 +11,74 @@ import h5py
 import numpy as np
 import scipp as sc
 from loguru import logger
+
+
+def _is_nested_sequence(value) -> bool:
+    """Return True if ``value`` is a list/tuple that contains a list/tuple element.
+
+    Nested sequences (e.g. per-run file-path provenance ``[[...], [...]]``) cannot be
+    stored natively by h5py when ragged, so they are JSON-serialized instead (#140).
+    """
+    return isinstance(value, (list, tuple)) and any(isinstance(item, (list, tuple)) for item in value)
+
+
+def _write_json_metadata(f: h5py.File, name: str, value) -> None:
+    """Store ``value`` as a JSON string dataset tagged with ``encoding="json"`` (issue #140).
+
+    Non-string leaves are coerced via ``str()`` (``json`` ``default=str``); the round-trip is
+    therefore lossless only for string-valued data such as the per-run file-path provenance
+    the pipelines emit. May raise (e.g. on a circular reference, or an invalid dataset name);
+    the caller backstops any failure so a single bad key never aborts the write.
+    """
+    ds = f.create_dataset(name, data=json.dumps(value, default=str), dtype=h5py.string_dtype("utf-8"))
+    ds.attrs["encoding"] = "json"
+
+
+def _write_metadata_value(f: h5py.File, name: str, value) -> None:
+    """Write one metadata value, choosing the best HDF5 representation (issue #140).
+
+    Strings, scalars, and flat arrays are stored natively; nested list/tuple provenance is
+    stored as a round-trippable JSON string. May raise; the caller backstops failures so a
+    single un-writable key never aborts the write or corrupts the file.
+    """
+    if isinstance(value, str):
+        f.create_dataset(name, data=value, dtype=h5py.string_dtype("utf-8"))
+    elif _is_nested_sequence(value):
+        _write_json_metadata(f, name, value)
+    else:
+        try:
+            f.create_dataset(name, data=value)
+        except (TypeError, ValueError):
+            # h5py cannot store this value natively; remove the partial dataset it registered
+            # before failing (only a dataset, never a pre-existing group), then JSON-encode it.
+            if name in f and isinstance(f[name], h5py.Dataset):
+                del f[name]
+            _write_json_metadata(f, name, value)
+
+
+def _discard_failed_metadata(f: h5py.File, name: Optional[str], key, exc: Exception, created_here: bool) -> None:
+    """Best-effort cleanup + warning for a metadata key that could not be written (issue #140).
+
+    Never raises: provenance is best-effort and must not abort the bulk-data write. Removes a
+    leftover dataset only when this key's write actually created it (``created_here``) — never a
+    pre-existing dataset or group — so a colliding or duplicate name cannot drop earlier
+    metadata. Logs a pre-formatted string (no live key/exception objects) so a pathological key
+    or exception cannot make logging itself raise.
+    """
+    try:
+        if created_here and name is not None and name in f and isinstance(f[name], h5py.Dataset):
+            del f[name]
+    except Exception:  # noqa: BLE001 - cleanup is best-effort; an h5py name error here must not propagate
+        pass
+    try:
+        detail = f"key {key!r}: {exc}"
+    except Exception:  # noqa: BLE001 - a pathological key/exception repr must not break logging
+        detail = "an un-formattable key or error"
+    logger.warning(
+        "Skipping unwritable metadata in HDF5 output ({}). Array data and other metadata are still "
+        "written. See https://github.com/ornlneutronimaging/NeuNorm/issues/140",
+        detail,
+    )
 
 
 def write_hdf5(  # noqa: C901
@@ -35,6 +104,12 @@ def write_hdf5(  # noqa: C901
         /masks/hot        # (y, x) bool (optional)
         /tof_bin_edges    # (N+1,) float64 (optional)
         /metadata/        # processing provenance
+
+    Metadata values are stored as native datasets (strings, scalars, flat arrays).
+    Nested values such as per-run file-path lists (``sample_paths=[[...], [...]]``) are
+    stored as a JSON string with a ``encoding="json"`` dataset attribute; read them back
+    with ``json.loads(dataset.asstr()[()])``. The round-trip is lossless for string-valued
+    provenance (what the pipelines emit); non-string leaves are coerced via ``str()``.
 
     Metadata contents:
 
@@ -90,34 +165,24 @@ def write_hdf5(  # noqa: C901
         if hot_pixel_mask in transmission.masks:
             f.create_dataset("masks/hot", data=transmission.masks[hot_pixel_mask].values)
 
-        # Write metadata
+        # Write metadata. Provenance is best-effort: a single un-writable key — a bad value
+        # (ragged/unserializable) or a malformed/colliding name — must never abort the write or
+        # leave a corrupt, partially-written file (issue #140). Nested list/tuple values are
+        # serialized as round-trippable JSON (read back with json.loads(dataset.asstr()[()])).
         if metadata:
             for key, value in metadata.items():
-                if isinstance(value, str):
-                    f.create_dataset(f"metadata/{key}", data=value, dtype=h5py.string_dtype(encoding="utf-8"))
-                else:
+                name = None
+                created_here = False
+                try:
                     name = f"metadata/{key}"
-                    try:
-                        f.create_dataset(name, data=value)
-                    except (TypeError, ValueError) as exc:
-                        # h5py cannot store some values — notably a RAGGED nested list, e.g.
-                        # per-run file paths with unequal run sizes (sample_paths=[[...],[...]]).
-                        # Without this guard the error aborts the write *after* the bulk arrays
-                        # are written, leaving a corrupt, partial file. Rectangular nested lists
-                        # still write normally; only genuinely unstorable values are skipped here.
-                        # Note: h5py registers the dataset name before failing on the data, so a
-                        # malformed partial dataset is left behind — delete it before continuing.
-                        # Proper fix (serialize the nested provenance) is tracked in
-                        # https://github.com/ornlneutronimaging/NeuNorm/issues/140
-                        if name in f:
-                            del f[name]
-                        logger.warning(
-                            "Skipping metadata '{}' in HDF5 output: h5py cannot store this value "
-                            "(e.g. a ragged per-run list), which would otherwise abort the write and "
-                            "corrupt the file. Array data and other metadata are still written. "
-                            "See https://github.com/ornlneutronimaging/NeuNorm/issues/140 ({})",
-                            key,
-                            exc,
-                        )
+                    if name in f:
+                        # Two metadata keys collide under str() (e.g. int 1 and str "1" both ->
+                        # "metadata/1"). Keep the first and skip the later one — never overwrite or
+                        # delete the earlier value. `created_here` stays False so cleanup won't touch it.
+                        raise ValueError(f"duplicate metadata path {name!r}")
+                    created_here = True
+                    _write_metadata_value(f, name, value)
+                except Exception as exc:  # noqa: BLE001 - metadata is best-effort; never abort the bulk-data write (#140)
+                    _discard_failed_metadata(f, name, key, exc, created_here)
 
     logger.info("HDF5 file written to {}", output_path)

--- a/tests/unit/test_hdf5_writer.py
+++ b/tests/unit/test_hdf5_writer.py
@@ -2,6 +2,7 @@
 Unit tests for the HDF5 writer module.
 """
 
+import json
 import tempfile
 
 import h5py
@@ -76,13 +77,14 @@ def test_write_hdf5():
             np.testing.assert_equal(f["metadata/software_version"].asstr()[()], "1.0.0")
 
 
-def test_write_hdf5_skips_ragged_nested_metadata():
-    """Ragged list-of-lists metadata (e.g. per-run file paths) must not crash the writer.
+def test_write_hdf5_roundtrips_nested_metadata():
+    """Nested list-of-lists metadata (per-run file paths) round-trips losslessly as JSON.
 
-    Regression for https://github.com/ornlneutronimaging/NeuNorm/issues/140: h5py raises
-    TypeError on a ragged nested list, which previously aborted write_hdf5 *after* the bulk
-    arrays were written, leaving a corrupt partial file. The guard skips such keys with a
-    warning so the array data and scalar metadata still write correctly.
+    Regression for https://github.com/ornlneutronimaging/NeuNorm/issues/140: h5py cannot
+    store a ragged nested list natively, which previously aborted write_hdf5 *after* the
+    bulk arrays were written (a corrupt partial file). Nested provenance is now serialized
+    to a JSON string tagged with the dataset attribute ``encoding="json"`` and read back
+    with ``json.loads`` — handling ragged and rectangular shapes uniformly without loss.
     """
     from neunorm.exporters.hdf5_writer import write_hdf5
 
@@ -97,9 +99,11 @@ def test_write_hdf5_skips_ragged_nested_metadata():
     )
     data.variances = values * 2.0
 
+    ragged = [["s_0001.tiff", "s_0002.tiff"], ["s_0003.tiff"]]  # unequal run sizes (production shape)
+    rectangular = [["ob_0001.tiff", "ob_0002.tiff"], ["ob_0003.tiff", "ob_0004.tiff"]]
     metadata = {
-        # Two runs with UNEQUAL file counts -> ragged nested list (the production shape).
-        "sample_paths": [["s_0001.tiff", "s_0002.tiff"], ["s_0003.tiff"]],
+        "sample_paths": ragged,
+        "ob_paths": rectangular,
         "num_runs_combined": 2,  # a normal scalar that must still be written
     }
 
@@ -111,9 +115,232 @@ def test_write_hdf5_skips_ragged_nested_metadata():
             # The bulk array was written (file is not a corrupt partial).
             assert "transmission" in f
             np.testing.assert_allclose(f["transmission"][:], values)
-            # The ragged nested key was skipped, not written.
-            assert "metadata/sample_paths" not in f
-            # Scalar metadata after it still wrote.
+            # Nested provenance is preserved (not dropped) and round-trips exactly,
+            # for both ragged and rectangular shapes.
+            for key, expected in (("sample_paths", ragged), ("ob_paths", rectangular)):
+                assert f[f"metadata/{key}"].attrs["encoding"] == "json"
+                assert json.loads(f[f"metadata/{key}"].asstr()[()]) == expected
+            # Scalar metadata still wrote.
+            assert "metadata/num_runs_combined" in f
+            np.testing.assert_equal(f["metadata/num_runs_combined"], np.array(2))
+
+
+def _data_3d():
+    values = np.arange(3 * 5 * 5).reshape((3, 5, 5))
+    data = sc.DataArray(
+        data=sc.array(dims=["tof_edges", "x", "y"], values=values, unit="counts", dtype="float64"),
+        coords={
+            "tof_edges": sc.linspace("tof_edges", 1e5, 1e7, num=4, unit="ns"),
+            "y": sc.arange("y", 5, unit=None),
+            "x": sc.arange("x", 5, unit=None),
+        },
+    )
+    data.variances = values * 2.0
+    return data, values
+
+
+def test_write_hdf5_fallback_json_for_non_native_metadata():
+    """A non-nested value h5py cannot store natively (e.g. a dict) falls back to JSON.
+
+    Exercises the defensive fallback path (issue #140): the native create_dataset raises,
+    the partial dataset is removed, and the value is JSON-encoded instead of dropped.
+    """
+    from neunorm.exporters.hdf5_writer import write_hdf5
+
+    data, values = _data_3d()
+    params = {"threshold": 3.0, "mode": "auto"}  # dict: not natively storable, JSON-serializable
+    metadata = {"params": params, "num_runs_combined": 2}
+
+    with tempfile.NamedTemporaryFile(suffix=".h5", delete=True) as f:
+        write_hdf5(f.name, data, metadata=metadata)  # must not raise
+        with h5py.File(f.name, "r") as f:
+            assert "transmission" in f
+            np.testing.assert_allclose(f["transmission"][:], values)
+            assert f["metadata/params"].attrs["encoding"] == "json"
+            assert json.loads(f["metadata/params"].asstr()[()]) == params
+            np.testing.assert_equal(f["metadata/num_runs_combined"], np.array(2))
+
+
+def test_write_hdf5_skips_unserializable_nested_metadata_without_corrupting():
+    """A nested value json.dumps cannot encode is skipped — never aborting the write (#140).
+
+    json.dumps can still raise (e.g. on a circular reference) even with default=str. A
+    self-referential list is nested, so this exercises the *nested-branch* guard: the key is
+    skipped so the bulk arrays and other metadata write intact and the file is not corrupt.
+    """
+    from neunorm.exporters.hdf5_writer import write_hdf5
+
+    data, values = _data_3d()
+    circular = []  # nested (list-containing-list) AND not JSON-serializable
+    circular.append(circular)
+    metadata = {"weird": circular, "num_runs_combined": 2}
+
+    with tempfile.NamedTemporaryFile(suffix=".h5", delete=True) as f:
+        write_hdf5(f.name, data, metadata=metadata)  # must not raise
+        with h5py.File(f.name, "r") as f:
+            # Bulk arrays written; file is not a corrupt partial.
+            assert "transmission" in f
+            np.testing.assert_allclose(f["transmission"][:], values)
+            # The un-encodable key was skipped, not partially written.
+            assert "metadata/weird" not in f
+            # Metadata after the skipped key still wrote.
+            assert "metadata/num_runs_combined" in f
+            np.testing.assert_equal(f["metadata/num_runs_combined"], np.array(2))
+
+
+def test_write_hdf5_skips_unstorable_fallback_metadata_without_corrupting():
+    """The fallback branch skips a value h5py AND json both reject — without corrupting (#140).
+
+    A dict with a tuple key is not natively storable by h5py (TypeError) and not
+    JSON-serializable (json requires str/number keys), so it exercises the native-write
+    fallback's skip-with-warning path, distinct from the nested-branch guard.
+    """
+    from neunorm.exporters.hdf5_writer import write_hdf5
+
+    data, values = _data_3d()
+    metadata = {"weird": {(1, 2): "v"}, "num_runs_combined": 2}  # not nested; h5py- and json-unstorable
+
+    with tempfile.NamedTemporaryFile(suffix=".h5", delete=True) as f:
+        write_hdf5(f.name, data, metadata=metadata)  # must not raise
+        with h5py.File(f.name, "r") as f:
+            assert "transmission" in f
+            np.testing.assert_allclose(f["transmission"][:], values)
+            assert "metadata/weird" not in f
+            assert "metadata/num_runs_combined" in f
+            np.testing.assert_equal(f["metadata/num_runs_combined"], np.array(2))
+
+
+def test_write_hdf5_skips_malformed_key_metadata_without_corrupting():
+    """A malformed metadata key (empty / trailing-slash) is skipped, not fatal (issue #140).
+
+    h5py rejects empty or slash-bearing dataset names with ValueError. That raise happens
+    inside the per-key write *after* the bulk arrays, so the loop's backstop must skip the bad
+    key (cleaning up any partial) and keep writing the rest rather than corrupt the file. This
+    exercises the catch-all that guards the otherwise-unguarded create_dataset name.
+    """
+    from neunorm.exporters.hdf5_writer import write_hdf5
+
+    data, values = _data_3d()
+    metadata = {
+        "valid_before": "ok",  # valid key BEFORE the bad ones must survive (cleanup must not over-delete)
+        "": [["a.tiff"], ["b.tiff"]],  # empty key -> name "metadata/" -> h5py ValueError (nested branch)
+        "runs/": {"threshold": 3.0},  # trailing-slash key -> h5py ValueError (fallback branch)
+        "num_runs_combined": 2,  # valid key after the bad ones must still write
+    }
+
+    with tempfile.NamedTemporaryFile(suffix=".h5", delete=True) as f:
+        write_hdf5(f.name, data, metadata=metadata)  # must not raise
+        with h5py.File(f.name, "r") as f:
+            # Bulk arrays intact; loop continued past the malformed keys.
+            assert "transmission" in f
+            np.testing.assert_allclose(f["transmission"][:], values)
+            # Valid metadata both before AND after the bad keys is preserved.
+            assert f["metadata/valid_before"].asstr()[()] == "ok"
+            assert "metadata/num_runs_combined" in f
+            np.testing.assert_equal(f["metadata/num_runs_combined"], np.array(2))
+
+
+def test_write_hdf5_skips_unformattable_key_metadata_without_corrupting():
+    """A non-string key whose formatting raises is skipped, not fatal (issue #140).
+
+    Name construction (f"metadata/{key}") runs inside the per-key backstop, so even a key
+    object whose __format__/__str__/__repr__ raises is skipped with a warning rather than
+    aborting the write. Realistic provenance dicts never contain such keys; this guards the
+    public write_hdf5 API against the one remaining raise-after-bulk-arrays path.
+    """
+    from neunorm.exporters.hdf5_writer import write_hdf5
+
+    class BadKey:
+        def __str__(self):
+            raise RuntimeError("boom")
+
+        def __repr__(self):
+            raise RuntimeError("boom")
+
+        def __format__(self, spec):
+            raise RuntimeError("boom")
+
+        def __hash__(self):
+            return 1
+
+        def __eq__(self, other):
+            return self is other
+
+    data, values = _data_3d()
+    metadata = {BadKey(): "x", "num_runs_combined": 2}
+
+    with tempfile.NamedTemporaryFile(suffix=".h5", delete=True) as f:
+        write_hdf5(f.name, data, metadata=metadata)  # must not raise
+        with h5py.File(f.name, "r") as f:
+            assert "transmission" in f
+            np.testing.assert_allclose(f["transmission"][:], values)
+            # The valid key after the unformattable one still wrote (loop did not abort).
+            assert "metadata/num_runs_combined" in f
+            np.testing.assert_equal(f["metadata/num_runs_combined"], np.array(2))
+
+
+def test_write_hdf5_colliding_keys_keep_first_without_dropping_earlier():
+    """When two keys collide under str() (e.g. 1 and "1"), the first is kept (issue #140).
+
+    Both int 1 and str "1" map to dataset path "metadata/1". The earlier value must survive and
+    the later colliding key is skipped — cleanup must never delete the earlier valid dataset.
+    """
+    from neunorm.exporters.hdf5_writer import write_hdf5
+
+    data, values = _data_3d()
+    metadata = {1: "first", "1": "second", "after": "ok"}  # 1 and "1" collide -> "metadata/1"
+
+    with tempfile.NamedTemporaryFile(suffix=".h5", delete=True) as f:
+        write_hdf5(f.name, data, metadata=metadata)  # must not raise
+        with h5py.File(f.name, "r") as f:
+            assert "transmission" in f
+            np.testing.assert_allclose(f["transmission"][:], values)
+            # The first value at the colliding path survives (not deleted by the later key).
+            assert f["metadata/1"].asstr()[()] == "first"
+            # Metadata after the collision still wrote.
+            assert f["metadata/after"].asstr()[()] == "ok"
+
+
+def test_write_hdf5_skips_surrogate_key_metadata_without_corrupting():
+    """A string key h5py cannot encode (lone surrogate) is skipped, not fatal (issue #140).
+
+    For a key like "\\udcff", create_dataset raises UnicodeEncodeError, and the `name in f`
+    cleanup lookup would re-raise the same error — so the except-body cleanup must be guarded.
+    The write must complete and later metadata must still be written.
+    """
+    from neunorm.exporters.hdf5_writer import write_hdf5
+
+    data, values = _data_3d()
+    metadata = {"\udcff": "boom", "num_runs_combined": 2}  # lone surrogate key -> h5py UnicodeEncodeError
+
+    with tempfile.NamedTemporaryFile(suffix=".h5", delete=True) as f:
+        write_hdf5(f.name, data, metadata=metadata)  # must not raise
+        with h5py.File(f.name, "r") as f:
+            assert "transmission" in f
+            np.testing.assert_allclose(f["transmission"][:], values)
+            assert "metadata/num_runs_combined" in f
+            np.testing.assert_equal(f["metadata/num_runs_combined"], np.array(2))
+
+
+def test_write_hdf5_skips_unstorable_string_metadata_without_corrupting():
+    """A string h5py cannot store (embedded NUL) is skipped — never aborting the write (#140).
+
+    h5py VLEN strings reject embedded NULs (ValueError) and lone surrogates
+    (UnicodeEncodeError, a ValueError subclass); both raise *after* the bulk arrays are
+    written, so the str branch must skip rather than leave a corrupt partial file.
+    """
+    from neunorm.exporters.hdf5_writer import write_hdf5
+
+    data, values = _data_3d()
+    metadata = {"note": "bad\x00null", "num_runs_combined": 2}  # embedded NUL -> h5py ValueError
+
+    with tempfile.NamedTemporaryFile(suffix=".h5", delete=True) as f:
+        write_hdf5(f.name, data, metadata=metadata)  # must not raise
+        with h5py.File(f.name, "r") as f:
+            assert "transmission" in f
+            np.testing.assert_allclose(f["transmission"][:], values)
+            assert "metadata/note" not in f
+            # Metadata after the skipped key still wrote (no mid-loop abort).
             assert "metadata/num_runs_combined" in f
             np.testing.assert_equal(f["metadata/num_runs_combined"], np.array(2))
 

--- a/tests/unit/test_mars_ccd.py
+++ b/tests/unit/test_mars_ccd.py
@@ -1,3 +1,4 @@
+import json
 import tempfile
 from pathlib import Path
 
@@ -134,13 +135,13 @@ class TestMarsCCDPipeline:
                 # Check masks
                 assert "masks/dead" in hf
                 np.testing.assert_equal(hf["masks/dead"], np.zeros((32, 32), dtype=bool))
-                # Check metadata
+                # Check metadata (nested per-run paths stored as round-trippable JSON, issue #140)
                 assert "metadata/sample_paths" in hf
-                np.testing.assert_equal(hf["metadata/sample_paths"].asstr()[:], [[str(p) for p in self.sample_paths]])
+                assert json.loads(hf["metadata/sample_paths"].asstr()[()]) == [[str(p) for p in self.sample_paths]]
                 assert "metadata/ob_paths" in hf
-                np.testing.assert_equal(hf["metadata/ob_paths"].asstr()[:], [[str(p) for p in self.ob_paths]])
+                assert json.loads(hf["metadata/ob_paths"].asstr()[()]) == [[str(p) for p in self.ob_paths]]
                 assert "metadata/dark_paths" in hf
-                np.testing.assert_equal(hf["metadata/dark_paths"].asstr()[:], [[str(p) for p in self.dark_paths]])
+                assert json.loads(hf["metadata/dark_paths"].asstr()[()]) == [[str(p) for p in self.dark_paths]]
                 assert "metadata/dark_correction_applied" in hf
                 np.testing.assert_equal(hf["metadata/dark_correction_applied"][()], True)
                 assert "metadata/gamma_filter_applied" in hf
@@ -527,13 +528,13 @@ class TestMarsCCDPipelineFITS:
                 # Check masks
                 assert "masks/dead" in hf
                 np.testing.assert_equal(hf["masks/dead"], np.zeros((32, 32), dtype=bool))
-                # Check metadata
+                # Check metadata (nested per-run paths stored as round-trippable JSON, issue #140)
                 assert "metadata/sample_paths" in hf
-                np.testing.assert_equal(hf["metadata/sample_paths"].asstr()[()], [[str(p) for p in self.sample_paths]])
+                assert json.loads(hf["metadata/sample_paths"].asstr()[()]) == [[str(p) for p in self.sample_paths]]
                 assert "metadata/ob_paths" in hf
-                np.testing.assert_equal(hf["metadata/ob_paths"].asstr()[()], [[str(p) for p in self.ob_paths]])
+                assert json.loads(hf["metadata/ob_paths"].asstr()[()]) == [[str(p) for p in self.ob_paths]]
                 assert "metadata/dark_paths" in hf
-                np.testing.assert_equal(hf["metadata/dark_paths"].asstr()[()], [[str(p) for p in self.dark_paths]])
+                assert json.loads(hf["metadata/dark_paths"].asstr()[()]) == [[str(p) for p in self.dark_paths]]
                 assert "metadata/gamma_filter_applied" in hf
                 np.testing.assert_equal(hf["metadata/gamma_filter_applied"][()], True)
                 assert "metadata/processing_timestamp" in hf

--- a/tests/unit/test_mars_tpx3.py
+++ b/tests/unit/test_mars_tpx3.py
@@ -1,3 +1,4 @@
+import json
 import tempfile
 from pathlib import Path
 
@@ -132,11 +133,11 @@ class TestMarsTPX3Pipeline:
                 np.testing.assert_equal(hf["masks/dead"], np.zeros((32, 32), dtype=bool))
                 assert "masks/hot" in hf
                 np.testing.assert_equal(hf["masks/hot"], np.zeros((32, 32), dtype=bool))
-                # Check metadata
+                # Check metadata (nested per-run paths stored as round-trippable JSON, issue #140)
                 assert "metadata/sample_paths" in hf
-                np.testing.assert_equal(hf["metadata/sample_paths"].asstr()[:], [[str(p) for p in self.sample_paths]])
+                assert json.loads(hf["metadata/sample_paths"].asstr()[()]) == [[str(p) for p in self.sample_paths]]
                 assert "metadata/ob_paths" in hf
-                np.testing.assert_equal(hf["metadata/ob_paths"].asstr()[:], [[str(p) for p in self.ob_paths]])
+                assert json.loads(hf["metadata/ob_paths"].asstr()[()]) == [[str(p) for p in self.ob_paths]]
                 assert "metadata/gamma_filter_applied" in hf
                 np.testing.assert_equal(hf["metadata/gamma_filter_applied"][()], True)
                 assert "metadata/processing_timestamp" in hf

--- a/tests/unit/test_venus_ccd.py
+++ b/tests/unit/test_venus_ccd.py
@@ -1,3 +1,4 @@
+import json
 import tempfile
 from pathlib import Path
 
@@ -139,13 +140,13 @@ class TestVenusCCDPipeline:
                 # Check masks
                 assert "masks/dead" in hf
                 np.testing.assert_equal(hf["masks/dead"], np.zeros((32, 32), dtype=bool))
-                # Check metadata
+                # Check metadata (nested per-run paths stored as round-trippable JSON, issue #140)
                 assert "metadata/sample_paths" in hf
-                np.testing.assert_equal(hf["metadata/sample_paths"].asstr()[:], [[str(p) for p in self.sample_paths]])
+                assert json.loads(hf["metadata/sample_paths"].asstr()[()]) == [[str(p) for p in self.sample_paths]]
                 assert "metadata/ob_paths" in hf
-                np.testing.assert_equal(hf["metadata/ob_paths"].asstr()[:], [[str(p) for p in self.ob_paths]])
+                assert json.loads(hf["metadata/ob_paths"].asstr()[()]) == [[str(p) for p in self.ob_paths]]
                 assert "metadata/dark_paths" in hf
-                np.testing.assert_equal(hf["metadata/dark_paths"].asstr()[:], [[str(p) for p in self.dark_paths]])
+                assert json.loads(hf["metadata/dark_paths"].asstr()[()]) == [[str(p) for p in self.dark_paths]]
                 assert "metadata/dark_correction_applied" in hf
                 np.testing.assert_equal(hf["metadata/dark_correction_applied"][()], True)
                 assert "metadata/gamma_filter_applied" in hf


### PR DESCRIPTION
## Summary

Closes #140. `write_hdf5` previously **crashed and left a corrupt partial file** on ragged nested metadata; the stopgap (PR #143) avoided the crash by *dropping* those keys — so per-run file-path provenance (`sample_paths`/`ob_paths`/`dark_paths`) was **silently lost** from the primary HDF5 output whenever runs had unequal file counts (the normal multi-run reduction). This is the proper fix.

## Changes

- **Nested provenance → round-trippable JSON.** Nested list-of-lists metadata is serialized to a JSON string tagged with a `encoding="json"` dataset attribute (read back via `json.loads(ds.asstr()[()])`). Ragged **and** rectangular shapes are handled uniformly — lossless for the string provenance the pipelines emit. Flat lists, scalars, and strings remain native datasets.
- **Per-key best-effort backstop.** Each metadata key is written inside a guard: a colliding dataset path (two keys equal under `str()`) is detected up front and the later key skipped (the earlier value is never overwritten/deleted); on any failure, `_discard_failed_metadata` removes only a dataset *this key created* (never a pre-existing dataset or group) and logs a pre-formatted message. The helper is provably non-raising, so **no metadata key can abort the write or corrupt the file** — the scientific payload (transmission/uncertainty/masks) is always written.
- **On-disk format:** the *only* representation change is nested path lists moving from native 2D string arrays → JSON strings (documented in the `write_hdf5` docstring). All other keys are unchanged.

The three pipelines emitting nested per-run paths (`mars_ccd`, `venus_ccd`, `mars_tpx3`) now round-trip their provenance; `venus_tpx3_event` uses flat lists and is unchanged.

## Tests

Lossless nested round-trip (ragged + rectangular); dict → JSON fallback; skip-without-corruption for unserializable-nested, unstorable-fallback, unstorable-string, malformed key (earlier metadata survives), surrogate key, unformattable non-string key, and colliding keys (first kept); CCD + `mars_tpx3` assertions updated to `json.loads`. Full suite green (**371 passed**, ~90% cov); pre-commit clean.

## Review

Hardened across **seven** detection-only dual-LLM-family (Claude + Codex) review rounds. Round 1 caught the reachable bug; rounds 2–6 progressively closed unreachable adversarial-input edges (and corrected two over-stated invariants in the process); the terminal round 7 converged **clean — 0 P0/P1, both families "safe to ship"**, with no pipeline-reachable or bulk-data-affecting defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)