### PR TITLE
docs: point Zenodo badge/citation at the NeuNorm DOI + add ORCIDs

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -7,15 +7,18 @@
   "creators": [
     {
       "name": "Whitfield, Ross",
-      "affiliation": "Oak Ridge National Laboratory"
+      "affiliation": "Oak Ridge National Laboratory",
+      "orcid": "0000-0002-9852-1044"
     },
     {
       "name": "Bilheux, Jean",
-      "affiliation": "Oak Ridge National Laboratory"
+      "affiliation": "Oak Ridge National Laboratory",
+      "orcid": "0000-0003-2172-6487"
     },
     {
       "name": "Zhang, Chen",
-      "affiliation": "Oak Ridge National Laboratory"
+      "affiliation": "Oak Ridge National Laboratory",
+      "orcid": "0000-0001-8374-4467"
     }
   ],
   "keywords": [

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,22 +1,23 @@
 # This CITATION.cff describes how to cite the NeuNorm software.
-# The software DOI (minted by Zenodo on the first GitHub Release of this repo)
-# should be added below as `doi:` once the v2.0.0 release is archived.
-# ORCIDs are omitted; add `orcid: "https://orcid.org/0000-0000-0000-0000"` under
-# each author when available.
+# The `doi:` below is the Zenodo concept DOI (resolves to the latest archived release).
 cff-version: 1.2.0
 message: "If you use this software, please cite both the software itself and the accompanying paper (Bilheux, 2018)."
 title: "NeuNorm: Neutron imaging normalization and time-of-flight data processing for ORNL facilities"
 type: software
+doi: 10.5281/zenodo.20753780
 authors:
   - family-names: Whitfield
     given-names: Ross
     affiliation: "Oak Ridge National Laboratory"
+    orcid: "https://orcid.org/0000-0002-9852-1044"
   - family-names: Bilheux
     given-names: Jean
     affiliation: "Oak Ridge National Laboratory"
+    orcid: "https://orcid.org/0000-0003-2172-6487"
   - family-names: Zhang
     given-names: Chen
     affiliation: "Oak Ridge National Laboratory"
+    orcid: "https://orcid.org/0000-0001-8374-4467"
 repository-code: "https://github.com/ornlneutronimaging/NeuNorm"
 url: "https://neunorm.readthedocs.io"
 license: BSD-3-Clause

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PyPI version](https://badge.fury.io/py/NeuNorm.svg)](https://badge.fury.io/py/NeuNorm)
 [![codecov](https://codecov.io/gh/ornlneutronimaging/NeuNorm/branch/next/graph/badge.svg)](https://codecov.io/gh/ornlneutronimaging/NeuNorm)
 [![Documentation Status](https://readthedocs.org/projects/neunorm/badge/?version=latest)](http://neunorm.readthedocs.io/en/latest/?badge=latest)
-[![DOI](https://zenodo.org/badge/97755175.svg)](https://zenodo.org/badge/latestdoi/97755175)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20753780.svg)](https://doi.org/10.5281/zenodo.20753780)
 [![DOI](http://joss.theoj.org/papers/10.21105/joss.00815/status.svg)](https://doi.org/10.21105/joss.00815)
 
 NeuNorm normalizes neutron imaging data and processes time-of-flight (TOF) data


### PR DESCRIPTION
Post-release follow-up to the v2.1.0 cut, which auto-minted the NeuNorm Zenodo archive.

## Changes
- **README badge** — swap the stale Zenodo DOI badge off the old **scikit-beam/NeuNorm** record (`97755175` → `zenodo.1414282`) to the new **concept DOI** `10.5281/zenodo.20753780` (all-versions; resolves to the latest archived release).
- **`CITATION.cff`** — add `doi: 10.5281/zenodo.20753780` and author ORCIDs (full `https://orcid.org/...` URIs); refresh the now-outdated header comment.
- **`.zenodo.json`** — add author ORCIDs (bare IDs, per the Zenodo schema) so future releases link each author's ORCID profile.

## ORCIDs (verified against the public ORCID API)
| Author | ORCID | API name |
|---|---|---|
| Ross Whitfield | `0000-0002-9852-1044` | Ross Whitfield ✓ |
| Jean Bilheux | `0000-0003-2172-6487` | Jean Bilheux ✓ |
| Chen Zhang | `0000-0001-8374-4467` | Chen Zhang ✓ |

## Verification
- `.zenodo.json` parses as JSON; `CITATION.cff` parses as YAML with the expected `doi`/`orcid` fields (format matches CFF 1.2.0).
- `pre-commit` clean on all three files.
- Concept vs version DOI: the badge/citation use the **concept** DOI (`…780`) so they always point at the latest; the v2.1.0 **version** DOI is `…781`.

Docs-only; no code or test changes.

Assisted-With: Claude Opus 4.8 <noreply@anthropic.com>