### PR TITLE
security: pin third-party GitHub Actions to commit SHAs + least-privilege permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: "33 13 * * 5" # Fridays 13:33 UTC
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze (python)

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-tags: true
 
       - name: Setup pixi
-        uses: prefix-dev/setup-pixi@v0.9.6
+        uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           pixi-version: v0.70.1
           manifest-path: pyproject.toml
@@ -44,13 +44,13 @@ jobs:
 
       - name: Install built conda package
         id: install
-        uses: neutrons/conda-actions/pkg-install@v2
+        uses: neutrons/conda-actions/pkg-install@bba9ca89d48d9ae846db9650cc63fde736340b3d # v2
         with:
           package-name: neunorm
           local-channel: /tmp/local-channel
 
       - name: Scan installed environment with Grype
-        uses: neutrons/conda-actions/grype@v2
+        uses: neutrons/conda-actions/grype@bba9ca89d48d9ae846db9650cc63fde736340b3d # v2
         with:
           path: ${{ steps.install.outputs.conda_install_dir }}
           # gate on fixable findings; only-fixed defaults true in the v2

--- a/.github/workflows/test_and_deploy.yaml
+++ b/.github/workflows/test_and_deploy.yaml
@@ -31,7 +31,7 @@ jobs:
           fetch-tags: true
 
       - name: Setup pixi
-        uses: prefix-dev/setup-pixi@v0.9.6
+        uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           pixi-version: v0.70.1
           manifest-path: pyproject.toml
@@ -62,7 +62,7 @@ jobs:
           fetch-tags: true
 
       - name: Setup pixi
-        uses: prefix-dev/setup-pixi@v0.9.6
+        uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           pixi-version: v0.70.1
           manifest-path: pyproject.toml
@@ -75,7 +75,7 @@ jobs:
           cp *.conda /tmp/local-channel/linux-64
 
       - name: Verify conda package
-        uses: neutrons/conda-verify@main
+        uses: neutrons/conda-verify@e1b26a86406e34b371fd633f9993c390f662910d # main
         with:
           package-name: ${{ env.PKG_NAME }}
           module-name: ${{ env.MODULE_NAME }}
@@ -101,7 +101,7 @@ jobs:
           fetch-tags: true
 
       - name: Setup Pixi
-        uses: prefix-dev/setup-pixi@v0.9.6
+        uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           pixi-version: v0.70.1
           manifest-path: pyproject.toml
@@ -141,7 +141,7 @@ jobs:
           fetch-tags: true
 
       - name: Setup pixi
-        uses: prefix-dev/setup-pixi@v0.9.6
+        uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           pixi-version: v0.70.1
           manifest-path: pyproject.toml
@@ -155,7 +155,7 @@ jobs:
       # publish your distributions here (need to setup on PyPI first)
       - name: Publish package distributions to PyPI
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           # Tolerate re-runs of a release tag: files already on PyPI are skipped
           # instead of failing the whole job (PyPI uploads are immutable).

--- a/.github/workflows/update-lockfiles.yml
+++ b/.github/workflows/update-lockfiles.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pixi
-        uses: prefix-dev/setup-pixi@v0.9.6
+        uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           # Pin to the same pixi the rest of CI uses, so the regenerated
           # lockfile stays in a format the pinned CI pixi can read.
@@ -32,7 +32,7 @@ jobs:
           pixi update --json | pixi exec pixi-diff-to-markdown >> diff.md
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: Update pixi lockfile


### PR DESCRIPTION
## What

Supply-chain hardening of this repo's GitHub Actions workflows, from the 2026-06-22 workspace GitHub Actions security audit:

- **Pin all third-party actions to full 40-char commit SHAs**, retaining a trailing `# version` comment for readability.
- **Add a conservative top-level `permissions: contents: read` block** to pure-CI workflows that have no existing top-level permissions block and request no write/elevated scopes.

First-party `actions/*` and `github/*` actions are intentionally left tag-pinned per group convention.

## Why

Tag refs (e.g. `@v8`, `@main`) are mutable — a compromised or retagged upstream action can silently run arbitrary code in CI. Pinning to immutable commit SHAs closes that supply-chain vector. The least-privilege default token scope reduces blast radius if a workflow is exploited.

## Pins applied

- `prefix-dev/setup-pixi@v0.9.6` -> `@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6` (5 occurrences across test_and_deploy.yaml, dependency-scan.yml, update-lockfiles.yml)
- `neutrons/conda-actions/pkg-install@v2` -> `@bba9ca89d48d9ae846db9650cc63fde736340b3d # v2`
- `neutrons/conda-actions/grype@v2` -> `@bba9ca89d48d9ae846db9650cc63fde736340b3d # v2`
- `neutrons/conda-verify@main` -> `@e1b26a86406e34b371fd633f9993c390f662910d # main`
- `pypa/gh-action-pypi-publish@release/v1` -> `@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0`
- `peter-evans/create-pull-request@v8` -> `@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8`

`codecov/codecov-action` was already SHA-pinned and left unchanged.

## Permissions

- Added top-level `permissions:\n  contents: read` to `codeql.yml` only (it had no top-level permissions block and requests no write/elevated scopes; its job-level `security-events: write` is preserved).
- `dependency-scan.yml` and `update-lockfiles.yml` already have top-level permissions blocks — left untouched.
- `test_and_deploy.yaml` requests `id-token: write` and runs the PyPI/anaconda publish steps, so no top-level permissions block was added (would have been too restrictive for the release pipeline).

## Notes

- No `dtolnay/rust-toolchain` or `taiki-e/install-action` uses exist in this repo, so those special-case handling rules did not apply.
- No behavior change intended; CI on this PR validates.

> **This repo is actively maintained by another team member — please review/coordinate before merging.**

🤖 Assisted with Claude Code
