### PR TITLE
docs(api): fix incorrect autodoc docstrings in src/neunorm (#161)

### DIFF
--- a/src/neunorm/data_models/core.py
+++ b/src/neunorm/data_models/core.py
@@ -1,7 +1,7 @@
 """
 Core data models for NeuNorm 2.0.
 
-Pydantic models for event data, histogram data, and processing results.
+Pydantic model for event-mode neutron data.
 """
 
 from pathlib import Path
@@ -25,6 +25,12 @@ class EventData(BaseModel):
         X pixel coordinates (1D array, same length as tof)
     y : np.ndarray
         Y pixel coordinates (1D array, same length as tof)
+    chip_id : np.ndarray or None, optional
+        Chip ID for each event (0-3 for quad detector); 1D integer array,
+        same length as tof if present (default: None)
+    pulse_id : np.ndarray or None, optional
+        Reconstructed pulse ID for each event; 1D integer array,
+        same length as tof if present (default: None)
     file_path : Path
         Source file path
     total_events : int

--- a/src/neunorm/exporters/hdf5_writer.py
+++ b/src/neunorm/exporters/hdf5_writer.py
@@ -25,10 +25,11 @@ def _is_nested_sequence(value) -> bool:
 def _write_json_metadata(f: h5py.File, name: str, value) -> None:
     """Store ``value`` as a JSON string dataset tagged with ``encoding="json"`` (issue #140).
 
-    Non-string leaves are coerced via ``str()`` (``json`` ``default=str``); the round-trip is
-    therefore lossless only for string-valued data such as the per-run file-path provenance
-    the pipelines emit. May raise (e.g. on a circular reference, or an invalid dataset name);
-    the caller backstops any failure so a single bad key never aborts the write.
+    JSON-native leaves (strings, numbers, bools, ``null``) keep their JSON types; only
+    non-JSON-serializable leaves are coerced via ``str()`` (``json.dumps(..., default=str)``).
+    The round-trip is therefore lossless for the string-valued per-run file-path provenance the
+    pipelines emit. May raise (e.g. on a circular reference, or an invalid dataset name); the
+    caller backstops any failure so a single bad key never aborts the write.
     """
     ds = f.create_dataset(name, data=json.dumps(value, default=str), dtype=h5py.string_dtype("utf-8"))
     ds.attrs["encoding"] = "json"
@@ -99,17 +100,18 @@ def write_hdf5(  # noqa: C901
     Output Structure::
 
         /transmission     # (θ, [TOF,] y, x) float32
-        /uncertainty      # (θ, [TOF,] y, x) float32
-        /masks/dead       # (y, x) bool
-        /masks/hot        # (y, x) bool (optional)
-        /tof_bin_edges    # (N+1,) float64 (optional)
-        /metadata/        # processing provenance
+        /uncertainty      # (θ, [TOF,] y, x) float32 (only if variances are present)
+        /masks/dead       # (y, x) bool (only if the named dead-pixel mask exists)
+        /masks/hot        # (y, x) bool (only if the named hot-pixel mask exists)
+        /tof              # (N+1,) float64 (only if the data carries a "tof" coordinate)
+        /metadata/        # processing provenance (only when metadata is supplied)
 
     Metadata values are stored as native datasets (strings, scalars, flat arrays).
     Nested values such as per-run file-path lists (``sample_paths=[[...], [...]]``) are
     stored as a JSON string with a ``encoding="json"`` dataset attribute; read them back
     with ``json.loads(dataset.asstr()[()])``. The round-trip is lossless for string-valued
-    provenance (what the pipelines emit); non-string leaves are coerced via ``str()``.
+    provenance (what the pipelines emit); only non-JSON-serializable leaves are coerced via
+    ``str()`` (``json.dumps(..., default=str)``), so JSON-native numbers/bools/null keep their types.
 
     Metadata contents:
 

--- a/src/neunorm/exporters/tiff_writer.py
+++ b/src/neunorm/exporters/tiff_writer.py
@@ -57,7 +57,8 @@ def write_tiff_stack(
     Requirements
 
     Write transmission as TIFF stack (one file per image or multi-page TIFF)
-    Write uncertainty as separate TIFF stack
+    Write uncertainty (stdevs) and a mask packed into the same stack via the
+    channel dimension (``concat_stdevs_and_mask=True``), not as a separate file
     Support 32-bit float output
     Embed metadata in scitiff format (JSON in TIFF tags)
     Preserve scipp coordinate information through scitiff

--- a/src/neunorm/loaders/event_loader.py
+++ b/src/neunorm/loaders/event_loader.py
@@ -126,6 +126,9 @@ def load_event_nexus(  # noqa: C901
     detector_shape : tuple[int, int], optional
         Detector dimensions (x_bins, y_bins) for unrolling event_id to x, y.
         Default: (512, 512) for SNS VENUS detectors
+    event_id_offset : int, optional
+        Base offset subtracted from each event_id before unrolling to x, y
+        pixel coordinates (default: 0)
     max_events : int, optional
         Maximum number of events to load (for testing/memory limits)
         If None, loads all events
@@ -140,13 +143,12 @@ def load_event_nexus(  # noqa: C901
     FileNotFoundError
         If file doesn't exist
     KeyError
-        If NeXus structure or required fields not found
-    ValueError
-        If detector_bank specified but not found
+        If the NeXus structure, required fields, or the requested
+        detector_bank are not found
 
     Examples
     --------
-    >>> # Auto-detect detector bank
+    >>> # Use the default detector bank ('bank1')
     >>> events = load_event_nexus('VENUS_15159.nxs.h5')
 
     >>> # Specify detector bank

--- a/src/neunorm/loaders/fits_loader.py
+++ b/src/neunorm/loaders/fits_loader.py
@@ -39,7 +39,11 @@ def load_fits_stack(paths: Sequence[str | Path], tof_edges: Optional[np.ndarray]
 
         - dims: ['TOF', 'y', 'x'] if tof_edges provided, else ['N_image', 'y', 'x']
         - coords: y, x pixel indices, and optionally TOF.
-          Additionally, FITS header keys are added as coordinates with dimension of the stack.
+          Additionally, FITS header keys are added as (unaligned) coordinates.
+          The ``COMMENT`` and ``HISTORY`` keys are skipped. A key whose value is
+          constant across the stack is stored as a scalar coordinate; a key
+          whose value differs across files is stored as an array coordinate
+          along the stack dimension.
     """
 
     if not paths:

--- a/src/neunorm/loaders/tiff_loader.py
+++ b/src/neunorm/loaders/tiff_loader.py
@@ -34,7 +34,10 @@ def load_tiff_stack(paths: Sequence[str | Path], tof_edges: Optional[np.ndarray]
 
         - dims: ['TOF', 'y', 'x'] if tof_edges provided, else ['N_image', 'y', 'x']
         - coords: y, x pixel indices, and optionally TOF.
-          Additionally, TIFF metadata is added as coordinates with dimension of the stack.
+          Additionally, TIFF metadata is added as coordinates. Each metadata
+          coordinate may be scalar (when its value is constant across the stack
+          and not float-convertible) or stack-dimensioned (when values are
+          float-convertible or differ across files).
     """
 
     if not paths:

--- a/src/neunorm/pipelines/venus_tpx1.py
+++ b/src/neunorm/pipelines/venus_tpx1.py
@@ -48,7 +48,7 @@ def run_venus_tpx1_pipeline(  # noqa: C901
     - Run combine
     - ROI clip (optional)
     - Dead pixel detection
-    - Statistics analysis + rebinning recommendation
+    - Statistics analysis + rebinning recommendation (only when ``rebin_by_tof=True``)
     - Rebinning (TOF and/or spatial, optional)
     - Beam correction (proton charge)
     - Normalization (TOF-resolved)
@@ -79,9 +79,10 @@ def run_venus_tpx1_pipeline(  # noqa: C901
     rebin_by_tof : Optional[Union[bool,int]]
         Whether to apply TOF rebinning based on statistics analysis. If an integer is provided,
         it will be used as the rebinning factor instead of the recommended one.
-    rebin_by_spatial : Optional[int]
-        Whether to apply spatial rebinning. If an integer is provided, it will be used as the
-        rebinning factor. If None, no spatial rebinning is applied.
+    rebin_by_spatial : Optional[int | tuple[int, int]]
+        Whether to apply spatial rebinning. If an integer is provided, it is used as the
+        rebinning factor for both spatial axes. A ``(rows, cols)`` tuple selects per-axis
+        rebinning factors (x and y). If None, no spatial rebinning is applied.
     flight_path : sc.Variable
         Source-to-detector flight path used for TOF→energy/wavelength coordinate labeling.
         Defaults to ``VENUS_FLIGHT_PATH_M`` (25 m); set it per detector/sample position.

--- a/src/neunorm/pipelines/venus_tpx1.py
+++ b/src/neunorm/pipelines/venus_tpx1.py
@@ -81,7 +81,7 @@ def run_venus_tpx1_pipeline(  # noqa: C901
         it will be used as the rebinning factor instead of the recommended one.
     rebin_by_spatial : Optional[int | tuple[int, int]]
         Whether to apply spatial rebinning. If an integer is provided, it is used as the
-        rebinning factor for both spatial axes. A ``(rows, cols)`` tuple selects per-axis
+        rebinning factor for both spatial axes. A ``(x, y)`` tuple selects per-axis
         rebinning factors (x and y). If None, no spatial rebinning is applied.
     flight_path : sc.Variable
         Source-to-detector flight path used for TOF→energy/wavelength coordinate labeling.

--- a/src/neunorm/pipelines/venus_tpx3_event.py
+++ b/src/neunorm/pipelines/venus_tpx3_event.py
@@ -51,7 +51,7 @@ def run_venus_tpx3_event_pipeline(  # noqa: C901
     - ROI clip (optional)
     - Dead pixel detection
     - Hot pixel detection
-    - Statistics analysis
+    - Statistics analysis (only when ``rebin_by_tof=True``)
     - Coarsening strategy (spatial/TOF)
     - Event → histogram conversion (flexible binning)
     - Beam correction (p_charge)

--- a/src/neunorm/pipelines/venus_tpx3_event.py
+++ b/src/neunorm/pipelines/venus_tpx3_event.py
@@ -52,7 +52,7 @@ def run_venus_tpx3_event_pipeline(  # noqa: C901
     - Dead pixel detection
     - Hot pixel detection
     - Statistics analysis
-    - Coarsening strategy (spatial/TOF/augmentation)
+    - Coarsening strategy (spatial/TOF)
     - Event → histogram conversion (flexible binning)
     - Beam correction (p_charge)
     - Normalization (TOF-resolved)
@@ -78,9 +78,10 @@ def run_venus_tpx3_event_pipeline(  # noqa: C901
     rebin_by_tof : Optional[bool,int]
         Whether to apply TOF rebinning based on statistics analysis. If an integer is provided,
         it will be used as the rebinning factor instead of the recommended one.
-    rebin_by_spatial : Optional[int]
-        Whether to apply spatial rebinning. If an integer is provided, it will be used as the
-        rebinning factor. If None, no spatial rebinning is applied.
+    rebin_by_spatial : Optional[int | tuple[int, int]]
+        Whether to apply spatial rebinning. If an integer is provided, it is used as the
+        rebinning factor for both spatial axes. A ``(x, y)`` tuple selects per-axis rebinning
+        factors. If None, no spatial rebinning is applied.
     detector_shape : tuple[int, int]
         Shape of the TPX3 detector (default: (514, 514))
     event_id_offset : int

--- a/src/neunorm/pipelines/venus_tpx3_histogram.py
+++ b/src/neunorm/pipelines/venus_tpx3_histogram.py
@@ -80,9 +80,10 @@ def run_venus_tpx3_histogram_pipeline(  # noqa: C901
     rebin_by_tof : Optional[Union[bool,int]]
         Whether to apply TOF rebinning based on statistics analysis. If an integer is provided,
         it will be used as the rebinning factor instead of the recommended one.
-    rebin_by_spatial : Optional[int]
-        Whether to apply spatial rebinning. If an integer is provided, it will be used as the
-        rebinning factor. If None, no spatial rebinning is applied.
+    rebin_by_spatial : Optional[int | tuple[int, int]]
+        Whether to apply spatial rebinning. If a single integer is provided, it is used as the
+        rebinning factor for both spatial axes. A ``(rows, cols)`` tuple selects per-axis
+        rebinning factors (x and y). If None, no spatial rebinning is applied.
     flight_path : sc.Variable
         Source-to-detector flight path used for TOF→energy/wavelength coordinate labeling.
         Defaults to ``VENUS_FLIGHT_PATH_M`` (25 m); set it per detector/sample position.

--- a/src/neunorm/pipelines/venus_tpx3_histogram.py
+++ b/src/neunorm/pipelines/venus_tpx3_histogram.py
@@ -49,7 +49,7 @@ def run_venus_tpx3_histogram_pipeline(  # noqa: C901
     - ROI clip (optional)
     - Dead pixel detection
     - Hot pixel detection (TPX3-specific, even in histogram mode)
-    - Statistics analysis + rebinning recommendation
+    - Statistics analysis + rebinning recommendation (only when ``rebin_by_tof=True``)
     - Rebinning (TOF and/or spatial, optional)
     - Beam correction (proton charge)
     - Normalization (TOF-resolved)
@@ -82,7 +82,7 @@ def run_venus_tpx3_histogram_pipeline(  # noqa: C901
         it will be used as the rebinning factor instead of the recommended one.
     rebin_by_spatial : Optional[int | tuple[int, int]]
         Whether to apply spatial rebinning. If a single integer is provided, it is used as the
-        rebinning factor for both spatial axes. A ``(rows, cols)`` tuple selects per-axis
+        rebinning factor for both spatial axes. A ``(x, y)`` tuple selects per-axis
         rebinning factors (x and y). If None, no spatial rebinning is applied.
     flight_path : sc.Variable
         Source-to-detector flight path used for TOF→energy/wavelength coordinate labeling.

--- a/src/neunorm/processing/run_combiner.py
+++ b/src/neunorm/processing/run_combiner.py
@@ -28,7 +28,9 @@ def combine_runs(  # noqa: C901
     runs : list[sc.DataArray]
         List of DataArrays representing individual runs.
     metadata_keys_to_sum : Sequence[str], optional
-        Sequence of metadata keys to sum across runs, by default ("acquisition_time", "p_charge")
+        Sequence of metadata keys to aggregate across runs, by default ("acquisition_time", "p_charge").
+        These coordinates are summed across runs unless ``normalize_by_runs=True``, in which case they
+        are averaged instead.
     metadata_check_match : Sequence[str], optional
         Sequence of metadata keys that must match across all runs for combination, by default ()
     normalize_by_runs : bool, optional

--- a/src/neunorm/processing/uncertainty_calculator.py
+++ b/src/neunorm/processing/uncertainty_calculator.py
@@ -98,8 +98,8 @@ def add_systematic_variance(data: sc.DataArray, relative_uncertainty: float) -> 
 
     Examples
     --------
-    >>> data = sc.DataArray(data=sc.array(dims=['x'], values=[100, 200], unit='counts'))
-    >>> data.variances = np.array([100, 200])  # Poisson
+    >>> data = sc.DataArray(data=sc.array(dims=['x'], values=[100.0, 200.0], unit='counts'))
+    >>> data.variances = np.array([100.0, 200.0])  # Poisson (float data required for variances)
     >>> # Add 0.5% systematic (e.g., proton charge)
     >>> data_sys = add_systematic_variance(data, 0.005)
     >>> # var_total = 100 + (0.005*100)² = 100.25
@@ -143,8 +143,8 @@ def get_uncertainty(data: sc.DataArray) -> sc.DataArray:
 
     Examples
     --------
-    >>> data = sc.DataArray(data=sc.array(dims=['x'], values=[100], unit='counts'))
-    >>> data.variances = np.array([100])
+    >>> data = sc.DataArray(data=sc.array(dims=['x'], values=[100.0], unit='counts'))
+    >>> data.variances = np.array([100.0])  # float data required for variances
     >>> uncertainty = get_uncertainty(data)
     >>> print(uncertainty.values)  # [10.0]
     """
@@ -175,8 +175,8 @@ def get_relative_uncertainty(data: sc.DataArray) -> sc.DataArray:
 
     Examples
     --------
-    >>> data = sc.DataArray(data=sc.array(dims=['x'], values=[100, 400], unit='counts'))
-    >>> data.variances = np.array([100, 400])  # Poisson
+    >>> data = sc.DataArray(data=sc.array(dims=['x'], values=[100.0, 400.0], unit='counts'))
+    >>> data.variances = np.array([100.0, 400.0])  # Poisson (float data required for variances)
     >>> rel_unc = get_relative_uncertainty(data)
     >>> # For Poisson: σ/N = √N/N = 1/√N
     >>> print(rel_unc.values)  # [0.1, 0.05]

--- a/src/neunorm/tof/binning.py
+++ b/src/neunorm/tof/binning.py
@@ -4,7 +4,7 @@ Binning utilities for TOF/Energy/Wavelength conversions.
 Provides functions for:
 - Creating TOF bin edges from energy or wavelength specifications
 - Converting histograms between TOF/energy/wavelength spaces
-- Physics-based conversions using scipy.constants
+- Physics-based conversions using scipp.constants
 
 All conversions preserve variance (uncertainty) information.
 """
@@ -48,7 +48,7 @@ def tof_to_energy(tof: sc.Variable, flight_path: sc.Variable) -> sc.Variable:
 
     Notes
     -----
-    Uses scipy.constants.m_n for neutron mass (no hardcoded values).
+    Uses scipp.constants.m_n for neutron mass (no hardcoded values).
     Higher TOF → lower energy (inverse relationship).
 
     Examples
@@ -56,7 +56,7 @@ def tof_to_energy(tof: sc.Variable, flight_path: sc.Variable) -> sc.Variable:
     >>> tof = sc.scalar(1e-3, unit='s')  # 1 ms
     >>> L = sc.scalar(25.0, unit='m')
     >>> energy = tof_to_energy(tof, L)
-    >>> print(energy)  # ~5.2 eV
+    >>> print(energy)  # ~3.27 eV
     """
     # Check for zero or negative TOF
     tof_seconds = tof.to(unit="s")
@@ -95,7 +95,7 @@ def tof_to_wavelength(tof: sc.Variable, flight_path: sc.Variable) -> sc.Variable
 
     Notes
     -----
-    Uses scipy.constants.h and scipy.constants.m_n (no hardcoded values).
+    Uses scipp.constants.h and scipp.constants.m_n (no hardcoded values).
     Linear relationship: TOF ∝ wavelength.
 
     Examples
@@ -103,7 +103,7 @@ def tof_to_wavelength(tof: sc.Variable, flight_path: sc.Variable) -> sc.Variable
     >>> tof = sc.scalar(1e-3, unit='s')  # 1 ms
     >>> L = sc.scalar(25.0, unit='m')
     >>> wavelength = tof_to_wavelength(tof, L)
-    >>> print(wavelength)  # ~1.58 Å
+    >>> print(wavelength)  # ~0.158 Å
     """
     # λ = h * t / (m_n * L)
     # = (h / m_n) * (t / L)
@@ -135,7 +135,7 @@ def wavelength_to_energy(wavelength: sc.Variable) -> sc.Variable:
 
     Notes
     -----
-    Uses scipy.constants (no hardcoded values).
+    Uses scipp.constants (no hardcoded values).
     Inverse square relationship: E ∝ 1/λ².
 
     Examples
@@ -178,7 +178,7 @@ def energy_to_wavelength(energy: sc.Variable) -> sc.Variable:
 
     Notes
     -----
-    Uses scipy.constants (no hardcoded values).
+    Uses scipp.constants (no hardcoded values).
 
     Examples
     --------

--- a/src/neunorm/tof/histogram_rebinner.py
+++ b/src/neunorm/tof/histogram_rebinner.py
@@ -87,9 +87,13 @@ def rebin_tof(  # noqa: C901
         If `time`, width is interpreted as the desired width of the new TOF bins in the same unit as the coordinates.
         If `wavelength`, width is interpreted as the desired width of the new TOF bins in Angstrom units,
         and converted to time using the provided source-to-detector distance and detector time offset.
-        If `manual`, width is required to be a 1-D sc.Variable representing the explicit TOF bin edges;
-        its values are interpreted as TOF coordinate values (time-of-flight) and must be in, or convertible to,
-        the unit of the TOF coordinates, and are treated as bin edges rather than bin indices or counts.
+        If `manual`, width is required to be a 1-D sc.Variable (at least two values) representing the
+        desired edges of the new TOF bins. Its interpretation depends on the variable's unit:
+        if dimensionless, the values are treated as integer bin indices into the existing TOF coordinate
+        (must be of integer dtype and within bounds) and the corresponding original edges are selected;
+        otherwise the values are interpreted as explicit TOF edges in, or convertible to, the unit of the
+        TOF coordinates (a wavelength unit is also accepted and converted using `l_source_to_detector` and
+        `detector_time_offset`), and are then snapped to the nearest original edges on the left.
     logarithmic : bool
         Whether to use logarithmic binning. Default is False.
     tof_dim : str

--- a/src/neunorm/tof/pulse_reconstruction.py
+++ b/src/neunorm/tof/pulse_reconstruction.py
@@ -14,7 +14,7 @@ The algorithm handles:
 
 See Also
 --------
-examples/pulse_reconstruction_tutorial.ipynb : Interactive tutorial with visualizations
+examples/pulse_reconstruction_explained.ipynb : Interactive walkthrough with visualizations
 tests/unit/test_pulse_reconstruction.py : Unit tests and usage examples
 """
 
@@ -72,7 +72,7 @@ def _cluster_rollovers(
     Identify first rollover in each cluster.
 
     This is the JIT-compiled helper for _clean_clustered_rollovers.
-    Returns an array of indices (into rollover_indices) that should be kept.
+    Returns a boolean mask (over rollover_indices) marking which to keep.
 
     Parameters
     ----------
@@ -453,14 +453,17 @@ def reconstruct_pulse_ids(  # noqa: C901
     >>> from neunorm.loaders.event_loader import load_event_data
     >>> from neunorm.tof.pulse_reconstruction import reconstruct_pulse_ids
     >>> events = load_event_data('run_12557.h5')
-    >>> pulse_ids = reconstruct_pulse_ids(events.tof)
+    >>> # load_event_data stores TOF in nanoseconds; this API expects milliseconds
+    >>> tof_ms = events.tof / 1e6
+    >>> pulse_ids = reconstruct_pulse_ids(tof_ms)
     >>> print(f"Found {pulse_ids.max() + 1} pulses")
 
     Multi-chip detector (VENUS quad) with parallel processing:
 
     >>> events = load_event_data('run_14749.h5')  # Has chip_id field
+    >>> tof_ms = events.tof / 1e6  # nanoseconds -> milliseconds
     >>> pulse_ids = reconstruct_pulse_ids(
-    ...     events.tof,
+    ...     tof_ms,
     ...     chip_id=events.chip_id,
     ...     threshold=-10.0,
     ...     late_margin=14.0,

--- a/src/neunorm/tof/pulse_reconstruction.py
+++ b/src/neunorm/tof/pulse_reconstruction.py
@@ -460,25 +460,27 @@ def reconstruct_pulse_ids(  # noqa: C901
 
     Multi-chip detector (VENUS quad) with parallel processing:
 
-    >>> events = load_event_data('run_14749.h5')  # Has chip_id field
+    >>> events = load_event_data('run_14749.h5')
     >>> tof_ms = events.tof / 1e6  # nanoseconds -> milliseconds
+    >>> # chip_id is supplied by the caller (the loaders do not populate it):
+    >>> # a 1D int array (0-3 for a quad detector), same length as events.tof
     >>> pulse_ids = reconstruct_pulse_ids(
     ...     tof_ms,
-    ...     chip_id=events.chip_id,
+    ...     chip_id=chip_id,
     ...     threshold=-10.0,
     ...     late_margin=14.0,
     ...     n_jobs=4,  # Process 4 chips in parallel
     ... )
     >>> # Pulse IDs synchronized across all 4 chips
     >>> for chip in range(4):
-    ...     mask = events.chip_id == chip
+    ...     mask = chip_id == chip
     ...     print(f"Chip {chip}: {pulse_ids[mask].max() + 1} pulses")
 
-    Filter events by pulse:
+    Filter events by pulse (EventData is not indexable - filter the arrays):
 
     >>> # Skip first 5 pulses (warmup)
     >>> valid_mask = pulse_ids >= 5
-    >>> events_filtered = events[valid_mask]
+    >>> tof_kept = events.tof[valid_mask]
     """
     # Validate n_jobs parameter
     if n_jobs is not None:

--- a/src/neunorm/tof/pulse_reconstruction.py
+++ b/src/neunorm/tof/pulse_reconstruction.py
@@ -460,10 +460,12 @@ def reconstruct_pulse_ids(  # noqa: C901
 
     Multi-chip detector (VENUS quad) with parallel processing:
 
+    >>> import numpy as np
     >>> events = load_event_data('run_14749.h5')
     >>> tof_ms = events.tof / 1e6  # nanoseconds -> milliseconds
-    >>> # chip_id is supplied by the caller (the loaders do not populate it):
-    >>> # a 1D int array (0-3 for a quad detector), same length as events.tof
+    >>> # chip_id is caller-supplied (the loaders do not populate it): a 1D int
+    >>> # array (0-3 for a quad detector), same length as events.tof
+    >>> chip_id = np.zeros_like(events.tof, dtype=int)  # replace with real per-event chip IDs
     >>> pulse_ids = reconstruct_pulse_ids(
     ...     tof_ms,
     ...     chip_id=chip_id,
@@ -472,7 +474,7 @@ def reconstruct_pulse_ids(  # noqa: C901
     ...     n_jobs=4,  # Process 4 chips in parallel
     ... )
     >>> # Pulse IDs synchronized across all 4 chips
-    >>> for chip in range(4):
+    >>> for chip in np.unique(chip_id):  # robust: only chips actually present
     ...     mask = chip_id == chip
     ...     print(f"Chip {chip}: {pulse_ids[mask].max() + 1} pulses")
 

--- a/src/neunorm/tof/resonance.py
+++ b/src/neunorm/tof/resonance.py
@@ -197,7 +197,7 @@ def detect_resonances(
         - 'n_initial': int, peaks after initial detection
         - 'n_snr_filtered': int, peaks after SNR filter
         - 'n_shape_filtered': int, peaks after shape filter
-        - 'validation': dict (if known_resonances provided)
+        - 'validation': dict, only when ``known_resonances`` is given and at least one peak survives filtering
 
     Examples
     --------

--- a/src/neunorm/tof/resonance.py
+++ b/src/neunorm/tof/resonance.py
@@ -197,7 +197,7 @@ def detect_resonances(
         - 'n_initial': int, peaks after initial detection
         - 'n_snr_filtered': int, peaks after SNR filter
         - 'n_shape_filtered': int, peaks after shape filter
-        - 'validation': dict, only when ``known_resonances`` is given and at least one peak survives filtering
+        - 'validation': dict, only when ``known_resonances`` is given and at least one peak passes the SNR filter
 
     Examples
     --------


### PR DESCRIPTION
Resolves #161 (Theme 2 of the documentation-accuracy epic #164).

Reconciles the NumPy-style docstrings (rendered into the API reference by Sphinx autodoc) across `src/neunorm/**` with the actual signatures and behavior. **Docstring/comment-only — no code logic changed** (independently verified: every changed line is module-docstring / Parameters-Returns prose / `>>>` example text; all 15 fixers reported `docstring_only=true`).

## Highlights (28 fixes, 15 files)
- **hdf5_writer** — output dataset is `/tof` (not `/tof_bin_edges`); `/uncertainty`, `/masks/*`, `/metadata` marked conditional; only *non-JSON-serializable* leaves are coerced via `str()`.
- **tiff_writer** — stdevs + mask are packed into the same stack (`concat_stdevs_and_mask=True`), not a separate file.
- **event_loader** — document the default `bank1` (no auto-detect), `KeyError` (not `ValueError`) for a missing bank, and the `event_id_offset` parameter.
- **binning** — corrected example values (`tof_to_energy` ~3.27 eV, `tof_to_wavelength` ~0.158 Å) and `scipp.constants` (not `scipy.constants`).
- **pipelines** — `rebin_by_spatial` typed `Optional[int | tuple[int, int]]`; `run_combiner` summed keys are averaged when `normalize_by_runs=True`.
- **data_models** — document `EventData.chip_id`/`pulse_id`; narrow the module docstring to event data.
- **misc** — `histogram_rebinner` manual=bin-index note; `pulse_reconstruction` units / See-Also / return-type; `resonance` `'validation'` conditional; loader coord-scalar-vs-stack notes.

## Scope
- **Excludes** the `tof_clock` docstring (`event_loader.py:32-34`) — per #161's note it rides with the code decision in **#163**.
- Two multi-line docstring additions caused reST "unexpected indentation" warnings; fixed by collapsing to single lines.

## Verification
- `pixi run build-docs` (sphinx `-W`): clean apart from a transient, unrelated intersphinx SSL fetch of `docs.scipy.org` (passed clean earlier today on the same setup).
- `pre-commit` (ruff check + format, codespell) clean.
- `/review-pipeline` (dual-family Claude + Codex) + Copilot review to follow on this PR before it's marked ready.

Assisted-With: Claude Opus 4.8 <noreply@anthropic.com>