### PR TITLE
fix: resolve latent code-smells surfaced by the doc-accuracy audit (#163)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`EventData` is now indexable, plus an `assign_chip_ids` helper.** `events[mask]` (boolean
+  mask, index array, or slice) returns a new `EventData` with every per-event array filtered.
+  `neunorm.tof.pulse_reconstruction.assign_chip_ids(x, y, detector_shape)` derives a chip id (0–3)
+  from the pixel quadrant for a 2×2 quad Timepix3 detector, giving multi-chip
+  `reconstruct_pulse_ids` a data source (the loaders do not record the originating chip).
+  ([#163](https://github.com/ornlneutronimaging/NeuNorm/issues/163))
+
+### Fixed
+
+- **`load_event_data` no longer truncates a fractional TOF clock.** The raw-tick → nanosecond
+  conversion now multiplies by the full `tof_clock` and rounds to `int64` ns; previously
+  `int(tof_clock)` truncated a fractional clock (e.g. the ~1.5625 ns TPX3 fine clock to 1 ns).
+  ([#163](https://github.com/ornlneutronimaging/NeuNorm/issues/163))
+- **`normalize_transmission` rejects a one-sided proton-charge correction.** Supplying only one of
+  `proton_charge_sample` / `proton_charge_ob` produced a non-dimensionless transmission; it now
+  raises `ValueError` (both or neither). The pipelines always pass both, so behavior is unchanged.
+  ([#163](https://github.com/ornlneutronimaging/NeuNorm/issues/163))
+- **`combine_runs` no longer aliases caller data for a single run.** It returns a copy (matching
+  the multi-run path), so mutating the combined result cannot leak back into the caller's input.
+  ([#163](https://github.com/ornlneutronimaging/NeuNorm/issues/163))
+
 ## [2.1.0] - 2026-06-18
 
 ### Changed

--- a/src/neunorm/data_models/core.py
+++ b/src/neunorm/data_models/core.py
@@ -161,6 +161,11 @@ class EventData(BaseModel):
         --------
         >>> kept = events[pulse_ids >= 5]  # drop warmup pulses
         """
+        if isinstance(key, (int, np.integer)):
+            raise TypeError(
+                "EventData indexing requires a boolean mask, index array, or slice; scalar "
+                "integer indexing is not supported (it would produce 0-D arrays)."
+            )
         tof = self.tof[key]
         return EventData(
             tof=tof,

--- a/src/neunorm/data_models/core.py
+++ b/src/neunorm/data_models/core.py
@@ -148,6 +148,31 @@ class EventData(BaseModel):
         """Return number of events in this dataset"""
         return len(self.tof)
 
+    def __getitem__(self, key):
+        """Return a new EventData with all per-event arrays filtered by ``key``.
+
+        ``key`` is anything that indexes a 1D NumPy array while preserving 1D shape — a
+        boolean mask, an integer-index array, or a slice (a plain scalar ``int`` is not
+        supported, since it would yield 0-D arrays). Optional ``chip_id`` / ``pulse_id``
+        arrays are filtered when present; scalar metadata (``file_path``, ``tof_clock``)
+        is carried over and ``total_events`` is recomputed.
+
+        Examples
+        --------
+        >>> kept = events[pulse_ids >= 5]  # drop warmup pulses
+        """
+        tof = self.tof[key]
+        return EventData(
+            tof=tof,
+            x=self.x[key],
+            y=self.y[key],
+            chip_id=None if self.chip_id is None else self.chip_id[key],
+            pulse_id=None if self.pulse_id is None else self.pulse_id[key],
+            file_path=self.file_path,
+            total_events=len(tof),
+            tof_clock=self.tof_clock,
+        )
+
     def __repr__(self):
         return (
             f"EventData(\n"

--- a/src/neunorm/loaders/event_loader.py
+++ b/src/neunorm/loaders/event_loader.py
@@ -87,8 +87,10 @@ def load_event_data(
         x = f["x"][:n_events].astype(np.int32)
         y = f["y"][:n_events].astype(np.int32)
 
-    # Convert TOF ticks to nanoseconds
-    tof_ns = tof_raw * int(tof_clock)
+    # Convert TOF ticks to nanoseconds. Multiply by the full (possibly fractional) clock
+    # period, then round to integer ns — int(tof_clock) would truncate a fractional clock
+    # (e.g. the ~1.5625 ns TPX3 fine clock to 1, a ~37% error).
+    tof_ns = np.round(tof_raw * tof_clock).astype(np.int64)
 
     logger.info(f"  TOF range: {tof_ns.min():,} - {tof_ns.max():,} ns")
     logger.info(f"  X range: [{x.min()}, {x.max()}]")

--- a/src/neunorm/processing/normalizer.py
+++ b/src/neunorm/processing/normalizer.py
@@ -74,6 +74,14 @@ def normalize_transmission(  # noqa: C901
     """
     logger.info("Normalizing transmission: T = Sample / OB")
 
+    # Proton-charge correction must be applied to both sample and OB, or to neither: a one-sided
+    # correction leaves counts/charge uncancelled, so the transmission would not be dimensionless.
+    if (proton_charge_sample is None) != (proton_charge_ob is None):
+        raise ValueError(
+            "proton_charge_sample and proton_charge_ob must both be provided or both omitted; "
+            "a one-sided proton-charge correction yields a non-dimensionless transmission."
+        )
+
     # Apply proton charge corrections if provided
     if proton_charge_sample is not None:
         if isinstance(proton_charge_sample, sc.Variable):

--- a/src/neunorm/processing/run_combiner.py
+++ b/src/neunorm/processing/run_combiner.py
@@ -47,7 +47,9 @@ def combine_runs(  # noqa: C901
         raise ValueError("No runs provided for combination")
 
     if len(runs) == 1:
-        return runs[0]
+        # Return a copy so the combined result never aliases caller-owned data
+        # (the multi-run path below also builds a fresh array via .copy()).
+        return runs[0].copy()
 
     # Validate all runs have the same shape, dimensions and required metadata keys for matching
     base_shape = runs[0].shape

--- a/src/neunorm/tof/pulse_reconstruction.py
+++ b/src/neunorm/tof/pulse_reconstruction.py
@@ -374,6 +374,48 @@ def _process_chip_worker(
     return _reconstruct_pulse_ids_single_chip(chip_tof, threshold, window, late_margin)
 
 
+def assign_chip_ids(
+    x: np.ndarray,
+    y: np.ndarray,
+    detector_shape: tuple[int, int] = (512, 512),
+) -> np.ndarray:
+    """Assign a chip id (0-3) to each event from its pixel quadrant, for a 2x2 quad detector.
+
+    The loaders do not record which physical chip an event came from, but multi-chip pulse
+    reconstruction (:func:`reconstruct_pulse_ids` with ``chip_id``) needs the events partitioned
+    by chip. For a standard 2x2 quad Timepix3 detector each chip tiles one spatial quadrant, so
+    the chip can be recovered from the pixel ``(x, y)`` position.
+
+    .. note::
+        This assumes the **standard 2x2 quad layout** — four equal chips splitting the detector
+        at ``x_bins // 2`` and ``y_bins // 2`` — with chip numbering ``chip = (x >= W/2) + 2*(y >= H/2)``
+        (row-major: 0=lower-left, 1=lower-right, 2=upper-left, 3=upper-right). The numbering itself
+        is arbitrary for reconstruction (which only needs the four chips *separated*), but if the
+        VENUS detector uses a different physical tiling this mapping must be adjusted. Single-chip
+        detectors do not need this helper.
+
+    Parameters
+    ----------
+    x, y : np.ndarray
+        1D integer pixel-coordinate arrays (same length), e.g. ``events.x`` / ``events.y``.
+    detector_shape : tuple[int, int], optional
+        ``(x_bins, y_bins)`` of the full detector; the chip boundary is at the midpoint of each
+        axis. Default ``(512, 512)`` for SNS VENUS detectors.
+
+    Returns
+    -------
+    np.ndarray
+        1D ``int`` array of chip ids in ``{0, 1, 2, 3}``, same length as ``x``/``y``.
+    """
+    x = np.asarray(x)
+    y = np.asarray(y)
+    if x.shape != y.shape:
+        raise ValueError(f"x and y must have the same shape, got {x.shape} and {y.shape}")
+    x_bins, y_bins = detector_shape
+    chip = (x >= x_bins // 2).astype(np.int64) + 2 * (y >= y_bins // 2).astype(np.int64)
+    return chip
+
+
 def reconstruct_pulse_ids(  # noqa: C901
     tof: np.ndarray,
     chip_id: np.ndarray | None = None,
@@ -461,11 +503,11 @@ def reconstruct_pulse_ids(  # noqa: C901
     Multi-chip detector (VENUS quad) with parallel processing:
 
     >>> import numpy as np
+    >>> from neunorm.tof.pulse_reconstruction import assign_chip_ids
     >>> events = load_event_data('run_14749.h5')
     >>> tof_ms = events.tof / 1e6  # nanoseconds -> milliseconds
-    >>> # chip_id is caller-supplied (the loaders do not populate it): a 1D int
-    >>> # array (0-3 for a quad detector), same length as events.tof
-    >>> chip_id = np.zeros_like(events.tof, dtype=int)  # replace with real per-event chip IDs
+    >>> # the loaders don't record the chip; derive it from the pixel quadrant
+    >>> chip_id = assign_chip_ids(events.x, events.y, detector_shape=(512, 512))
     >>> pulse_ids = reconstruct_pulse_ids(
     ...     tof_ms,
     ...     chip_id=chip_id,
@@ -478,11 +520,10 @@ def reconstruct_pulse_ids(  # noqa: C901
     ...     mask = chip_id == chip
     ...     print(f"Chip {chip}: {pulse_ids[mask].max() + 1} pulses")
 
-    Filter events by pulse (EventData is not indexable - filter the arrays):
+    Filter events by pulse:
 
     >>> # Skip first 5 pulses (warmup)
-    >>> valid_mask = pulse_ids >= 5
-    >>> tof_kept = events.tof[valid_mask]
+    >>> kept = events[pulse_ids >= 5]  # EventData is indexable; filters all per-event arrays
     """
     # Validate n_jobs parameter
     if n_jobs is not None:

--- a/src/neunorm/tof/pulse_reconstruction.py
+++ b/src/neunorm/tof/pulse_reconstruction.py
@@ -412,6 +412,14 @@ def assign_chip_ids(
     if x.shape != y.shape:
         raise ValueError(f"x and y must have the same shape, got {x.shape} and {y.shape}")
     x_bins, y_bins = detector_shape
+    if x.size:
+        if not (np.issubdtype(x.dtype, np.integer) and np.issubdtype(y.dtype, np.integer)):
+            raise ValueError(f"x and y must be integer pixel coordinates, got {x.dtype} and {y.dtype}")
+        if x.min() < 0 or x.max() >= x_bins or y.min() < 0 or y.max() >= y_bins:
+            raise ValueError(
+                f"x/y pixel coordinates out of bounds for detector_shape {detector_shape}: "
+                f"x in [{x.min()}, {x.max()}], y in [{y.min()}, {y.max()}]"
+            )
     chip = (x >= x_bins // 2).astype(np.int64) + 2 * (y >= y_bins // 2).astype(np.int64)
     return chip
 

--- a/src/neunorm/tof/pulse_reconstruction.py
+++ b/src/neunorm/tof/pulse_reconstruction.py
@@ -377,7 +377,7 @@ def _process_chip_worker(
 def assign_chip_ids(
     x: np.ndarray,
     y: np.ndarray,
-    detector_shape: tuple[int, int] = (512, 512),
+    detector_shape: tuple[int, int] = (514, 514),
 ) -> np.ndarray:
     """Assign a chip id (0-3) to each event from its pixel quadrant, for a 2x2 quad detector.
 
@@ -400,7 +400,7 @@ def assign_chip_ids(
         1D integer pixel-coordinate arrays (same length), e.g. ``events.x`` / ``events.y``.
     detector_shape : tuple[int, int], optional
         ``(x_bins, y_bins)`` of the full detector; the chip boundary is at the midpoint of each
-        axis. Default ``(512, 512)`` for SNS VENUS detectors.
+        axis. Default ``(514, 514)`` to match the VENUS TPX3 pipeline / ``event_converter``.
 
     Returns
     -------
@@ -507,7 +507,7 @@ def reconstruct_pulse_ids(  # noqa: C901
     >>> events = load_event_data('run_14749.h5')
     >>> tof_ms = events.tof / 1e6  # nanoseconds -> milliseconds
     >>> # the loaders don't record the chip; derive it from the pixel quadrant
-    >>> chip_id = assign_chip_ids(events.x, events.y, detector_shape=(512, 512))
+    >>> chip_id = assign_chip_ids(events.x, events.y, detector_shape=(514, 514))
     >>> pulse_ids = reconstruct_pulse_ids(
     ...     tof_ms,
     ...     chip_id=chip_id,

--- a/tests/unit/test_event_loader.py
+++ b/tests/unit/test_event_loader.py
@@ -200,7 +200,8 @@ def test_load_event_data_fractional_tof_clock():
             hf.create_dataset("y", data=np.zeros(4, dtype=np.int32))
         # TPX3 fine clock ~1.5625 ns: int(1.5625) == 1 would lose ~36% of every TOF.
         events = load_event_data(temp_path, tof_clock=1.5625)
-        expected = np.round(ticks * 1.5625).astype(np.int64)
+        # ticks * 1.5625 = [1.5625, 3.125, 4.6875, 12.5] -> rounded ns (hand-computed, not mirrored):
+        expected = np.array([2, 3, 5, 12], dtype=np.int64)
         np.testing.assert_array_equal(events.tof, expected)
         assert events.tof.dtype == np.int64
         assert not np.array_equal(events.tof, ticks)  # the int()-truncated bug would give ticks * 1

--- a/tests/unit/test_event_loader.py
+++ b/tests/unit/test_event_loader.py
@@ -184,3 +184,61 @@ def test_event_data_model_total_events_mismatch():
             file_path=Path("test.h5"),
             total_events=5,  # Wrong! Arrays have 2 events
         )
+
+
+def test_load_event_data_fractional_tof_clock():
+    """A fractional TOF clock must use the full period, not int()-truncate it (issue #163)."""
+    from neunorm.loaders.event_loader import load_event_data
+
+    with tempfile.NamedTemporaryFile(suffix=".h5", delete=False) as f:
+        temp_path = Path(f.name)
+    try:
+        ticks = np.array([1, 2, 3, 8], dtype=np.int64)
+        with h5py.File(temp_path, "w") as hf:
+            hf.create_dataset("tof", data=ticks)
+            hf.create_dataset("x", data=np.zeros(4, dtype=np.int32))
+            hf.create_dataset("y", data=np.zeros(4, dtype=np.int32))
+        # TPX3 fine clock ~1.5625 ns: int(1.5625) == 1 would lose ~36% of every TOF.
+        events = load_event_data(temp_path, tof_clock=1.5625)
+        expected = np.round(ticks * 1.5625).astype(np.int64)
+        np.testing.assert_array_equal(events.tof, expected)
+        assert events.tof.dtype == np.int64
+        assert not np.array_equal(events.tof, ticks)  # the int()-truncated bug would give ticks * 1
+    finally:
+        temp_path.unlink()
+
+
+def test_event_data_getitem_filters_all_arrays():
+    """EventData is indexable: a mask returns a new EventData with all per-event arrays filtered (issue #163)."""
+    from neunorm.data_models.core import EventData
+
+    events = EventData(
+        tof=np.array([10, 20, 30, 40], dtype=np.int64),
+        x=np.array([1, 2, 3, 4], dtype=np.int32),
+        y=np.array([5, 6, 7, 8], dtype=np.int32),
+        chip_id=np.array([0, 1, 2, 3], dtype=np.int64),
+        pulse_id=np.array([0, 0, 1, 1], dtype=np.int64),
+        file_path=Path("test.h5"),
+        total_events=4,
+    )
+
+    kept = events[events.pulse_id >= 1]
+    assert len(kept) == 2
+    assert kept.total_events == 2
+    np.testing.assert_array_equal(kept.tof, [30, 40])
+    np.testing.assert_array_equal(kept.x, [3, 4])
+    np.testing.assert_array_equal(kept.y, [7, 8])
+    np.testing.assert_array_equal(kept.chip_id, [2, 3])
+    np.testing.assert_array_equal(kept.pulse_id, [1, 1])
+
+    # optional arrays stay None when absent
+    bare = EventData(
+        tof=np.array([1, 2, 3], dtype=np.int64),
+        x=np.array([0, 0, 0], dtype=np.int32),
+        y=np.array([0, 0, 0], dtype=np.int32),
+        file_path=Path("t.h5"),
+        total_events=3,
+    )
+    sub = bare[np.array([True, False, True])]
+    assert len(sub) == 2
+    assert sub.chip_id is None and sub.pulse_id is None

--- a/tests/unit/test_event_loader.py
+++ b/tests/unit/test_event_loader.py
@@ -243,3 +243,7 @@ def test_event_data_getitem_filters_all_arrays():
     sub = bare[np.array([True, False, True])]
     assert len(sub) == 2
     assert sub.chip_id is None and sub.pulse_id is None
+
+    # scalar integer indexing is rejected with a clear error (would yield 0-D arrays)
+    with pytest.raises(TypeError, match="boolean mask"):
+        _ = events[0]

--- a/tests/unit/test_normalizer.py
+++ b/tests/unit/test_normalizer.py
@@ -290,3 +290,24 @@ def test_normalize_transmission_2d_ob():
     # Var(T) = (T^2) * (Var(Sample)/Sample^2 + Var(OB)/OB^2)
     # Var = (80/100)^2 * (1/80 + 1/100) = 0.0144
     np.testing.assert_allclose(transmission.variances, 0.0144)
+
+
+def test_normalize_transmission_requires_both_proton_charges():
+    """One-sided proton charge -> non-dimensionless T, so it must raise (issue #163)."""
+    import pytest
+
+    from neunorm.processing.normalizer import normalize_transmission
+
+    sample = sc.DataArray(data=sc.array(dims=["x"], values=[80.0, 80.0], unit="counts", dtype="float64"))
+    sample.variances = sample.values.copy()
+    ob = sc.DataArray(data=sc.array(dims=["x"], values=[100.0, 100.0], unit="counts", dtype="float64"))
+    ob.variances = ob.values.copy()
+
+    with pytest.raises(ValueError, match="both be provided or both omitted"):
+        normalize_transmission(sample, ob, proton_charge_sample=500.0)
+    with pytest.raises(ValueError, match="both be provided or both omitted"):
+        normalize_transmission(sample, ob, proton_charge_ob=505.0)
+
+    # both provided is fine and stays dimensionless
+    t = normalize_transmission(sample, ob, proton_charge_sample=500.0, proton_charge_ob=505.0)
+    assert t.unit == sc.units.one

--- a/tests/unit/test_pulse_reconstruction.py
+++ b/tests/unit/test_pulse_reconstruction.py
@@ -190,3 +190,9 @@ def test_assign_chip_ids_quadrants():
 
     with pytest.raises(ValueError):
         assign_chip_ids(np.array([1, 2]), np.array([1]))
+    # out-of-bounds pixel coordinates are rejected (would mispartition / hide upstream bugs)
+    with pytest.raises(ValueError, match="out of bounds"):
+        assign_chip_ids(np.array([0, 999]), np.array([0, 0]), detector_shape=(8, 8))
+    # non-integer coordinates are rejected
+    with pytest.raises(ValueError, match="integer"):
+        assign_chip_ids(np.array([0.0, 1.0]), np.array([0.0, 1.0]), detector_shape=(8, 8))

--- a/tests/unit/test_pulse_reconstruction.py
+++ b/tests/unit/test_pulse_reconstruction.py
@@ -172,3 +172,21 @@ class TestPulseReconstruction:
             f"Algorithm accuracy {accuracy:.2f}% below target 99.5%. "
             f"This may indicate regression in algorithm implementation."
         )
+
+
+def test_assign_chip_ids_quadrants():
+    """assign_chip_ids maps pixel quadrants to chip 0-3 for a 2x2 quad detector (issue #163)."""
+    import pytest
+
+    from neunorm.tof.pulse_reconstruction import assign_chip_ids
+
+    # 8x8 detector -> chip boundary at 4; one pixel per quadrant
+    x = np.array([1, 5, 1, 5])
+    y = np.array([1, 1, 5, 5])
+    chip = assign_chip_ids(x, y, detector_shape=(8, 8))
+    # chip = (x>=4) + 2*(y>=4): lower-left=0, lower-right=1, upper-left=2, upper-right=3
+    np.testing.assert_array_equal(chip, [0, 1, 2, 3])
+    assert set(np.unique(chip).tolist()) <= {0, 1, 2, 3}
+
+    with pytest.raises(ValueError):
+        assign_chip_ids(np.array([1, 2]), np.array([1]))

--- a/tests/unit/test_run_combiner.py
+++ b/tests/unit/test_run_combiner.py
@@ -275,7 +275,7 @@ def test_combine_runs_missing():
 
 
 def test_combine_runs_single_run():
-    """Test that combining a single run returns the same run."""
+    """Test that combining a single run returns an equal but independent copy (issue #163)."""
     from neunorm.processing.run_combiner import combine_runs
 
     run = sc.DataArray(
@@ -287,6 +287,11 @@ def test_combine_runs_single_run():
     combined = combine_runs([run])
     assert combined is not run  # must not alias caller-owned data
     assert sc.identical(combined, run)
+    # mutating the combined result must not leak back into the caller's input
+    combined.values[0, 0, 0] = 999.0
+    combined.variances[0, 0, 0] = 999.0
+    assert run.values[0, 0, 0] == 0.0
+    assert run.variances[0, 0, 0] == 0.0
 
 
 def test_combine_runs_missing_metadata_key():

--- a/tests/unit/test_run_combiner.py
+++ b/tests/unit/test_run_combiner.py
@@ -285,7 +285,8 @@ def test_combine_runs_single_run():
     run.variances = run.values.copy()
 
     combined = combine_runs([run])
-    assert combined is run
+    assert combined is not run  # must not alias caller-owned data
+    assert sc.identical(combined, run)
 
 
 def test_combine_runs_missing_metadata_key():


### PR DESCRIPTION
Resolves #163. Five code fixes/additions surfaced (and source-verified) during the documentation-accuracy audit. **Full suite green (383 passed); the shipped pipelines are unaffected** (they pass both proton charges, use the default clock, and feed freshly-loaded data).

## Changes

| # | Fix | File |
|---|---|---|
| CS1 | Fractional **TOF clock** no longer truncated — `round(tof_raw * tof_clock)` → `int64` ns (was `tof_raw * int(tof_clock)`, which truncated a ~1.5625 ns TPX3 fine clock to 1 ns, ~36% error) | `loaders/event_loader.py` |
| CS2 | `normalize_transmission` **raises** if exactly one proton charge is given (a one-sided correction is non-dimensionless); both-or-neither | `processing/normalizer.py` |
| CS3 | `EventData.__getitem__` — `events[mask]` filters all per-event arrays and returns a new `EventData` | `data_models/core.py` |
| CS4 | `combine_runs` single-run path returns a **copy**, not the caller's object (no aliasing leak; matches the multi-run path) | `processing/run_combiner.py` |
| CS5 | `assign_chip_ids(x, y, detector_shape)` derives a chip id (0–3) from the pixel quadrant, giving multi-chip `reconstruct_pulse_ids` a data source | `tof/pulse_reconstruction.py` |

Each has a unit test (4 new + 1 updated). The `reconstruct_pulse_ids` multi-chip docstring example now uses `assign_chip_ids` and indexable `events[mask]`. CHANGELOG updated.

## ⚠️ Needs maintainer confirmation
**`assign_chip_ids` assumes the standard 2×2 quad layout** — four equal chips split at `x_bins // 2` / `y_bins // 2`, numbered `(x≥W/2) + 2·(y≥H/2)`. The codebase has **no chip/quad geometry** (`event_id` is a linearized `y*y_bins + x`, no chip bits), so I used the conventional quad-TPX3 tiling. The numbering is arbitrary for reconstruction (which only needs the four chips *separated*), but **if the VENUS detector tiles differently this mapping must be adjusted** — flagged in the docstring.

## Verification
- `pixi run test` — **383 passed** (379 + 4 new).
- `pixi run build-docs` (sphinx `-W`) — build succeeded.
- `pre-commit` (ruff check + format, codespell) clean.
- `/review-pipeline` (dual-family) + Copilot review to follow before this is marked ready.

Assisted-With: Claude Opus 4.8 <noreply@anthropic.com>