### PR TITLE
docs(reference): fix stale module/task names + rewrite scoping module tables (#162)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ This is a **Pixi** project (`pyproject.toml` `[tool.pixi.*]` + `pixi.lock`).
   `update-lockfiles` workflow is pinned to the same pixi for this reason.
 
 Key tasks (`[tool.pixi.tasks]`): `test`, `build-docs`, `conda-build`,
-`pypi-build`, `audit-deps`, `clean*`.
+`pypi-build`, `clean*`.
 
 ## Layout
 

--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ Where:
 
 | Detector Type | Dark Correction | Beam Correction | Hot Pixels |
 |---------------|-----------------|-----------------|------------|
-| CCD/CMOS | Required | Time or p_charge | Not needed |
+| CCD/CMOS | Optional | Time or p_charge | Not needed |
 | TPX1 (histogram) | Not needed | p_charge or shutter | Not needed |
-| TPX3 (event/histogram) | Not needed | p_charge | Required |
+| TPX3 (event/histogram) | Not needed | p_charge (VENUS); none (MARS) | Required |
 
 ### Uncertainty Propagation
 
@@ -175,7 +175,7 @@ This enables **hyperspectral imaging** with wavelength-resolved transmission T(Î
 
 - **Data Models**: Pydantic v2 for validation
 - **Array Processing**: scipp with automatic variance propagation
-- **TIFF I/O**: scitiff (scipp ecosystem)
+- **TIFF I/O**: Pillow (input), scitiff (output)
 - **Performance**: Numba JIT for hot paths (optional, via the `performance` extra)
 - **Testing**: pytest with coverage
 

--- a/docs/development/DEVELOPMENT_PLAN.md
+++ b/docs/development/DEVELOPMENT_PLAN.md
@@ -6,7 +6,7 @@ Phased development plan to complete NeuNorm v2.0, building on existing codebase 
 
 ## Current State Assessment
 
-### Already Implemented (`/NeuNorm/src/NeuNorm/`)
+### Already Implemented (`/NeuNorm/src/neunorm/`)
 | Module | Status | Description |
 |--------|--------|-------------|
 | `data_models/core.py` | Complete | EventData (Pydantic v2) |
@@ -250,9 +250,9 @@ NeuNorm/docs/
 ## Critical Files Reference
 
 **Patterns to follow**:
-- `NeuNorm/src/NeuNorm/loaders/event_loader.py` - Loader pattern
-- `NeuNorm/src/NeuNorm/processing/normalizer.py` - Processing module pattern
-- `NeuNorm/src/NeuNorm/tof/pixel_detector.py` - Detection algorithm pattern
+- `NeuNorm/src/neunorm/loaders/event_loader.py` - Loader pattern
+- `NeuNorm/src/neunorm/processing/normalizer.py` - Processing module pattern
+- `NeuNorm/src/neunorm/tof/pixel_detector.py` - Detection algorithm pattern
 
 **Legacy code for reference**:
 - `NeuNorm/archive/neunorm-1.x/NeuNorm/normalization.py` - TIFF loading, gamma filtering patterns

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ imaging facilities — MARS at HFIR and VENUS at SNS.
 
 NeuNorm 2.0 is a complete, scipp-based rewrite of the library. It provides
 end-to-end pipelines (TIFF/FITS/event loading, dark/gamma correction, flat-field
-normalization, TOF binning, resonance and Bragg-edge analysis) with HDF5 as the
+normalization, TOF binning, resonance detection and Bragg-edge imaging) with HDF5 as the
 primary output format.
 
 ```{note}

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -44,7 +44,7 @@ o_norm.load(folder="/data/ob/", data_type="ob")
 o_norm.load(folder="/data/df/", data_type="df")   # dark / "df" frames
 o_norm.normalization()
 o_norm.export(folder="/data/normalized/", data_type="normalized")
-normalized = o_norm.get_normalized_data()           # NumPy array
+normalized = o_norm.get_normalized_data()           # list of NumPy arrays
 ```
 
 **2.0** (MARS CCD/CMOS — continuous source, the closest analogue to the 1.x CCD case)
@@ -106,7 +106,7 @@ transmission = normalize_transmission(sample, ob)  # T = sample / ob, variances 
 | `Normalization()` (stateful object) | a `run_*_pipeline(...)` call, or composable functions |
 | `.load(..., data_type="sample"/"ob")` | pipeline `sample_paths` / `ob_paths`, or `neunorm.loaders.stack_loader.load_stack` / `tiff_loader.load_tiff_stack` / `fits_loader.load_fits_stack` |
 | `.load(..., data_type="df")` (dark/"df") | pipeline `dark_paths`, or `neunorm.processing.dark_corrector.subtract_dark(data, dark)` |
-| `.normalization(roi=...)` | `run_*_pipeline(..., roi=...)`, or `neunorm.processing.normalizer.normalize_transmission(sample, ob, ...)` |
+| `.normalization(roi=...)` | Flux normalization by a background ROI — not yet in 2.x; planned as `background_roi=` ([#159](https://github.com/ornlneutronimaging/NeuNorm/issues/159)). Note: 2.x `roi=` is a spatial **crop** (`apply_roi`), not this. |
 | `.df_correction()` | `neunorm.processing.dark_corrector.subtract_dark(data, dark)` |
 | `.crop(roi=ROI(...))` | `neunorm.processing.roi_clipper.apply_roi(data, (x0, y0, x1, y1))` |
 | auto/manual gamma filtering on `load()` | `neunorm.filters.gamma_filter.apply_gamma_filter(...)`, or pipeline `gamma_filter=True` |
@@ -125,7 +125,7 @@ from NeuNorm.roi import ROI
 roi = ROI(x0=10, y0=10, x1=110, y1=110)
 
 # 2.0
-roi = (10, 10, 110, 110)   # (x0, y0, x1, y1), pixel bounds
+roi = (10, 10, 111, 111)   # (x0, y0, x1, y1); 2.x stops are EXCLUSIVE (1.x x1/y1 were inclusive)
 ```
 
 ## Working with the result

--- a/docs/workflows/README.md
+++ b/docs/workflows/README.md
@@ -55,7 +55,7 @@ This directory contains detector-centric data reduction workflows for scoping Ne
 |--------|-------------|
 | `processing.normalizer` | Compute transmission T = Sample/OB |
 | `processing.uncertainty_calculator` | Error propagation |
-| `tof.pixel_detector` | Identify zero-count pixels |
+| `tof.pixel_detector` (`detect_dead_pixels`) | Identify zero-count pixels |
 | `processing.roi_clipper` | Apply region of interest |
 | `processing.run_combiner` | Aggregate multiple acquisitions |
 | `exporters.hdf5_writer` | Write results |
@@ -80,15 +80,14 @@ This directory contains detector-centric data reduction workflows for scoping Ne
 | Module | Used By |
 |--------|---------|
 | `processing.dark_corrector` | CCD/CMOS only |
-| `processing.normalizer` | VENUS all |
+| `processing.normalizer` (p_charge term) | VENUS all |
 | `filters.gamma_filter` | MARS all |
-| `tof.pixel_detector` | TPX3, TPX4 |
+| `tof.pixel_detector` (`detect_hot_pixels`) | TPX3, TPX4 |
 
 ### TOF Processing
 
 | Module | Used By |
 |--------|---------|
-| `tof.statistics_analyzer` | TPX1, TPX3, TPX4 |
 | `tof.statistics_analyzer` | TPX1, TPX3, TPX4 |
 | `tof.histogram_rebinner` | TPX1, TPX3, TPX4 |
 | `tof.coordinate_converter` | TPX1, TPX3, TPX4 |

--- a/docs/workflows/README.md
+++ b/docs/workflows/README.md
@@ -55,10 +55,10 @@ This directory contains detector-centric data reduction workflows for scoping Ne
 |--------|-------------|
 | `processing.normalizer` | Compute transmission T = Sample/OB |
 | `processing.uncertainty_calculator` | Error propagation |
-| `processing.dead_pixel_detector` | Identify zero-count pixels |
+| `tof.pixel_detector` | Identify zero-count pixels |
 | `processing.roi_clipper` | Apply region of interest |
 | `processing.run_combiner` | Aggregate multiple acquisitions |
-| `exporters.output_writer` | Write results |
+| `exporters.hdf5_writer` | Write results |
 
 ### Histogram Loaders
 
@@ -80,17 +80,17 @@ This directory contains detector-centric data reduction workflows for scoping Ne
 | Module | Used By |
 |--------|---------|
 | `processing.dark_corrector` | CCD/CMOS only |
-| `processing.beam_corrector` | VENUS all |
+| `processing.normalizer` | VENUS all |
 | `filters.gamma_filter` | MARS all |
-| `processing.hot_pixel_detector` | TPX3, TPX4 |
+| `tof.pixel_detector` | TPX3, TPX4 |
 
 ### TOF Processing
 
 | Module | Used By |
 |--------|---------|
 | `tof.statistics_analyzer` | TPX1, TPX3, TPX4 |
-| `tof.binning_recommender` | TPX1, TPX3, TPX4 |
-| `tof.rebinner` | TPX1, TPX3, TPX4 |
+| `tof.statistics_analyzer` | TPX1, TPX3, TPX4 |
+| `tof.histogram_rebinner` | TPX1, TPX3, TPX4 |
 | `tof.coordinate_converter` | TPX1, TPX3, TPX4 |
 
 ---
@@ -147,8 +147,8 @@ Based on complexity and shared dependencies:
 | MARS CCD/CMOS | 3D | 3D | - | 2D | - |
 | MARS TPX3 | 3D | 3D | - | 2D | 2D |
 | VENUS CCD/CMOS | 3D | 3D | - | 2D | - |
-| VENUS TPX1 | 4D | 4D | 1D | 2D | - |
-| VENUS TPX3 | 4D | 4D | 1D | 2D | 2D |
+| VENUS TPX1 | 3D | 3D | 1D | 2D | - |
+| VENUS TPX3 | 3D | 3D | 1D | 2D | 2D |
 | VENUS TPX4 | 4D | 4D | 1D | 2D | 2D |
 
 ---

--- a/docs/workflows/README.md
+++ b/docs/workflows/README.md
@@ -58,7 +58,7 @@ This directory contains detector-centric data reduction workflows for scoping Ne
 | `tof.pixel_detector` (`detect_dead_pixels`) | Identify zero-count pixels |
 | `processing.roi_clipper` | Apply region of interest |
 | `processing.run_combiner` | Aggregate multiple acquisitions |
-| `exporters.hdf5_writer` | Write results |
+| `exporters.hdf5_writer` / `exporters.tiff_writer` | Write results (HDF5 primary; TIFF optional) |
 
 ### Histogram Loaders
 

--- a/docs/workflows/mars_tpx3.md
+++ b/docs/workflows/mars_tpx3.md
@@ -302,12 +302,12 @@ flowchart TD
 | `tof.event_converter` | Convert events to histogram | P0 |
 | `processing.run_combiner` | Aggregate multiple runs | P1 |
 | `processing.roi_clipper` | Apply ROI to arrays | P1 |
-| `processing.dead_pixel_detector` | Identify dead pixels | P0 |
-| `processing.hot_pixel_detector` | Identify hot pixels (TPX3) | P0 |
+| `tof.pixel_detector` | Identify dead pixels | P0 |
+| `tof.pixel_detector` | Identify hot pixels (TPX3) | P0 |
 | `filters.gamma_filter` | Remove gamma contamination | P0 |
 | `processing.normalizer` | Compute transmission | P0 |
 | `processing.uncertainty_calculator` | Error propagation | P0 |
-| `exporters.output_writer` | Write results | P0 |
+| `exporters.hdf5_writer` | Write results | P0 |
 
 ### Data Models
 

--- a/docs/workflows/mars_tpx3.md
+++ b/docs/workflows/mars_tpx3.md
@@ -307,7 +307,7 @@ flowchart TD
 | `filters.gamma_filter` | Remove gamma contamination | P0 |
 | `processing.normalizer` | Compute transmission | P0 |
 | `processing.uncertainty_calculator` | Error propagation | P0 |
-| `exporters.hdf5_writer` | Write results | P0 |
+| `exporters.hdf5_writer` / `exporters.tiff_writer` | Write results (HDF5 primary; TIFF optional) | P0 |
 
 ### Data Models
 

--- a/docs/workflows/venus_ccd_cmos.md
+++ b/docs/workflows/venus_ccd_cmos.md
@@ -348,14 +348,14 @@ detectors) and halves the in-memory footprint of large stacks.
 | `loaders.metadata_loader` | Extract p_charge from DAQ | P0 |
 | `processing.run_combiner` | Aggregate multiple runs | P0 (critical for VENUS) |
 | `processing.roi_clipper` | Apply ROI to arrays | P1 |
-| `processing.dead_pixel_detector` | Identify dead pixels | P0 |
+| `tof.pixel_detector` | Identify dead pixels | P0 |
 | `filters.gamma_filter` | Remove gamma contamination | P1 |
 | `processing.dark_corrector` | Subtract dark current | P0 |
-| `processing.beam_corrector` | Apply p_charge correction | P0 |
+| `processing.normalizer` | Apply p_charge correction | P0 |
 | `processing.normalizer` | Compute transmission | P0 |
 | `processing.air_region_corrector` | Optional post-normalization correction | P1 |
 | `processing.uncertainty_calculator` | Error propagation | P0 |
-| `exporters.output_writer` | Write results | P0 |
+| `exporters.hdf5_writer` | Write results | P0 |
 
 ### Data Models
 

--- a/docs/workflows/venus_ccd_cmos.md
+++ b/docs/workflows/venus_ccd_cmos.md
@@ -355,7 +355,7 @@ detectors) and halves the in-memory footprint of large stacks.
 | `processing.normalizer` | Compute transmission | P0 |
 | `processing.air_region_corrector` | Optional post-normalization correction | P1 |
 | `processing.uncertainty_calculator` | Error propagation | P0 |
-| `exporters.hdf5_writer` | Write results | P0 |
+| `exporters.hdf5_writer` / `exporters.tiff_writer` | Write results (HDF5 primary; TIFF optional) | P0 |
 
 ### Data Models
 

--- a/docs/workflows/venus_tpx1.md
+++ b/docs/workflows/venus_tpx1.md
@@ -423,7 +423,7 @@ TPX1 histogram data has fixed TOF bins determined at acquisition. Rebinning opti
 | `processing.air_region_corrector` | Optional post-normalization correction | P1 |
 | `processing.uncertainty_calculator` | Error propagation | P0 |
 | `tof.coordinate_converter` | TOF ↔ λ ↔ E | P1 |
-| `exporters.hdf5_writer` | Write results | P0 |
+| `exporters.hdf5_writer` / `exporters.tiff_writer` | Write results (HDF5 primary; TIFF optional) | P0 |
 
 ### Data Models
 

--- a/docs/workflows/venus_tpx1.md
+++ b/docs/workflows/venus_tpx1.md
@@ -414,16 +414,16 @@ TPX1 histogram data has fixed TOF bins determined at acquisition. Rebinning opti
 | `loaders.metadata_loader` | Extract p_charge, shutter_counts, TOF edges | P0 |
 | `processing.run_combiner` | Aggregate multiple runs | P0 |
 | `processing.roi_clipper` | Apply ROI to arrays | P1 |
-| `processing.dead_pixel_detector` | Identify dead pixels | P0 |
+| `tof.pixel_detector` | Identify dead pixels | P0 |
 | `tof.statistics_analyzer` | Analyze bin occupancy, compute SNR | P0 |
 | `tof.histogram_rebinner` | Combine adjacent TOF bins | P0 |
 | `processing.spatial_rebinner` | Combine NxN pixel blocks | P1 |
-| `processing.beam_corrector` | Apply p_charge correction | P0 |
+| `processing.normalizer` | Apply p_charge correction | P0 |
 | `processing.normalizer` | Compute transmission | P0 |
 | `processing.air_region_corrector` | Optional post-normalization correction | P1 |
 | `processing.uncertainty_calculator` | Error propagation | P0 |
 | `tof.coordinate_converter` | TOF ↔ λ ↔ E | P1 |
-| `exporters.output_writer` | Write results | P0 |
+| `exporters.hdf5_writer` | Write results | P0 |
 
 ### Data Models
 

--- a/docs/workflows/venus_tpx3.md
+++ b/docs/workflows/venus_tpx3.md
@@ -526,16 +526,16 @@ Performance:
 | `tof.event_converter` | Events → 3D histogram | P0 |
 | `processing.run_combiner` | Aggregate multiple runs | P0 |
 | `processing.roi_clipper` | Apply ROI | P1 |
-| `processing.dead_pixel_detector` | Identify dead pixels | P0 |
-| `processing.hot_pixel_detector` | Identify hot pixels | P0 |
+| `tof.pixel_detector` | Identify dead pixels | P0 |
+| `tof.pixel_detector` | Identify hot pixels | P0 |
 | `tof.statistics_analyzer` | Analyze bin occupancy | P0 |
-| `tof.binning_recommender` | Recommend rebinning | P0 |
-| `tof.rebinner` | Apply rebinning | P0 |
-| `processing.beam_corrector` | Apply p_charge correction | P0 |
+| `tof.statistics_analyzer` | Recommend rebinning | P0 |
+| `tof.histogram_rebinner` | Apply rebinning | P0 |
+| `processing.normalizer` | Apply p_charge correction | P0 |
 | `processing.normalizer` | Compute transmission | P0 |
 | `processing.uncertainty_calculator` | Error propagation | P0 |
 | `tof.coordinate_converter` | TOF ↔ λ ↔ E | P1 |
-| `exporters.output_writer` | Write results | P0 |
+| `exporters.hdf5_writer` | Write results | P0 |
 
 ### Data Models
 
@@ -992,14 +992,14 @@ Histogram mode shares most modules with event mode and TPX1:
 | `loaders.metadata_loader` | TPX1 | Extract TOF bins, p_charge |
 | `processing.run_combiner` | Event mode | Sum histograms |
 | `processing.roi_clipper` | Event mode | Apply ROI |
-| `processing.dead_pixel_detector` | Event mode | Same algorithm |
-| `processing.hot_pixel_detector` | Event mode | TPX3-specific |
+| `tof.pixel_detector` | Event mode | Same algorithm |
+| `tof.pixel_detector` | Event mode | TPX3-specific |
 | `tof.statistics_analyzer` | Event mode | Same algorithm |
-| `tof.rebinner` | TPX1 | Adjacent-bin combining |
-| `processing.beam_corrector` | Event mode | p_charge correction |
+| `tof.histogram_rebinner` | TPX1 | Adjacent-bin combining |
+| `processing.normalizer` | Event mode | p_charge correction |
 | `processing.normalizer` | Event mode | Same algorithm |
 | `processing.uncertainty_calculator` | Event mode | Same algorithm |
-| `exporters.output_writer` | Event mode | Same output format |
+| `exporters.hdf5_writer` | Event mode | Same output format |
 
 ---
 

--- a/docs/workflows/venus_tpx3.md
+++ b/docs/workflows/venus_tpx3.md
@@ -534,7 +534,7 @@ Performance:
 | `processing.normalizer` | Compute transmission | P0 |
 | `processing.uncertainty_calculator` | Error propagation | P0 |
 | `tof.coordinate_converter` | TOF ↔ λ ↔ E | P1 |
-| `exporters.hdf5_writer` | Write results | P0 |
+| `exporters.hdf5_writer` / `exporters.tiff_writer` | Write results (HDF5 primary; TIFF optional) | P0 |
 
 ### Data Models
 
@@ -998,7 +998,7 @@ Histogram mode shares most modules with event mode and TPX1:
 | `processing.normalizer` | Event mode | p_charge correction |
 | `processing.normalizer` | Event mode | Same algorithm |
 | `processing.uncertainty_calculator` | Event mode | Same algorithm |
-| `exporters.hdf5_writer` | Event mode | Same output format |
+| `exporters.hdf5_writer` / `exporters.tiff_writer` | Event mode | Same output format (HDF5 + optional TIFF) |
 
 ---
 

--- a/docs/workflows/venus_tpx3.md
+++ b/docs/workflows/venus_tpx3.md
@@ -105,8 +105,8 @@ flowchart TD
     end
 
     subgraph Output["15. Output"]
-        O1[Transmission 4D]
-        O2[Uncertainty 4D]
+        O1[Transmission 3D]
+        O2[Uncertainty 3D]
         O3[TOF Bin Edges]
         O4[Dead Pixel Mask]
         O5[Hot Pixel Mask]
@@ -521,7 +521,6 @@ Performance:
 | Component | Purpose | Priority |
 |-----------|---------|----------|
 | `loaders.event_loader` | Load TPX3 HDF5 event files | P0 |
-| `loaders.pulse_loader` | Load DAQ pulse timestamps | P0 |
 | `tof.pulse_reconstruction` | Assign events to pulses | P0 |
 | `tof.event_converter` | Events → 3D histogram | P0 |
 | `processing.run_combiner` | Aggregate multiple runs | P0 |
@@ -680,8 +679,8 @@ flowchart TD
     end
 
     subgraph Output["12. Output"]
-        O1[Transmission 4D]
-        O2[Uncertainty 4D]
+        O1[Transmission 3D]
+        O2[Uncertainty 3D]
         O3[TOF Bin Edges]
         O4[Dead Pixel Mask]
         O5[Hot Pixel Mask]


### PR DESCRIPTION
Resolves #162 (Theme 3 of the documentation-accuracy epic #164). Reference / index / scoping-doc corrections — **doc-only, no code changes**.

## Highlights
- **Scoping/Required-Modules tables rewritten to real module names** (wholesale, across `docs/workflows/README.md` + 5 guides, 26 cells):

  | Notional | Real |
  |---|---|
  | `processing.dead_pixel_detector` / `hot_pixel_detector` | `tof.pixel_detector` |
  | `processing.beam_corrector` | `processing.normalizer` (proton-charge) |
  | `exporters.output_writer` | `exporters.hdf5_writer` |
  | `tof.rebinner` | `tof.histogram_rebinner` |
  | `tof.binning_recommender` | `tof.statistics_analyzer` |

- **`AGENTS.md`** — drop the non-existent `audit-deps` pixi task (dependency scanning is a CI workflow).
- **`README.md`** — CCD dark correction is **Optional** (not Required, #146); TPX3 beam correction split (**VENUS** p_charge / **MARS** none); TIFF **input via Pillow, output via scitiff**.
- **`migration.md`** — 1.x `.normalization(roi=...)` maps to the planned **`background_roi`** (#159), **not** a crop `roi=`; 2.x ROI stop bounds are **exclusive** (use `111` to match 1.x inclusive `110`); `get_normalized_data()` returns a **list** of arrays.
- **`docs/workflows/README.md`** — VENUS TPX1 **and** TPX3 transmission/error are **3D** (no θ axis), matching the corrected guides.
- **`docs/index.md`** — "resonance detection and Bragg-edge imaging".
- **`DEVELOPMENT_PLAN.md`** — `src/NeuNorm` → `src/neunorm` path casing (4 spots).

This also clears the per-guide module tables deferred from the Theme 1 PR (#165).

## Verification
- `pixi run build-docs` (sphinx `-W`) — build succeeded, 0 warnings.
- `pre-commit` (codespell etc.) clean.
- `/review-pipeline` (dual-family) + Copilot review to follow on this PR before it's marked ready.

Assisted-With: Claude Opus 4.8 <noreply@anthropic.com>