### PR TITLE
fix: apply detector_time_offset + configurable flight path in event E/λ binning (#141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   arrays were written (corrupt partial file); the interim guard avoided the crash by
   silently **dropping** that provenance. Flat lists, scalars, and strings are
   unchanged. ([#140](https://github.com/ornlneutronimaging/NeuNorm/issues/140))
+- **Event-pipeline energy/wavelength binning now applies the detector time offset and a
+  configurable flight path.** When `run_venus_tpx3_event_pipeline` histograms directly in
+  `bin_space='energy'`/`'wavelength'`, the energy/wavelength bin edges are now built in raw
+  detector-TOF space (applying `detector_time_offset`, the exact inverse of the coordinate
+  labeling), so events land in the correct bins instead of being shifted by the offset. The
+  flight path is now a single configurable `flight_path` parameter (default
+  `VENUS_FLIGHT_PATH_M`) used for both binning and labeling, replacing the hardcoded 25 m
+  literals. The public `get_energy_histogram` / `get_wavelength_histogram` helpers gained an
+  `offset` argument so they label consistently with offset-aware bins, and the
+  `run_venus_tpx1_pipeline` / `run_venus_tpx3_histogram_pipeline` pipelines also take a
+  configurable `flight_path`. The default bin-in-TOF path is unaffected.
+  ([#141](https://github.com/ornlneutronimaging/NeuNorm/issues/141))
 
 ## [2.0.0] - 2026-06-09
 

--- a/src/neunorm/pipelines/venus_tpx1.py
+++ b/src/neunorm/pipelines/venus_tpx1.py
@@ -24,6 +24,7 @@ from neunorm.tof.coordinate_converter import convert_tof_to_energy, convert_tof_
 from neunorm.tof.histogram_rebinner import rebin_tof
 from neunorm.tof.pixel_detector import detect_dead_pixels
 from neunorm.tof.statistics_analyzer import analyze_statistics
+from neunorm.utils.constants import VENUS_FLIGHT_PATH_M
 
 
 def run_venus_tpx1_pipeline(  # noqa: C901
@@ -36,6 +37,7 @@ def run_venus_tpx1_pipeline(  # noqa: C901
     air_roi: Optional[tuple] = None,
     rebin_by_tof: Optional[bool | int] = False,
     rebin_by_spatial: Optional[int | tuple[int, int]] = None,
+    flight_path: sc.Variable = sc.scalar(VENUS_FLIGHT_PATH_M, unit="m"),
 ) -> sc.DataArray:
     """Execute VENUS TPX1 normalization pipeline.
 
@@ -80,6 +82,9 @@ def run_venus_tpx1_pipeline(  # noqa: C901
     rebin_by_spatial : Optional[int]
         Whether to apply spatial rebinning. If an integer is provided, it will be used as the
         rebinning factor. If None, no spatial rebinning is applied.
+    flight_path : sc.Variable
+        Source-to-detector flight path used for TOF→energy/wavelength coordinate labeling.
+        Defaults to ``VENUS_FLIGHT_PATH_M`` (25 m); set it per detector/sample position.
 
     Notes
     -----
@@ -195,13 +200,14 @@ def run_venus_tpx1_pipeline(  # noqa: C901
     if air_roi is not None:
         transmission = apply_air_region_correction(transmission, air_roi)
 
-    # Add wavelength and energy coordinates converted from TOF using the detector distance
-    # and time offset from the metadata
+    # Add wavelength and energy coordinates converted from TOF using the configurable flight
+    # path and the time offset from the metadata (issue #141).
     if "detector_time_offset" in sample.coords:
-        distance = sc.scalar(25.0, unit="m")  # distance for VENUS
         time_offset = sample.coords["detector_time_offset"]
-        transmission.coords["wavelength"] = convert_tof_to_wavelength(transmission.coords["tof"], distance, time_offset)
-        transmission.coords["energy"] = convert_tof_to_energy(transmission.coords["tof"], distance, time_offset)
+        transmission.coords["wavelength"] = convert_tof_to_wavelength(
+            transmission.coords["tof"], flight_path, time_offset
+        )
+        transmission.coords["energy"] = convert_tof_to_energy(transmission.coords["tof"], flight_path, time_offset)
     else:
         logger.warning("Time offset not found in metadata. Cannot add wavelength and energy coordinates.")
 

--- a/src/neunorm/pipelines/venus_tpx3_event.py
+++ b/src/neunorm/pipelines/venus_tpx3_event.py
@@ -26,6 +26,7 @@ from neunorm.tof.event_converter import convert_events_to_histogram
 from neunorm.tof.histogram_rebinner import rebin_tof
 from neunorm.tof.pixel_detector import detect_dead_pixels, detect_hot_pixels
 from neunorm.tof.statistics_analyzer import analyze_statistics
+from neunorm.utils.constants import VENUS_FLIGHT_PATH_M
 
 
 def run_venus_tpx3_event_pipeline(  # noqa: C901
@@ -40,6 +41,7 @@ def run_venus_tpx3_event_pipeline(  # noqa: C901
     detector_shape: tuple[int, int] = (514, 514),
     event_id_offset: int = 1_000_000,
     bank_name: str = "bank100",
+    flight_path: sc.Variable = sc.scalar(VENUS_FLIGHT_PATH_M, unit="m"),
 ) -> sc.DataArray:
     """Execute VENUS TPX3 event normalization pipeline.
 
@@ -86,6 +88,10 @@ def run_venus_tpx3_event_pipeline(  # noqa: C901
         This accounts for any non-zero starting point in the event_ids.
     bank_name : str
         Name of the detector bank in the NeXus file to load (default: "bank100")
+    flight_path : sc.Variable
+        Source-to-detector flight path used for both energy/wavelength binning and the
+        TOF→energy/wavelength coordinate labeling. Defaults to ``VENUS_FLIGHT_PATH_M`` (25 m);
+        set it per detector/sample position (the VENUS L2 varies ~24.5–25.5 m).
 
     Notes
     -----
@@ -98,13 +104,14 @@ def run_venus_tpx3_event_pipeline(  # noqa: C901
         Final normalized transmission DataArray with metadata and masks
     """
 
-    flight_path = sc.scalar(25.0, unit="m")  # Example flight path for energy/wavelength binning
     x_bins, y_bins = detector_shape
 
-    # Load data, metadata and convert to histogram
+    # Load metadata before histogramming so the detector time offset can be applied to
+    # energy/wavelength bin edges (issue #141); a missing offset defaults to zero.
     samples = []
-
     for run in sample_paths:
+        metadata = load_metadata(run)
+        time_offset = metadata.get("detector_time_offset", sc.scalar(0.0, unit="us"))
         sample = convert_events_to_histogram(
             load_event_nexus(
                 run, detector_bank=bank_name, detector_shape=detector_shape, event_id_offset=event_id_offset
@@ -113,8 +120,8 @@ def run_venus_tpx3_event_pipeline(  # noqa: C901
             flight_path,
             x_bins,
             y_bins,
+            detector_time_offset=time_offset,
         )
-        metadata = load_metadata(run)
         for key, value in metadata.items():
             sample.coords[key] = value
             sample.coords.set_aligned(key, False)
@@ -122,6 +129,8 @@ def run_venus_tpx3_event_pipeline(  # noqa: C901
 
     obs = []
     for run in ob_paths:
+        metadata = load_metadata(run)
+        time_offset = metadata.get("detector_time_offset", sc.scalar(0.0, unit="us"))
         ob = convert_events_to_histogram(
             load_event_nexus(
                 run, detector_bank=bank_name, detector_shape=detector_shape, event_id_offset=event_id_offset
@@ -130,8 +139,8 @@ def run_venus_tpx3_event_pipeline(  # noqa: C901
             flight_path,
             x_bins,
             y_bins,
+            detector_time_offset=time_offset,
         )
-        metadata = load_metadata(run)
         for key, value in metadata.items():
             ob.coords[key] = value
             ob.coords.set_aligned(key, False)
@@ -198,13 +207,14 @@ def run_venus_tpx3_event_pipeline(  # noqa: C901
     if air_roi is not None:
         transmission = apply_air_region_correction(transmission, air_roi)
 
-    # Add wavelength and energy coordinates converted from TOF using the detector distance
-    # and time offset from the metadata
+    # Add wavelength and energy coordinates converted from TOF using the same flight path as
+    # the binning step and the time offset from the metadata (issue #141).
     if "detector_time_offset" in sample.coords:
-        distance = sc.scalar(25.0, unit="m")  # distance for VENUS
         time_offset = sample.coords["detector_time_offset"]
-        transmission.coords["wavelength"] = convert_tof_to_wavelength(transmission.coords["tof"], distance, time_offset)
-        transmission.coords["energy"] = convert_tof_to_energy(transmission.coords["tof"], distance, time_offset)
+        transmission.coords["wavelength"] = convert_tof_to_wavelength(
+            transmission.coords["tof"], flight_path, time_offset
+        )
+        transmission.coords["energy"] = convert_tof_to_energy(transmission.coords["tof"], flight_path, time_offset)
     else:
         logger.warning("Time offset not found in metadata. Cannot add wavelength and energy coordinates.")
 

--- a/src/neunorm/pipelines/venus_tpx3_histogram.py
+++ b/src/neunorm/pipelines/venus_tpx3_histogram.py
@@ -24,6 +24,7 @@ from neunorm.tof.coordinate_converter import convert_tof_to_energy, convert_tof_
 from neunorm.tof.histogram_rebinner import rebin_tof
 from neunorm.tof.pixel_detector import detect_dead_pixels, detect_hot_pixels
 from neunorm.tof.statistics_analyzer import analyze_statistics
+from neunorm.utils.constants import VENUS_FLIGHT_PATH_M
 
 
 def run_venus_tpx3_histogram_pipeline(  # noqa: C901
@@ -36,6 +37,7 @@ def run_venus_tpx3_histogram_pipeline(  # noqa: C901
     air_roi: Optional[tuple] = None,
     rebin_by_tof: Optional[bool | int] = False,
     rebin_by_spatial: Optional[int | tuple[int, int]] = None,
+    flight_path: sc.Variable = sc.scalar(VENUS_FLIGHT_PATH_M, unit="m"),
 ) -> sc.DataArray:
     """Execute VENUS TPX3 histogram normalization pipeline.
 
@@ -81,6 +83,9 @@ def run_venus_tpx3_histogram_pipeline(  # noqa: C901
     rebin_by_spatial : Optional[int]
         Whether to apply spatial rebinning. If an integer is provided, it will be used as the
         rebinning factor. If None, no spatial rebinning is applied.
+    flight_path : sc.Variable
+        Source-to-detector flight path used for TOF→energy/wavelength coordinate labeling.
+        Defaults to ``VENUS_FLIGHT_PATH_M`` (25 m); set it per detector/sample position.
 
     Notes
     -----
@@ -218,13 +223,14 @@ def run_venus_tpx3_histogram_pipeline(  # noqa: C901
     if air_roi is not None:
         transmission = apply_air_region_correction(transmission, air_roi)
 
-    # Add wavelength and energy coordinates converted from TOF using the detector distance
-    # and time offset from the metadata
+    # Add wavelength and energy coordinates converted from TOF using the configurable flight
+    # path and the time offset from the metadata (issue #141).
     if "detector_time_offset" in sample.coords:
-        distance = sc.scalar(25.0, unit="m")  # distance for VENUS
         time_offset = sample.coords["detector_time_offset"]
-        transmission.coords["wavelength"] = convert_tof_to_wavelength(transmission.coords["tof"], distance, time_offset)
-        transmission.coords["energy"] = convert_tof_to_energy(transmission.coords["tof"], distance, time_offset)
+        transmission.coords["wavelength"] = convert_tof_to_wavelength(
+            transmission.coords["tof"], flight_path, time_offset
+        )
+        transmission.coords["energy"] = convert_tof_to_energy(transmission.coords["tof"], flight_path, time_offset)
     else:
         logger.warning("Time offset not found in metadata. Cannot add wavelength and energy coordinates.")
 

--- a/src/neunorm/tof/binning.py
+++ b/src/neunorm/tof/binning.py
@@ -15,6 +15,12 @@ import scipp as sc
 import scipp.constants as sc_const
 
 from neunorm.data_models.tof import BinningConfig
+from neunorm.tof.coordinate_converter import (
+    convert_energy_to_tof,
+    convert_tof_to_energy,
+    convert_tof_to_wavelength,
+    convert_wavelength_to_tof,
+)
 
 
 def tof_to_energy(tof: sc.Variable, flight_path: sc.Variable) -> sc.Variable:
@@ -195,7 +201,11 @@ def energy_to_wavelength(energy: sc.Variable) -> sc.Variable:
     return wavelength_angstrom
 
 
-def create_tof_bins(config: BinningConfig, flight_path: Optional[sc.Variable] = None) -> sc.Variable:
+def create_tof_bins(
+    config: BinningConfig,
+    flight_path: Optional[sc.Variable] = None,
+    offset: sc.Variable = sc.scalar(0, unit="us"),
+) -> sc.Variable:
     """
     Create TOF bin edges from binning configuration.
 
@@ -210,6 +220,10 @@ def create_tof_bins(config: BinningConfig, flight_path: Optional[sc.Variable] = 
         Binning configuration specifying domain and range
     flight_path : sc.Variable, optional
         Flight path in meters. Required for energy/wavelength modes.
+    offset : sc.Variable, optional
+        Detector time offset (e.g. TIDelay) applied so energy/wavelength bin edges live in
+        raw detector-TOF space — matching the raw event TOF that is histogrammed into them
+        and the later coordinate labeling (issue #141). Default: 0 us. Ignored for 'tof' mode.
 
     Returns
     -------
@@ -226,12 +240,12 @@ def create_tof_bins(config: BinningConfig, flight_path: Optional[sc.Variable] = 
     if config.bin_space == "energy":
         if flight_path is None:
             raise ValueError("flight_path required for energy binning")
-        return _energy_bins_to_tof(config, flight_path)
+        return _energy_bins_to_tof(config, flight_path, offset)
 
     elif config.bin_space == "wavelength":
         if flight_path is None:
             raise ValueError("flight_path required for wavelength binning")
-        return _wavelength_bins_to_tof(config, flight_path)
+        return _wavelength_bins_to_tof(config, flight_path, offset)
 
     elif config.bin_space == "tof":
         return _create_tof_bins_direct(config)
@@ -240,8 +254,15 @@ def create_tof_bins(config: BinningConfig, flight_path: Optional[sc.Variable] = 
         raise ValueError(f"Invalid bin_space: {config.bin_space}")
 
 
-def _energy_bins_to_tof(config: BinningConfig, flight_path: sc.Variable) -> sc.Variable:
-    """Create energy bins and convert to TOF bins (reversed)"""
+def _energy_bins_to_tof(
+    config: BinningConfig, flight_path: sc.Variable, offset: sc.Variable = sc.scalar(0, unit="us")
+) -> sc.Variable:
+    """Create energy bins and convert to raw detector-TOF bins (reversed).
+
+    Uses ``convert_energy_to_tof`` — the exact inverse of the labeling conversion — so the
+    edges live in raw detector-TOF space (``t = L*sqrt(m_n/(2E)) - offset``) and match the
+    raw event TOF histogrammed into them (issue #141).
+    """
     emin, emax = config.energy_range
 
     # Create energy bins
@@ -250,11 +271,7 @@ def _energy_bins_to_tof(config: BinningConfig, flight_path: sc.Variable) -> sc.V
     else:
         energy_bins = sc.linspace("energy", emin, emax, num=config.bins + 1, unit="eV")
 
-    # Convert to TOF: t = L * sqrt(m_n / (2*E))
-    energy_j = energy_bins.to(unit="J", copy=False)
-    velocity = sc.sqrt(2.0 * energy_j / sc_const.m_n)
-    tof_s = flight_path / velocity
-    tof_ns = tof_s.to(unit="ns")
+    tof_ns = sc.to_unit(convert_energy_to_tof(energy_bins, flight_path, offset), "ns")
 
     # Reverse: high energy = low TOF
     tof_bins_reversed = sc.array(dims=["tof"], values=tof_ns.values[::-1].copy(), unit="ns")
@@ -262,8 +279,15 @@ def _energy_bins_to_tof(config: BinningConfig, flight_path: sc.Variable) -> sc.V
     return tof_bins_reversed
 
 
-def _wavelength_bins_to_tof(config: BinningConfig, flight_path: sc.Variable) -> sc.Variable:
-    """Create wavelength bins and convert to TOF bins (ascending)"""
+def _wavelength_bins_to_tof(
+    config: BinningConfig, flight_path: sc.Variable, offset: sc.Variable = sc.scalar(0, unit="us")
+) -> sc.Variable:
+    """Create wavelength bins and convert to raw detector-TOF bins (ascending).
+
+    Uses ``convert_wavelength_to_tof`` — the exact inverse of the labeling conversion — so the
+    edges live in raw detector-TOF space (``t = λ*m_n*L/h - offset``) and match the raw event
+    TOF histogrammed into them (issue #141).
+    """
     wl_min, wl_max = config.wavelength_range
 
     # Create wavelength bins
@@ -272,10 +296,7 @@ def _wavelength_bins_to_tof(config: BinningConfig, flight_path: sc.Variable) -> 
     else:
         wl_bins = sc.linspace("wavelength", wl_min, wl_max, num=config.bins + 1, unit="angstrom")
 
-    # Convert to TOF: t = λ * m_n * L / h
-    tof_s = wl_bins.to(unit="m") * sc_const.m_n * flight_path / sc_const.h
-
-    tof_ns = tof_s.to(unit="ns")
+    tof_ns = sc.to_unit(convert_wavelength_to_tof(wl_bins, flight_path, offset), "ns")
 
     # NO reversal: low wavelength = low TOF (both ascending)
     return tof_ns.rename_dims({"wavelength": "tof"})
@@ -305,7 +326,9 @@ def _create_tof_bins_direct(config: BinningConfig) -> sc.Variable:
     return tof_bins
 
 
-def get_energy_histogram(hist_tof: sc.DataArray, flight_path: sc.Variable) -> sc.DataArray:
+def get_energy_histogram(
+    hist_tof: sc.DataArray, flight_path: sc.Variable, offset: sc.Variable = sc.scalar(0, unit="us")
+) -> sc.DataArray:
     """
     Convert TOF histogram to energy histogram.
 
@@ -318,6 +341,10 @@ def get_energy_histogram(hist_tof: sc.DataArray, flight_path: sc.Variable) -> sc
         Histogram with 'tof' dimension
     flight_path : sc.Variable
         Flight path in meters
+    offset : sc.Variable
+        Detector time offset (e.g. TIDelay) applied during TOF→energy labeling so it matches
+        offset-aware bin edges (issue #141). Default: 0 us. Pass the same offset used to build
+        the histogram's energy bins.
 
     Returns
     -------
@@ -328,9 +355,9 @@ def get_energy_histogram(hist_tof: sc.DataArray, flight_path: sc.Variable) -> sc
     -----
     Preserves variance if present. Both data and variance are reversed.
     """
-    # Convert TOF edges to energy
+    # Convert TOF edges to energy (offset-aware, the same inverse as the bin construction).
     tof_edges = hist_tof.coords["tof"]
-    energy_edges = tof_to_energy(tof_edges, flight_path)
+    energy_edges = sc.to_unit(convert_tof_to_energy(tof_edges, flight_path, offset), "eV")
 
     # Reverse data along TOF dimension (high TOF = low energy)
     hist_reversed = hist_tof.copy()
@@ -359,7 +386,9 @@ def get_energy_histogram(hist_tof: sc.DataArray, flight_path: sc.Variable) -> sc
     return hist_energy
 
 
-def get_wavelength_histogram(hist_tof: sc.DataArray, flight_path: sc.Variable) -> sc.DataArray:
+def get_wavelength_histogram(
+    hist_tof: sc.DataArray, flight_path: sc.Variable, offset: sc.Variable = sc.scalar(0, unit="us")
+) -> sc.DataArray:
     """
     Convert TOF histogram to wavelength histogram.
 
@@ -372,6 +401,10 @@ def get_wavelength_histogram(hist_tof: sc.DataArray, flight_path: sc.Variable) -
         Histogram with 'tof' dimension
     flight_path : sc.Variable
         Flight path in meters
+    offset : sc.Variable
+        Detector time offset (e.g. TIDelay) applied during TOF→wavelength labeling so it matches
+        offset-aware bin edges (issue #141). Default: 0 us. Pass the same offset used to build
+        the histogram's wavelength bins.
 
     Returns
     -------
@@ -382,9 +415,9 @@ def get_wavelength_histogram(hist_tof: sc.DataArray, flight_path: sc.Variable) -
     -----
     Preserves variance if present. No data reversal (unlike energy conversion).
     """
-    # Convert TOF edges to wavelength
+    # Convert TOF edges to wavelength (offset-aware, the same inverse as the bin construction).
     tof_edges = hist_tof.coords["tof"]
-    wavelength_edges = tof_to_wavelength(tof_edges, flight_path)
+    wavelength_edges = sc.to_unit(convert_tof_to_wavelength(tof_edges, flight_path, offset), "angstrom")
 
     # Copy histogram (no reversal needed)
     hist_wavelength = hist_tof.copy()

--- a/src/neunorm/tof/coordinate_converter.py
+++ b/src/neunorm/tof/coordinate_converter.py
@@ -84,3 +84,30 @@ def convert_tof_to_energy(
     velocity = distance / (tof + sc.to_unit(offset, tof.unit))
     energy_joules = 0.5 * sc.constants.m_n * velocity**2
     return sc.to_unit(energy_joules, "meV")
+
+
+def convert_energy_to_tof(
+    energy: sc.Variable, distance: sc.Variable, offset: sc.Variable = sc.scalar(0, unit="us")
+) -> sc.Variable:
+    """Convert energy data to time-of-flight (TOF).
+
+    Energy → TOF (the exact inverse of :func:`convert_tof_to_energy`):
+    TOF = L / sqrt(2E / m_n) − offset
+
+    Parameters
+    ----------
+    energy : sc.Variable
+        Variable containing energy values with appropriate units (e.g., meV or eV).
+    distance : sc.Variable
+        Variable representing the distance from the source to the detector, with appropriate units (e.g., meters).
+    offset : sc.Variable
+        Variable representing the time offset, with appropriate units (e.g., microseconds).
+
+    Returns
+    -------
+    sc.Variable
+        Variable containing TOF values corresponding to the input energy data, in units matching the offset unit.
+    """
+
+    velocity = sc.sqrt(2.0 * sc.to_unit(energy, "J") / sc.constants.m_n)
+    return sc.to_unit(distance / velocity, offset.unit) - offset

--- a/src/neunorm/tof/event_converter.py
+++ b/src/neunorm/tof/event_converter.py
@@ -23,6 +23,7 @@ def convert_events_to_histogram(
     y_bins: int = 514,
     chunk_size: int = 500_000_000,
     compute_variance: bool = True,
+    detector_time_offset: sc.Variable = sc.scalar(0, unit="us"),
 ) -> sc.DataArray:
     """
     Convert event-mode data to 3D TOF histogram.
@@ -47,6 +48,10 @@ def convert_events_to_histogram(
         Larger = faster but more memory
     compute_variance : bool, optional
         Attach Poisson variance (var = counts). Default: True
+    detector_time_offset : sc.Variable, optional
+        Detector time offset (e.g. TIDelay) applied when building energy/wavelength bin edges
+        so they live in raw detector-TOF space, matching the raw event TOF histogrammed into
+        them (issue #141). Default: 0 us. Has no effect for ``bin_space='tof'``.
 
     Returns
     -------
@@ -69,8 +74,9 @@ def convert_events_to_histogram(
     logger.info(f"  TOF bins: {binning.bins}, Spatial: {x_bins}×{y_bins}")
     logger.info(f"  Bin space: {binning.bin_space}, Log: {binning.use_log_bin}")
 
-    # Create TOF bin edges
-    tof_bins = create_tof_bins(binning, flight_path)
+    # Create TOF bin edges (raw detector-TOF; detector_time_offset shifts energy/wavelength
+    # edges so binning agrees with the later coordinate labeling — issue #141).
+    tof_bins = create_tof_bins(binning, flight_path, detector_time_offset)
     logger.info(f"  TOF range: {tof_bins.values.min():.1f} - {tof_bins.values.max():.1f} ns")
 
     # Create spatial bin edges (explicit to ensure consistency across chunks)

--- a/tests/unit/test_binning_conversions.py
+++ b/tests/unit/test_binning_conversions.py
@@ -369,3 +369,135 @@ def test_wavelength_energy_de_broglie_constant():
         # Should match: E = DE_BROGLIE_EV_ANGSQ / λ²
         expected_ev = DE_BROGLIE_EV_ANGSQ / (wl_val**2)
         assert abs(energy.value - expected_ev) / expected_ev < 1e-6
+
+
+# --- issue #141: energy/wavelength binning must apply detector_time_offset ---
+
+
+def test_convert_energy_to_tof_is_inverse_of_tof_to_energy():
+    """convert_energy_to_tof is the exact inverse of convert_tof_to_energy, offset included.
+
+    This is what makes the energy bin edges consistent with the coordinate labeling (#141).
+    """
+    from neunorm.tof.coordinate_converter import (
+        convert_energy_to_tof,
+        convert_tof_to_energy,
+        convert_tof_to_wavelength,
+        convert_wavelength_to_tof,
+    )
+
+    flight_path = sc.scalar(25.0, unit="m")
+    offset = sc.scalar(5.0, unit="us")
+
+    energy = sc.array(dims=["energy"], values=[1.0, 10.0, 100.0], unit="eV")
+    energy_rt = convert_tof_to_energy(convert_energy_to_tof(energy, flight_path, offset), flight_path, offset)
+    np.testing.assert_allclose(sc.to_unit(energy_rt, "eV").values, [1.0, 10.0, 100.0], rtol=1e-9)
+
+    wl = sc.array(dims=["wavelength"], values=[0.5, 1.8, 5.0], unit="angstrom")
+    wl_rt = convert_tof_to_wavelength(convert_wavelength_to_tof(wl, flight_path, offset), flight_path, offset)
+    np.testing.assert_allclose(sc.to_unit(wl_rt, "angstrom").values, [0.5, 1.8, 5.0], rtol=1e-9)
+
+
+def test_create_tof_bins_offset_shifts_edges_into_raw_space():
+    """A non-zero detector_time_offset shifts the energy/wavelength TOF edges by exactly -offset.
+
+    Regression for #141: the bin edges must live in raw detector-TOF space so they match the
+    raw event TOF histogrammed into them; offset=0 reproduces the old physical-TOF edges.
+    """
+    from neunorm.data_models.tof import BinningConfig
+    from neunorm.tof.binning import create_tof_bins
+
+    flight_path = sc.scalar(25.0, unit="m")
+    offset = sc.scalar(5.0, unit="us")  # 5000 ns
+
+    e_cfg = BinningConfig(bins=100, bin_space="energy", energy_range=(1.0, 100.0), use_log_bin=True)
+    e0 = sc.to_unit(create_tof_bins(e_cfg, flight_path), "ns").values
+    e_off = sc.to_unit(create_tof_bins(e_cfg, flight_path, offset), "ns").values
+    np.testing.assert_allclose(e_off, e0 - 5000.0, rtol=1e-9)
+
+    w_cfg = BinningConfig(bins=100, bin_space="wavelength", wavelength_range=(0.5, 5.0), use_log_bin=False)
+    w0 = sc.to_unit(create_tof_bins(w_cfg, flight_path), "ns").values
+    w_off = sc.to_unit(create_tof_bins(w_cfg, flight_path, offset), "ns").values
+    np.testing.assert_allclose(w_off, w0 - 5000.0, rtol=1e-9)
+
+
+def test_event_energy_binning_places_events_by_raw_tof_with_offset():
+    """Events histogrammed in energy space land in the bin bracketing their RAW TOF (#141).
+
+    With the offset applied, the energy bin edges are in raw detector-TOF space, so a peak at
+    a known raw TOF falls in the bin whose raw-TOF edges bracket it — consistent with the
+    later coordinate labeling. Without the offset (the old behavior) the edges are shifted, so
+    the peak lands in a different bin.
+    """
+    from neunorm.data_models.core import EventData
+    from neunorm.data_models.tof import BinningConfig
+    from neunorm.tof.event_converter import convert_events_to_histogram
+
+    flight_path = sc.scalar(25.0, unit="m")
+    offset = sc.scalar(20.0, unit="us")  # >> bin width here, so the offset clearly moves the peak bin
+    raw_tof_ns = 500_000.0  # within the TOF span of the (1, 100) eV range at L=25 m
+    n = 1000
+    events = EventData(
+        tof=np.full(n, raw_tof_ns, dtype=np.int64),
+        x=np.full(n, 5, dtype=np.int32),
+        y=np.full(n, 5, dtype=np.int32),
+        file_path="synthetic.h5",
+        total_events=n,
+    )
+    cfg = BinningConfig(bins=300, bin_space="energy", energy_range=(1.0, 100.0), use_log_bin=True)
+
+    hist = convert_events_to_histogram(
+        events, cfg, flight_path, x_bins=10, y_bins=10, compute_variance=False, detector_time_offset=offset
+    )
+    counts = hist.sum(("x", "y")).data.values
+    peak = int(np.argmax(counts))
+    assert counts[peak] == n  # all events fell in a single bin
+    edges = sc.to_unit(hist.coords["tof"], "ns").values
+    # The populated bin's raw-TOF edges bracket the raw event TOF.
+    assert edges[peak] <= raw_tof_ns <= edges[peak + 1]
+
+    # Old behavior (offset=0): edges are shifted, so the same events land in a different bin.
+    hist0 = convert_events_to_histogram(events, cfg, flight_path, x_bins=10, y_bins=10, compute_variance=False)
+    peak0 = int(np.argmax(hist0.sum(("x", "y")).data.values))
+    assert peak0 != peak
+
+
+def test_get_energy_and_wavelength_histogram_apply_offset():
+    """get_energy_histogram / get_wavelength_histogram label TOF with detector_time_offset (#141).
+
+    The public histogram-relabeling helpers must use the same offset-aware converter as the bin
+    construction, so a histogram built with an offset is labeled consistently. Without the offset
+    the labels differ.
+    """
+    from neunorm.tof.binning import get_energy_histogram, get_wavelength_histogram
+    from neunorm.tof.coordinate_converter import convert_tof_to_energy, convert_tof_to_wavelength
+
+    flight_path = sc.scalar(25.0, unit="m")
+    offset = sc.scalar(20.0, unit="us")
+    tof_edges = sc.linspace("tof", 1.0e5, 1.0e6, num=6, unit="ns")
+    hist = sc.DataArray(
+        data=sc.ones(dims=["tof", "x", "y"], shape=[5, 2, 2], unit="counts"),
+        coords={"tof": tof_edges, "x": sc.arange("x", 2), "y": sc.arange("y", 2)},
+    )
+
+    # Energy: edges match the offset-aware converter (in eV), reversed (high TOF = low energy).
+    he = get_energy_histogram(hist, flight_path, offset)
+    expected_e = sc.to_unit(convert_tof_to_energy(tof_edges, flight_path, offset), "eV").values[::-1]
+    np.testing.assert_allclose(he.coords["energy"].values, expected_e, rtol=1e-9)
+    # Independent (non-circular) physics anchor for one edge: E = 0.5*m_n*(L/(t+offset))^2.
+    # The lowest TOF edge (1e5 ns) maps to the highest energy -> last edge after the reversal.
+    t_plus_offset_s = (1.0e5 + 20_000.0) * 1e-9  # tof 1e5 ns + 20 us offset, in seconds
+    e_hand_ev = 0.5 * scipy_const.m_n * (25.0 / t_plus_offset_s) ** 2 / scipy_const.e
+    np.testing.assert_allclose(he.coords["energy"].values[-1], e_hand_ev, rtol=1e-5)
+    he0 = get_energy_histogram(hist, flight_path)  # offset=0 -> different labels
+    assert not np.allclose(he.coords["energy"].values, he0.coords["energy"].values)
+
+    # Wavelength: edges match the offset-aware converter (in angstrom), not reversed.
+    hw = get_wavelength_histogram(hist, flight_path, offset)
+    expected_w = sc.to_unit(convert_tof_to_wavelength(tof_edges, flight_path, offset), "angstrom").values
+    np.testing.assert_allclose(hw.coords["wavelength"].values, expected_w, rtol=1e-9)
+    # Independent physics anchor: lambda = h*(t+offset)/(m_n*L); lowest TOF -> first (shortest) edge.
+    w_hand_angstrom = scipy_const.h * t_plus_offset_s / (scipy_const.m_n * 25.0) * 1e10
+    np.testing.assert_allclose(hw.coords["wavelength"].values[0], w_hand_angstrom, rtol=1e-5)
+    hw0 = get_wavelength_histogram(hist, flight_path)  # offset=0 -> different labels
+    assert not np.allclose(hw.coords["wavelength"].values, hw0.coords["wavelength"].values)


### PR DESCRIPTION
## Summary

Closes #141. In the VENUS TPX3 **event** pipeline, histogramming directly in energy/wavelength space (`bin_space='energy'|'wavelength'`) placed events in the **wrong bins**: the energy/wavelength→TOF bin edges were built as the *physical* flight time with no `detector_time_offset`, while the raw detector event TOF (= physical + offset) was histogrammed into them — and the offset was applied only later when labeling the coordinates, so **binning and labeling disagreed**. The flight path was also a hardcoded 25 m placeholder, duplicated across steps and pipelines.

Only the non-default bin-in-energy/wavelength path was affected; the default bin-in-TOF-then-convert path was already correct.

## Changes

- **`coordinate_converter.py`** — add `convert_energy_to_tof`, the exact inverse of `convert_tof_to_energy` (offset-aware), mirroring `convert_wavelength_to_tof`.
- **`binning.py`** — `create_tof_bins` / `_energy_bins_to_tof` / `_wavelength_bins_to_tof` take an `offset` and build edges via the inverse converters, so bin edges live in **raw detector-TOF space** and are provably the inverse of the labeling. The public `get_energy_histogram` / `get_wavelength_histogram` helpers also gain an `offset` and label via the offset-aware converters (eV / angstrom), so a histogram built with an offset is labeled consistently.
- **`event_converter.py`** — `convert_events_to_histogram` gains `detector_time_offset` (default 0, appended → existing positional calls unaffected), forwarded to `create_tof_bins`.
- **Pipelines** — `venus_tpx3_event` loads metadata before histogramming and passes `detector_time_offset`; all three VENUS TPX pipelines (`tpx3_event`, `tpx3_histogram`, `tpx1`) now take a configurable `flight_path` (default `VENUS_FLIGHT_PATH_M`) used for binning/labeling, removing the hardcoded 25 m literals.

## Compatibility
`offset` defaults to 0 → existing edges reproduced (to floating-point round-off); all ~dozen existing call sites and the default TOF path are unchanged. Only a non-zero offset on the energy/wavelength path changes output — the buggy case.

## Tests
`convert_energy_to_tof` inverse round-trip; offset shifts edges by exactly `−offset`; events histogrammed in energy land in the bin bracketing their raw TOF (different bin without the offset); the relabeling helpers apply the offset, anchored by an independent hand-computed `E = ½·m_n·(L/(t+offset))²` / `λ = h·(t+offset)/(m_n·L)` value. Full suite **375 passed** (~90% cov); pre-commit clean.

## Review
Reviewed across two **scoped** dual-LLM-family (Claude + Codex) rounds (P0/P1 scoped to pipeline-reachable + bulk-data/UQ correctness). Round 1 confirmed the core fix and surfaced one P1 (public helpers ignoring the offset) — fixed here, along with unifying the flight path across the sibling pipelines. **Round 2 converged clean: 0 P0/P1, both families "safe to ship."**

🤖 Generated with [Claude Code](https://claude.com/claude-code)