### PR TITLE
fix: correct shared-dark variance double-count in CCD transmission uncertainty (#142)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `run_venus_tpx1_pipeline` / `run_venus_tpx3_histogram_pipeline` pipelines also take a
   configurable `flight_path`. The default bin-in-TOF path is unaffected.
   ([#141](https://github.com/ornlneutronimaging/NeuNorm/issues/141))
+- **Shared dark-frame variance is no longer double-counted in CCD transmission
+  uncertainty.** With the same averaged dark subtracted from both sample and open beam,
+  `T = (S−D)/(O−D)` was propagated as if numerator and denominator were independent, so
+  `Var(D)` entered twice. A new `normalize_with_dark` computes the dark correction and
+  normalization together and removes the spurious shared-dark covariance term, so the
+  reported uncertainty is slightly smaller (the **transmission values are unchanged**). The
+  CCD pipelines use it on the with-dark path; the no-dark path is unchanged.
+  ([#142](https://github.com/ornlneutronimaging/NeuNorm/issues/142))
 
 ## [2.0.0] - 2026-06-09
 

--- a/src/neunorm/pipelines/mars_ccd.py
+++ b/src/neunorm/pipelines/mars_ccd.py
@@ -15,8 +15,7 @@ from neunorm.exporters.hdf5_writer import write_hdf5
 from neunorm.exporters.tiff_writer import write_tiff_stack
 from neunorm.filters.gamma_filter import apply_gamma_filter
 from neunorm.loaders.stack_loader import load_stack
-from neunorm.processing.dark_corrector import subtract_dark
-from neunorm.processing.normalizer import normalize_transmission
+from neunorm.processing.normalizer import normalize_transmission, normalize_with_dark
 from neunorm.processing.reference_preparer import prepare_reference
 from neunorm.processing.roi_clipper import apply_roi
 from neunorm.processing.run_combiner import combine_runs
@@ -151,17 +150,14 @@ def run_mars_ccd_pipeline(  # noqa: C901
     if gamma_filter:
         sample = apply_gamma_filter(sample)
 
-    # Dark correction (optional)
+    # Dark correction (optional) + normalization. With a shared dark frame, normalize_with_dark
+    # subtracts the dark and normalizes in one step so the dark variance is not double-counted
+    # in the transmission uncertainty (issue #142). Without dark, normalize directly.
     if dark is not None:
-        sample_dark_corrected = subtract_dark(sample, dark)
-        ob_dark_corrected = subtract_dark(ob, dark)
+        transmission = normalize_with_dark(sample, ob, dark)
     else:
         logger.info("No dark current provided; skipping dark correction")
-        sample_dark_corrected = sample
-        ob_dark_corrected = ob
-
-    # Normalization
-    transmission = normalize_transmission(sample_dark_corrected, ob_dark_corrected)
+        transmission = normalize_transmission(sample, ob)
 
     # Guarantee a float32 normalized data product (issue #147), regardless of any
     # intermediate dtype promotion. .astype converts values and variances. MARS has

--- a/src/neunorm/pipelines/venus_ccd.py
+++ b/src/neunorm/pipelines/venus_ccd.py
@@ -16,8 +16,7 @@ from neunorm.exporters.tiff_writer import write_tiff_stack
 from neunorm.filters.gamma_filter import apply_gamma_filter
 from neunorm.loaders.stack_loader import load_stack
 from neunorm.processing.air_region_corrector import apply_air_region_correction
-from neunorm.processing.dark_corrector import subtract_dark
-from neunorm.processing.normalizer import normalize_transmission
+from neunorm.processing.normalizer import normalize_transmission, normalize_with_dark
 from neunorm.processing.reference_preparer import prepare_reference
 from neunorm.processing.roi_clipper import apply_roi
 from neunorm.processing.run_combiner import combine_runs
@@ -142,24 +141,29 @@ def run_venus_ccd_pipeline(  # noqa: C901
     if gamma_filter:
         sample = apply_gamma_filter(sample)
 
-    # Dark correction (optional)
+    # Dark correction (optional) + normalization. The proton-charge coords are cast to float32
+    # so the division does not silently re-promote the float32 image data to float64 (issue
+    # #147; the coord is float64 because metadata is parsed via float()). With a shared dark
+    # frame, normalize_with_dark subtracts the dark and normalizes in one step so the dark
+    # variance is not double-counted in the transmission uncertainty (issue #142).
+    proton_charge_sample = sample.coords["IntegratedPCharge"].astype("float32")
+    proton_charge_ob = ob.coords["IntegratedPCharge"].astype("float32")
     if dark is not None:
-        sample_dark_corrected = subtract_dark(sample, dark)
-        ob_dark_corrected = subtract_dark(ob, dark)
+        transmission = normalize_with_dark(
+            sample,
+            ob,
+            dark,
+            proton_charge_sample=proton_charge_sample,
+            proton_charge_ob=proton_charge_ob,
+        )
     else:
         logger.info("No dark current provided; skipping dark correction")
-        sample_dark_corrected = sample
-        ob_dark_corrected = ob
-
-    # Normalization. Cast the proton-charge coords to float32 so the division does
-    # not silently re-promote the float32 image data back to float64 (issue #147);
-    # the coord is float64 because metadata is parsed via float().
-    transmission = normalize_transmission(
-        sample=sample_dark_corrected,
-        ob=ob_dark_corrected,
-        proton_charge_sample=sample.coords["IntegratedPCharge"].astype("float32"),
-        proton_charge_ob=ob.coords["IntegratedPCharge"].astype("float32"),
-    )
+        transmission = normalize_transmission(
+            sample=sample,
+            ob=ob,
+            proton_charge_sample=proton_charge_sample,
+            proton_charge_ob=proton_charge_ob,
+        )
 
     # Air region correction (optional)
     if air_roi is not None:

--- a/src/neunorm/processing/normalizer.py
+++ b/src/neunorm/processing/normalizer.py
@@ -7,8 +7,11 @@ with proper uncertainty propagation and beam corrections.
 
 from typing import Optional, Union
 
+import numpy as np
 import scipp as sc
 from loguru import logger
+
+from neunorm.processing.dark_corrector import subtract_dark
 
 
 def normalize_transmission(  # noqa: C901
@@ -132,3 +135,94 @@ def normalize_transmission(  # noqa: C901
     logger.success("✓ Transmission normalized")
 
     return transmission
+
+
+def normalize_with_dark(
+    sample: sc.DataArray,
+    ob: sc.DataArray,
+    dark: sc.DataArray,
+    proton_charge_sample: Optional[Union[float, sc.Variable]] = None,
+    proton_charge_ob: Optional[Union[float, sc.Variable]] = None,
+    pc_uncertainty: float = 0.005,
+) -> sc.DataArray:
+    """Dark-correct and normalize in one step, treating the shared dark frame correctly.
+
+    Computes ``T = (sample - dark) / (ob - dark)`` (with the optional proton-charge
+    correction) where the **same** averaged ``dark`` is subtracted from both sample and open
+    beam. ``subtract_dark`` + ``normalize_transmission`` would treat the numerator and
+    denominator as statistically independent and propagate ``Var(dark)`` twice; this function
+    removes that spurious shared-dark covariance term (issue #142).
+
+    The transmission **values** are identical to
+    ``normalize_transmission(subtract_dark(sample, dark), subtract_dark(ob, dark), ...)`` — only
+    the propagated variance is corrected (reduced) by ``2 * k**2 * (sample-dark) * Var(dark) /
+    (ob-dark)**3``, with ``k = pc_ob / pc_sample`` (1 when no proton charge). The proton-charge
+    systematic and the sample/open-beam Poisson terms are unchanged.
+
+    Parameters
+    ----------
+    sample, ob, dark : sc.DataArray
+        Sample, open-beam and (averaged) dark-current frames, each carrying Poisson variance.
+        The same ``dark`` is subtracted from both ``sample`` and ``ob``.
+    proton_charge_sample, proton_charge_ob : float or sc.Variable, optional
+        Integrated proton charge for the SNS beam correction (see ``normalize_transmission``).
+    pc_uncertainty : float, optional
+        Relative proton-charge uncertainty (default 0.005).
+
+    Returns
+    -------
+    sc.DataArray
+        Transmission with correctly-propagated variance (no shared-dark double-counting).
+    """
+    sample_dc = subtract_dark(sample, dark)
+    ob_dc = subtract_dark(ob, dark)
+    transmission = normalize_transmission(sample_dc, ob_dc, proton_charge_sample, proton_charge_ob, pc_uncertainty)
+
+    # Correct the shared-dark double-count (issue #142). normalize_transmission propagated
+    # Var(dark) through BOTH numerator and denominator as if they were independent; the true
+    # propagation (dark appears once) is smaller by 2*k^2*s*Var(D)/o^3. Subtract that term.
+    if transmission.variances is None or dark.variances is None:
+        return transmission
+
+    # Use scipp's unit-carrying value/variance accessors so (a) the (3D sample) vs (2D ob/dark)
+    # broadcast and the per-image proton-charge ratio align by dimension name and (b) scipp
+    # validates units: counts * counts**2 / counts**3 = dimensionless, matching Var(T).
+    s_v = sc.values(sample_dc)  # counts
+    o_v = sc.values(ob_dc)  # counts
+    var_d_v = sc.variances(dark)  # counts**2
+    over_count = 2.0 * s_v * var_d_v / (o_v**3)
+
+    k_squared = _proton_charge_ratio_squared(proton_charge_sample, proton_charge_ob)
+    if k_squared is not None:
+        over_count = k_squared * over_count
+
+    over_values = sc.to_unit(over_count, "dimensionless").transpose(transmission.dims).values
+    # Match the variance dtype so the correction never promotes a float32 pipeline to float64.
+    over_values = over_values.astype(transmission.variances.dtype, copy=False)
+    # Zero the correction where ob-dark == 0 (those pixels are already inf/nan in T).
+    over_values = np.where(np.isfinite(over_values), over_values, 0.0)
+    # Clamp to >= 0 defensively; the corrected variance is a true (non-negative) variance.
+    transmission.variances = np.clip(transmission.variances - over_values, 0.0, None)
+    logger.success("✓ Shared-dark variance double-count corrected (issue #142)")
+
+    return transmission
+
+
+def _proton_charge_ratio_squared(
+    proton_charge_sample: Optional[Union[float, sc.Variable]],
+    proton_charge_ob: Optional[Union[float, sc.Variable]],
+) -> Optional[sc.Variable]:
+    """Return ``(pc_ob / pc_sample)**2`` as a dimensionless scipp Variable, or None if either
+    proton charge is absent (k = 1, the MARS / no-beam-correction case)."""
+    if proton_charge_sample is None or proton_charge_ob is None:
+        return None
+    pc_s = (
+        proton_charge_sample
+        if isinstance(proton_charge_sample, sc.Variable)
+        else sc.scalar(float(proton_charge_sample), unit="C")
+    )
+    pc_o = (
+        proton_charge_ob if isinstance(proton_charge_ob, sc.Variable) else sc.scalar(float(proton_charge_ob), unit="C")
+    )
+    k = sc.to_unit(pc_o / pc_s, "dimensionless")
+    return k * k

--- a/tests/unit/test_normalizer.py
+++ b/tests/unit/test_normalizer.py
@@ -145,6 +145,120 @@ def test_normalize_transmission_with_proton_charge():
     assert transmission.variances is not None
 
 
+# --- issue #142: shared-dark variance must not be double-counted ---
+
+
+def _ccd_frames(sample_counts, ob_counts, dark_counts):
+    """Build (sample 3D, ob 2D, dark 2D) DataArrays with Poisson variance for one pixel value."""
+    s, o, d = float(sample_counts), float(ob_counts), float(dark_counts)
+    sample = sc.DataArray(sc.array(dims=["N_image", "y", "x"], values=[[[s]]], variances=[[[s]]], unit="counts"))
+    ob = sc.DataArray(sc.array(dims=["y", "x"], values=[[o]], variances=[[o]], unit="counts"))
+    dark = sc.DataArray(sc.array(dims=["y", "x"], values=[[d]], variances=[[d]], unit="counts"))
+    return sample, ob, dark
+
+
+def test_normalize_with_dark_values_match_old_path():
+    """normalize_with_dark returns the SAME transmission values as subtract_dark+normalize (#142)."""
+    from neunorm.processing.dark_corrector import subtract_dark
+    from neunorm.processing.normalizer import normalize_transmission, normalize_with_dark
+
+    sample, ob, dark = _ccd_frames(800, 1500, 60)
+    # MARS (no proton charge)
+    old = normalize_transmission(subtract_dark(sample, dark), subtract_dark(ob, dark))
+    new = normalize_with_dark(sample, ob, dark)
+    np.testing.assert_allclose(new.values, old.values, rtol=1e-12)
+
+    # VENUS (proton charge): values still identical
+    pc_s = sc.array(dims=["N_image"], values=[0.1], unit="C")
+    pc_o = sc.scalar(0.2, unit="C")
+    old_v = normalize_transmission(subtract_dark(sample, dark), subtract_dark(ob, dark), pc_s, pc_o)
+    new_v = normalize_with_dark(sample, ob, dark, pc_s, pc_o)
+    np.testing.assert_allclose(new_v.values, old_v.values, rtol=1e-12)
+
+
+def test_normalize_with_dark_variance_matches_monte_carlo():
+    """The corrected Var(T) matches a shared-dark Monte Carlo and is smaller than the old
+    double-counted value by exactly 2*N*Var(D)/M^3 (MARS) (issue #142)."""
+    from neunorm.processing.dark_corrector import subtract_dark
+    from neunorm.processing.normalizer import normalize_transmission, normalize_with_dark
+
+    sample_counts, ob_counts, dark_counts = 800.0, 1500.0, 60.0
+    sample, ob, dark = _ccd_frames(sample_counts, ob_counts, dark_counts)
+
+    old = normalize_transmission(subtract_dark(sample, dark), subtract_dark(ob, dark))
+    new = normalize_with_dark(sample, ob, dark)
+    var_old = float(old.variances.ravel()[0])
+    var_new = float(new.variances.ravel()[0])
+
+    # Monte Carlo ground truth: the SAME dark draw feeds numerator and denominator.
+    # 500k trials keep this a fast unit test; the exact analytic check below is the precise oracle.
+    rng = np.random.default_rng(42)
+    n = 500_000
+    s = rng.normal(sample_counts, np.sqrt(sample_counts), n)
+    o = rng.normal(ob_counts, np.sqrt(ob_counts), n)
+    d = rng.normal(dark_counts, np.sqrt(dark_counts), n)
+    var_mc = ((s - d) / (o - d)).var()
+
+    # Corrected variance matches MC far better than the double-counted one.
+    assert abs(var_new - var_mc) / var_mc < 0.01
+    assert abs(var_old - var_mc) / var_mc > 0.03
+    # The exact over-count removed is 2 * numerator * Var(D) / denominator^3.
+    numerator, denominator = sample_counts - dark_counts, ob_counts - dark_counts
+    np.testing.assert_allclose(var_old - var_new, 2 * numerator * dark_counts / denominator**3, rtol=1e-6)
+
+
+def test_normalize_with_dark_reduces_variance_with_proton_charge():
+    """VENUS path: the correction also reduces the variance (no double-counted Var(dark))."""
+    from neunorm.processing.dark_corrector import subtract_dark
+    from neunorm.processing.normalizer import normalize_transmission, normalize_with_dark
+
+    sample, ob, dark = _ccd_frames(800, 1500, 60)
+    pc_s = sc.array(dims=["N_image"], values=[0.1], unit="C")
+    pc_o = sc.scalar(0.2, unit="C")
+    old = normalize_transmission(subtract_dark(sample, dark), subtract_dark(ob, dark), pc_s, pc_o)
+    new = normalize_with_dark(sample, ob, dark, pc_s, pc_o)
+    assert float(new.variances.ravel()[0]) < float(old.variances.ravel()[0])
+    assert float(new.variances.ravel()[0]) > 0.0
+
+
+def test_normalize_with_dark_pc_overcount_per_image_exact():
+    """VENUS: the removed over-count equals 2*k^2*(S-D)*Var(D)/(O-D)^3 with per-image k (#142).
+
+    Pins the exact k^2 = (pc_ob/pc_sample)^2 magnitude and the per-image broadcast for a
+    multi-image sample with VARYING per-image proton charge (not just directional reduction).
+    """
+    from neunorm.processing.dark_corrector import subtract_dark
+    from neunorm.processing.normalizer import normalize_transmission, normalize_with_dark
+
+    sample_vals = np.array([800.0, 820.0, 840.0])
+    ob_val, dark_val = 1500.0, 60.0
+    sample = sc.DataArray(
+        sc.array(
+            dims=["N_image", "y", "x"],
+            values=sample_vals.reshape(3, 1, 1),
+            variances=sample_vals.reshape(3, 1, 1),
+            unit="counts",
+        )
+    )
+    ob = sc.DataArray(sc.array(dims=["y", "x"], values=[[ob_val]], variances=[[ob_val]], unit="counts"))
+    dark = sc.DataArray(sc.array(dims=["y", "x"], values=[[dark_val]], variances=[[dark_val]], unit="counts"))
+    pc_sample_vals = np.array([0.10, 0.15, 0.20])
+    pc_ob_val = 0.20
+    pc_s = sc.array(dims=["N_image"], values=pc_sample_vals, unit="C")
+    pc_o = sc.scalar(pc_ob_val, unit="C")
+
+    old = normalize_transmission(subtract_dark(sample, dark), subtract_dark(ob, dark), pc_s, pc_o)
+    new = normalize_with_dark(sample, ob, dark, pc_s, pc_o)
+
+    # Independent analytic oracle (per image): over_count = 2*k^2*(S-D)*Var(D)/(O-D)^3.
+    k = pc_ob_val / pc_sample_vals
+    s = sample_vals - dark_val
+    o = ob_val - dark_val
+    expected = 2 * k**2 * s * dark_val / o**3
+    diff = old.variances.ravel() - new.variances.ravel()
+    np.testing.assert_allclose(diff, expected, rtol=1e-6)
+
+
 def test_normalize_transmission_2d_ob():
     """Test basic transmission normalization: T = Sample / OB with an averaged 2D OB"""
     from neunorm.processing.normalizer import normalize_transmission

--- a/tests/unit/test_venus_ccd.py
+++ b/tests/unit/test_venus_ccd.py
@@ -288,8 +288,10 @@ class TestVenusCCDPipeline:
             expected_value = np.full((20, 20), ((81 + i) - 5) / (100 - 5) * 2)
             np.testing.assert_allclose(transmission.values[i], expected_value, rtol=1e-5)
 
-        # check that the variances exist and are reasonable
-        np.testing.assert_allclose(transmission.variances, 0.018, atol=0.001)
+        # Variances are reasonable and reduced by combining runs. Pinned to the corrected
+        # values (~0.0168–0.0180 across the 5 images) after fixing the shared-dark variance
+        # double-count (issue #142); previously ~0.018 with the over-counted Var(dark).
+        np.testing.assert_allclose(transmission.variances, 0.0174, atol=0.0006)
 
         # The mask should only have the dead pixel masked
         expected_dead_pixel_mask = np.zeros((20, 20), dtype=bool)


### PR DESCRIPTION
## Summary

Closes #142. For CCD transmission `T = (S − D) / (O − D)`, the **same** averaged dark frame `D` was subtracted from sample and open beam in two independent `subtract_dark` calls, then divided by `normalize_transmission`. scipp (and the broadcast variance formula) treat numerator and denominator as statistically independent, so the shared `Var(D)` was propagated **twice** — the shared-dark covariance term was omitted. **Transmission values were correct; only the reported uncertainty was slightly too large** (second-order; dark ≪ sample/OB; priority:low).

## Fix — surgical variance correction (values provably unchanged)

New `normalize_with_dark(sample, ob, dark[, proton_charge…])` in `processing/normalizer.py`:
1. Reuses `subtract_dark` + `normalize_transmission` for the transmission **values and base variance** — so values are identical to the old path.
2. Subtracts the spurious shared-dark term `2·k²·(S−D)·Var(D)/(O−D)³` (`k = pc_ob/pc_sample`, 1 for MARS) from the variance — the exact double-counted delta — guarded for `o == 0` / missing dark variance and clamped ≥ 0.

The CCD pipelines (`mars_ccd`, `venus_ccd`) use it on the **with-dark** path; the **no-dark** path keeps `normalize_transmission` unchanged.

## Correctness

The corrected closed form was derived and **Monte-Carlo verified**: corrected `Var(T)` matches MC to ~0.3% (first-order residual), the old double-counted value was off ~4.8%, and the removed term equals `2N·Var(D)/M³` to machine precision. The proton-charge systematic and the S/O Poisson terms are unchanged.

## Tests
`normalize_with_dark` values match the old path (MARS + VENUS); variance matches a shared-dark Monte Carlo and equals old − over-count; an exact **per-image VENUS k²** regression test (varying proton charge across images); the one with-dark variance assertion that tightened was re-pinned (~6% smaller, corrected). No-dark assertions unaffected. Full suite **379 passed** (~90% cov); pre-commit clean.

## Review
Scoped dual-LLM-family (Claude + Codex) review, converged in **one round**: 0 P0/P1; the single finding (a P2 test-coverage gap on the per-image k² magnitude) is addressed by the added regression test. Claude independently verified the per-image broadcast correct to machine precision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)