### PR TITLE
feat: background-ROI flux normalization (proton-charge proxy) (#159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `background_roi=(x0, y0, x1, y1)` parameter that normalizes each image by its mean counts in a
   sample-free ROI — an approximation to proton-charge normalization for when proton charge is
   unavailable (e.g. MARS): `T = (S/mean(S[B])) / (O/mean(O[B]))`. Mutually exclusive with
-  `proton_charge_sample`/`_ob`; uncertainty is propagated first-order. Exposed on
-  `run_mars_ccd_pipeline`, `run_mars_tpx3_pipeline`, and `run_venus_ccd_pipeline` via
-  `background_roi=`. ([#159](https://github.com/ornlneutronimaging/NeuNorm/issues/159))
+  `proton_charge_sample`/`_ob`; uncertainty is propagated first-order (with the shared-dark
+  covariance corrected on the `normalize_with_dark` path). Exposed on `run_mars_ccd_pipeline`,
+  `run_mars_tpx3_pipeline`, and `run_venus_ccd_pipeline` via `background_roi=`.
+  ([#159](https://github.com/ornlneutronimaging/NeuNorm/issues/159))
+- **Named `ROI` type for region arguments.** A new `neunorm.ROI` pydantic model lets you specify any
+  region by name — `ROI(x0=10, y0=20, x1=30, y1=40)` or `ROI(x0=10, y0=20, width=20, height=20)` —
+  instead of remembering the order of a bare `(x0, y0, x1, y1)` tuple (requested by Jean Bilheux on
+  [#159](https://github.com/ornlneutronimaging/NeuNorm/issues/159)). Accepted everywhere an ROI tuple
+  is: `apply_roi` (`roi=`), `apply_air_region_correction` (`air_roi=`), `normalize_transmission`
+  (`background_roi=`), and every pipeline's `roi` / `air_roi` / `background_roi`. Stops are exclusive
+  (`width`/`height` resolve to `x1=x0+width`, `y1=y0+height`); bare tuples keep working unchanged.
 
 - **`EventData` is now indexable, plus an `assign_chip_ids` helper.** `events[mask]` (boolean
   mask, index array, or slice) returns a new `EventData` with every per-event array filtered.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Background-ROI flux normalization (proton-charge proxy).** `normalize_transmission` gains a
+  `background_roi=(x0, y0, x1, y1)` parameter that normalizes each image by its mean counts in a
+  sample-free ROI — an approximation to proton-charge normalization for when proton charge is
+  unavailable (e.g. MARS): `T = (S/mean(S[B])) / (O/mean(O[B]))`. Mutually exclusive with
+  `proton_charge_sample`/`_ob`; uncertainty is propagated first-order. Exposed on
+  `run_mars_ccd_pipeline`, `run_mars_tpx3_pipeline`, and `run_venus_ccd_pipeline` via
+  `background_roi=`. ([#159](https://github.com/ornlneutronimaging/NeuNorm/issues/159))
+
 - **`EventData` is now indexable, plus an `assign_chip_ids` helper.** `events[mask]` (boolean
   mask, index array, or slice) returns a new `EventData` with every per-event array filtered.
   `neunorm.tof.pulse_reconstruction.assign_chip_ids(x, y, detector_shape)` derives a chip id (0–3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   covariance corrected on the `normalize_with_dark` path). Exposed on `run_mars_ccd_pipeline`,
   `run_mars_tpx3_pipeline`, and `run_venus_ccd_pipeline` via `background_roi=`.
   ([#159](https://github.com/ornlneutronimaging/NeuNorm/issues/159))
-- **Named `ROI` type for region arguments.** A new `neunorm.ROI` pydantic model lets you specify any
+- **Named `ROI` type for region arguments.** A new `ROI` pydantic model (`neunorm.data_models.roi`) lets you specify any
   region by name — `ROI(x0=10, y0=20, x1=30, y1=40)` or `ROI(x0=10, y0=20, width=20, height=20)` —
   instead of remembering the order of a bare `(x0, y0, x1, y1)` tuple (requested by Jean Bilheux on
   [#159](https://github.com/ornlneutronimaging/NeuNorm/issues/159)). Accepted everywhere an ROI tuple

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -9,6 +9,9 @@ Data models
 .. automodule:: neunorm.data_models.core
    :members:
 
+.. automodule:: neunorm.data_models.roi
+   :members:
+
 .. automodule:: neunorm.data_models.tof
    :members:
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -106,7 +106,7 @@ transmission = normalize_transmission(sample, ob)  # T = sample / ob, variances 
 | `Normalization()` (stateful object) | a `run_*_pipeline(...)` call, or composable functions |
 | `.load(..., data_type="sample"/"ob")` | pipeline `sample_paths` / `ob_paths`, or `neunorm.loaders.stack_loader.load_stack` / `tiff_loader.load_tiff_stack` / `fits_loader.load_fits_stack` |
 | `.load(..., data_type="df")` (dark/"df") | pipeline `dark_paths`, or `neunorm.processing.dark_corrector.subtract_dark(data, dark)` |
-| `.normalization(roi=...)` | Flux normalization by a background ROI — not yet in 2.x; planned as `background_roi=` ([#159](https://github.com/ornlneutronimaging/NeuNorm/issues/159)). Note: 2.x `roi=` is a spatial **crop** (`apply_roi`), not this. |
+| `.normalization(roi=...)` | Flux normalization by a background ROI: `normalize_transmission(..., background_roi=(x0, y0, x1, y1))`, or pass `background_roi=` to `run_mars_ccd_pipeline` / `run_mars_tpx3_pipeline` / `run_venus_ccd_pipeline` ([#159](https://github.com/ornlneutronimaging/NeuNorm/issues/159)). A proton-charge proxy for when proton charge is unavailable; mutually exclusive with it. Note: 2.x `roi=` is a spatial **crop** (`apply_roi`), not this. |
 | `.df_correction()` | `neunorm.processing.dark_corrector.subtract_dark(data, dark)` |
 | `.crop(roi=ROI(...))` | `neunorm.processing.roi_clipper.apply_roi(data, (x0, y0, x1, y1))` |
 | auto/manual gamma filtering on `load()` | `neunorm.filters.gamma_filter.apply_gamma_filter(...)`, or pipeline `gamma_filter=True` |

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -112,20 +112,24 @@ transmission = normalize_transmission(sample, ob)  # T = sample / ob, variances 
 | auto/manual gamma filtering on `load()` | `neunorm.filters.gamma_filter.apply_gamma_filter(...)`, or pipeline `gamma_filter=True` |
 | `.export(folder=..., file_type="tif")` | `neunorm.exporters.hdf5_writer.write_hdf5(...)` (primary) or `tiff_writer.write_tiff_stack(...)`; pipelines write automatically via `output_path` |
 | `.get_normalized_data()` | the pipeline **returns** a `scipp.DataArray`; use `.values` for the NumPy array |
-| `from NeuNorm.roi import ROI; ROI(x0, y0, x1, y1)` | `from neunorm import ROI; ROI(x0=10, y0=20, x1=30, y1=40)` (also `ROI(x0=10, y0=20, width=20, height=20)`), or a bare `(x0, y0, x1, y1)` tuple. Accepted by `apply_roi`, `apply_air_region_correction`, `normalize_transmission(background_roi=)`, and the pipelines. |
+| `from NeuNorm.roi import ROI; ROI(x0, y0, x1, y1)` | `from neunorm.data_models.roi import ROI; ROI(x0=10, y0=20, x1=30, y1=40)` (also `ROI(x0=10, y0=20, width=20, height=20)`), or a bare `(x0, y0, x1, y1)` tuple. Accepted by `apply_roi`, `apply_air_region_correction`, `normalize_transmission(background_roi=)`, and the pipelines. |
 | `NeuNorm.normalization.DataType` | not needed — inputs are explicit function arguments |
 
 ## ROI
 
-1.x used an `ROI` object; 2.0 uses a 4-integer tuple in the same order:
+1.x had an `ROI` object; 2.0 has one too (`neunorm.data_models.roi.ROI`) and also accepts a bare
+4-integer tuple in the same order. 2.x stops are **exclusive** (1.x `x1`/`y1` were inclusive):
 
 ```python
 # 1.x
 from NeuNorm.roi import ROI
 roi = ROI(x0=10, y0=10, x1=110, y1=110)
 
-# 2.0
-roi = (10, 10, 111, 111)   # (x0, y0, x1, y1); 2.x stops are EXCLUSIVE (1.x x1/y1 were inclusive)
+# 2.0 — named ROI (exclusive stops) or a bare tuple
+from neunorm.data_models.roi import ROI
+roi = ROI(x0=10, y0=10, x1=111, y1=111)         # explicit stops
+roi = ROI(x0=10, y0=10, width=101, height=101)  # or by size
+roi = (10, 10, 111, 111)                        # or a bare (x0, y0, x1, y1) tuple
 ```
 
 ## Working with the result

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -108,11 +108,11 @@ transmission = normalize_transmission(sample, ob)  # T = sample / ob, variances 
 | `.load(..., data_type="df")` (dark/"df") | pipeline `dark_paths`, or `neunorm.processing.dark_corrector.subtract_dark(data, dark)` |
 | `.normalization(roi=...)` | Flux normalization by a background ROI: `normalize_transmission(..., background_roi=(x0, y0, x1, y1))`, or pass `background_roi=` to `run_mars_ccd_pipeline` / `run_mars_tpx3_pipeline` / `run_venus_ccd_pipeline` ([#159](https://github.com/ornlneutronimaging/NeuNorm/issues/159)). A proton-charge proxy for when proton charge is unavailable; mutually exclusive with it. Note: 2.x `roi=` is a spatial **crop** (`apply_roi`), not this. |
 | `.df_correction()` | `neunorm.processing.dark_corrector.subtract_dark(data, dark)` |
-| `.crop(roi=ROI(...))` | `neunorm.processing.roi_clipper.apply_roi(data, (x0, y0, x1, y1))` |
+| `.crop(roi=ROI(...))` | `neunorm.processing.roi_clipper.apply_roi(data, ROI(x0=.., y0=.., x1=.., y1=..))` (or a bare `(x0, y0, x1, y1)` tuple) |
 | auto/manual gamma filtering on `load()` | `neunorm.filters.gamma_filter.apply_gamma_filter(...)`, or pipeline `gamma_filter=True` |
 | `.export(folder=..., file_type="tif")` | `neunorm.exporters.hdf5_writer.write_hdf5(...)` (primary) or `tiff_writer.write_tiff_stack(...)`; pipelines write automatically via `output_path` |
 | `.get_normalized_data()` | the pipeline **returns** a `scipp.DataArray`; use `.values` for the NumPy array |
-| `from NeuNorm.roi import ROI; ROI(x0, y0, x1, y1)` | a plain tuple `(x0, y0, x1, y1)` |
+| `from NeuNorm.roi import ROI; ROI(x0, y0, x1, y1)` | `from neunorm import ROI; ROI(x0=10, y0=20, x1=30, y1=40)` (also `ROI(x0=10, y0=20, width=20, height=20)`), or a bare `(x0, y0, x1, y1)` tuple. Accepted by `apply_roi`, `apply_air_region_correction`, `normalize_transmission(background_roi=)`, and the pipelines. |
 | `NeuNorm.normalization.DataType` | not needed — inputs are explicit function arguments |
 
 ## ROI

--- a/src/neunorm/__init__.py
+++ b/src/neunorm/__init__.py
@@ -24,9 +24,8 @@ try:
 except ImportError:
     __version__ = "unknown"
 
-from neunorm.data_models.roi import ROI
 
 __author__ = "Jean Bilheux, Chen Zhang"
 __email__ = "bilheuxjm@ornl.gov, zhangc@ornl.gov"
 
-__all__ = ["ROI", "__version__"]
+__all__ = ["__version__"]

--- a/src/neunorm/__init__.py
+++ b/src/neunorm/__init__.py
@@ -24,7 +24,9 @@ try:
 except ImportError:
     __version__ = "unknown"
 
+from neunorm.data_models.roi import ROI
+
 __author__ = "Jean Bilheux, Chen Zhang"
 __email__ = "bilheuxjm@ornl.gov, zhangc@ornl.gov"
 
-__all__ = ["__version__"]
+__all__ = ["ROI", "__version__"]

--- a/src/neunorm/data_models/__init__.py
+++ b/src/neunorm/data_models/__init__.py
@@ -4,6 +4,7 @@ Data models for NeuNorm 2.0.
 Pydantic models for type-safe data handling throughout the processing pipeline.
 """
 
+from neunorm.data_models.roi import ROI, as_roi_bounds
 from neunorm.data_models.tof import BinningConfig
 
-__all__ = ["BinningConfig"]
+__all__ = ["ROI", "BinningConfig", "as_roi_bounds"]

--- a/src/neunorm/data_models/roi.py
+++ b/src/neunorm/data_models/roi.py
@@ -1,0 +1,78 @@
+"""Region-of-interest data model for NeuNorm 2.0."""
+
+from typing import Optional, Union
+
+from pydantic import BaseModel, model_validator
+
+
+class ROI(BaseModel):
+    """Rectangular region of interest with named, self-documenting bounds.
+
+    Define it either by explicit stop indices or by size — the two forms are equivalent::
+
+        ROI(x0=10, y0=20, x1=30, y1=40)          # exclusive stops
+        ROI(x0=10, y0=20, width=20, height=20)   # the same 20x20 region
+
+    Stop indices are **exclusive** (Python slice semantics), matching ``apply_roi``,
+    ``apply_air_region_correction`` and the ``background_roi`` flux proxy. An ``ROI`` may be passed
+    anywhere those APIs accept an ``(x0, y0, x1, y1)`` tuple; the bare-tuple form keeps working
+    unchanged for backward compatibility.
+
+    Parameters
+    ----------
+    x0, y0 : int
+        Lower (inclusive) pixel bounds in x and y.
+    x1, y1 : int, optional
+        Upper (exclusive) pixel bounds. Provide these **or** ``width``/``height``.
+    width, height : int, optional
+        Extent in x and y; ``x1 = x0 + width`` and ``y1 = y0 + height``. Provide these **or**
+        ``x1``/``y1``.
+
+    Examples
+    --------
+    >>> ROI(x0=10, y0=20, x1=30, y1=40).as_bounds()
+    (10, 20, 30, 40)
+    >>> ROI(x0=10, y0=20, width=20, height=20).as_bounds()
+    (10, 20, 30, 40)
+    """
+
+    x0: int
+    y0: int
+    x1: Optional[int] = None
+    y1: Optional[int] = None
+    width: Optional[int] = None
+    height: Optional[int] = None
+
+    @model_validator(mode="after")
+    def _resolve_bounds(self):
+        """Resolve width/height to exclusive stops and validate the rectangle (runs automatically)."""
+        if (self.x1 is None) == (self.width is None):
+            raise ValueError("ROI requires exactly one of 'x1' or 'width'")
+        if (self.y1 is None) == (self.height is None):
+            raise ValueError("ROI requires exactly one of 'y1' or 'height'")
+        if self.x1 is None:
+            self.x1 = self.x0 + self.width
+        if self.y1 is None:
+            self.y1 = self.y0 + self.height
+        if self.x0 < 0 or self.y0 < 0 or self.x1 <= self.x0 or self.y1 <= self.y0:
+            raise ValueError(f"Invalid ROI {self.as_bounds()}: need 0 <= x0 < x1 and 0 <= y0 < y1")
+        return self
+
+    def as_bounds(self) -> tuple[int, int, int, int]:
+        """Return the ROI as an ``(x0, y0, x1, y1)`` tuple with exclusive stop indices."""
+        return (self.x0, self.y0, self.x1, self.y1)
+
+
+# An ``ROI`` or a bare ``(x0, y0, x1, y1)`` tuple — accepted interchangeably by ROI-taking APIs.
+ROILike = Union[ROI, tuple[int, int, int, int]]
+
+
+def as_roi_bounds(roi: ROILike) -> tuple[int, int, int, int]:
+    """Coerce an :class:`ROI` (or a bare ``(x0, y0, x1, y1)`` tuple/list) to a bounds tuple.
+
+    A bare sequence is returned as a plain tuple so downstream code sees a consistent
+    ``(x0, y0, x1, y1)`` form regardless of how the ROI was specified.
+    """
+    if isinstance(roi, ROI):
+        return roi.as_bounds()
+    return tuple(roi)

--- a/src/neunorm/data_models/roi.py
+++ b/src/neunorm/data_models/roi.py
@@ -63,8 +63,9 @@ class ROI(BaseModel):
         return (self.x0, self.y0, self.x1, self.y1)
 
 
-# An ``ROI`` or a bare ``(x0, y0, x1, y1)`` tuple — accepted interchangeably by ROI-taking APIs.
-ROILike = Union[ROI, tuple[int, int, int, int]]
+# An ``ROI`` or a bare 4-element ``(x0, y0, x1, y1)`` tuple/list — accepted interchangeably by
+# ROI-taking APIs (``as_roi_bounds`` coerces either form to a bounds tuple).
+ROILike = Union[ROI, tuple[int, int, int, int], list[int]]
 
 
 def as_roi_bounds(roi: ROILike) -> tuple[int, int, int, int]:

--- a/src/neunorm/data_models/roi.py
+++ b/src/neunorm/data_models/roi.py
@@ -68,11 +68,16 @@ ROILike = Union[ROI, tuple[int, int, int, int]]
 
 
 def as_roi_bounds(roi: ROILike) -> tuple[int, int, int, int]:
-    """Coerce an :class:`ROI` (or a bare ``(x0, y0, x1, y1)`` tuple/list) to a bounds tuple.
+    """Coerce an :class:`ROI` (or a bare 4-element ``(x0, y0, x1, y1)`` sequence) to a bounds tuple.
 
     A bare sequence is returned as a plain tuple so downstream code sees a consistent
-    ``(x0, y0, x1, y1)`` form regardless of how the ROI was specified.
+    ``(x0, y0, x1, y1)`` form regardless of how the ROI was specified. Element-type/bounds validation
+    is left to the consumer (and to :class:`ROI` for the named form); only the 4-element length is
+    enforced here so a malformed bare sequence fails fast at one place.
     """
     if isinstance(roi, ROI):
         return roi.as_bounds()
-    return tuple(roi)
+    bounds = tuple(roi)
+    if len(bounds) != 4:
+        raise ValueError(f"ROI must be a tuple of 4 integers (x0, y0, x1, y1), or an ROI; got {bounds!r}")
+    return bounds

--- a/src/neunorm/exporters/hdf5_writer.py
+++ b/src/neunorm/exporters/hdf5_writer.py
@@ -17,13 +17,13 @@ def _is_nested_sequence(value) -> bool:
     """Return True if ``value`` is a list/tuple that contains a list/tuple element.
 
     Nested sequences (e.g. per-run file-path provenance ``[[...], [...]]``) cannot be
-    stored natively by h5py when ragged, so they are JSON-serialized instead (#140).
+    stored natively by h5py when ragged, so they are JSON-serialized instead.
     """
     return isinstance(value, (list, tuple)) and any(isinstance(item, (list, tuple)) for item in value)
 
 
 def _write_json_metadata(f: h5py.File, name: str, value) -> None:
-    """Store ``value`` as a JSON string dataset tagged with ``encoding="json"`` (issue #140).
+    """Store ``value`` as a JSON string dataset tagged with ``encoding="json"``.
 
     JSON-native leaves (strings, numbers, bools, ``null``) keep their JSON types; only
     non-JSON-serializable leaves are coerced via ``str()`` (``json.dumps(..., default=str)``).
@@ -36,7 +36,7 @@ def _write_json_metadata(f: h5py.File, name: str, value) -> None:
 
 
 def _write_metadata_value(f: h5py.File, name: str, value) -> None:
-    """Write one metadata value, choosing the best HDF5 representation (issue #140).
+    """Write one metadata value, choosing the best HDF5 representation.
 
     Strings, scalars, and flat arrays are stored natively; nested list/tuple provenance is
     stored as a round-trippable JSON string. May raise; the caller backstops failures so a
@@ -58,7 +58,7 @@ def _write_metadata_value(f: h5py.File, name: str, value) -> None:
 
 
 def _discard_failed_metadata(f: h5py.File, name: Optional[str], key, exc: Exception, created_here: bool) -> None:
-    """Best-effort cleanup + warning for a metadata key that could not be written (issue #140).
+    """Best-effort cleanup + warning for a metadata key that could not be written.
 
     Never raises: provenance is best-effort and must not abort the bulk-data write. Removes a
     leftover dataset only when this key's write actually created it (``created_here``) — never a
@@ -169,7 +169,7 @@ def write_hdf5(  # noqa: C901
 
         # Write metadata. Provenance is best-effort: a single un-writable key — a bad value
         # (ragged/unserializable) or a malformed/colliding name — must never abort the write or
-        # leave a corrupt, partially-written file (issue #140). Nested list/tuple values are
+        # leave a corrupt, partially-written file. Nested list/tuple values are
         # serialized as round-trippable JSON (read back with json.loads(dataset.asstr()[()])).
         if metadata:
             for key, value in metadata.items():
@@ -184,7 +184,7 @@ def write_hdf5(  # noqa: C901
                         raise ValueError(f"duplicate metadata path {name!r}")
                     created_here = True
                     _write_metadata_value(f, name, value)
-                except Exception as exc:  # noqa: BLE001 - metadata is best-effort; never abort the bulk-data write (#140)
+                except Exception as exc:  # noqa: BLE001 - metadata is best-effort; never abort the bulk-data write
                     _discard_failed_metadata(f, name, key, exc, created_here)
 
     logger.info("HDF5 file written to {}", output_path)

--- a/src/neunorm/loaders/fits_loader.py
+++ b/src/neunorm/loaders/fits_loader.py
@@ -63,7 +63,7 @@ def load_fits_stack(paths: Sequence[str | Path], tof_edges: Optional[np.ndarray]
 
                 # Assume data is in primary HDU. float32 is sufficient for neutron
                 # imaging (16-bit detectors) and halves the in-memory footprint of
-                # large stacks (issue #147).
+                # large stacks.
                 arr = hdul[0].data.astype(np.float32)
                 data_list.append(arr)
 

--- a/src/neunorm/loaders/tiff_loader.py
+++ b/src/neunorm/loaders/tiff_loader.py
@@ -50,7 +50,7 @@ def load_tiff_stack(paths: Sequence[str | Path], tof_edges: Optional[np.ndarray]
         for path in paths:
             with Image.open(path) as img:
                 # float32 is sufficient for neutron imaging (16-bit detectors) and
-                # halves the in-memory footprint of large stacks (issue #147).
+                # halves the in-memory footprint of large stacks.
                 data_list.append(np.asanyarray(img, dtype=np.float32))
                 metadata_list.append(img.tag_v2)
     except Exception as e:

--- a/src/neunorm/pipelines/mars_ccd.py
+++ b/src/neunorm/pipelines/mars_ccd.py
@@ -15,7 +15,6 @@ from neunorm.exporters.hdf5_writer import write_hdf5
 from neunorm.exporters.tiff_writer import write_tiff_stack
 from neunorm.filters.gamma_filter import apply_gamma_filter
 from neunorm.loaders.stack_loader import load_stack
-from neunorm.processing.dark_corrector import subtract_dark
 from neunorm.processing.normalizer import normalize_transmission, normalize_with_dark
 from neunorm.processing.reference_preparer import prepare_reference
 from neunorm.processing.roi_clipper import apply_roi
@@ -160,9 +159,12 @@ def run_mars_ccd_pipeline(  # noqa: C901
     # in the transmission uncertainty (issue #142). Without dark, normalize directly.
     if background_roi is not None:
         # Flux-proxy normalization from a sample-free ROI (issue #159), in place of proton charge.
-        s = subtract_dark(sample, dark) if dark is not None else sample
-        o = subtract_dark(ob, dark) if dark is not None else ob
-        transmission = normalize_transmission(s, o, background_roi=background_roi)
+        # With a shared dark, route through normalize_with_dark so the #142 shared-dark variance
+        # double-count is corrected (k = co/cs); without dark, normalize directly.
+        if dark is not None:
+            transmission = normalize_with_dark(sample, ob, dark, background_roi=background_roi)
+        else:
+            transmission = normalize_transmission(sample, ob, background_roi=background_roi)
     elif dark is not None:
         transmission = normalize_with_dark(sample, ob, dark)
     else:
@@ -191,6 +193,9 @@ def run_mars_ccd_pipeline(  # noqa: C901
 
     if roi:
         metadata["roi_applied"] = roi
+
+    if background_roi is not None:
+        metadata["background_roi"] = list(background_roi)
 
     if output_path.suffix.lower() in (".hdf5", ".h5"):
         write_hdf5(output_path, transmission, dead_pixel_mask="dead_pixels", metadata=metadata)

--- a/src/neunorm/pipelines/mars_ccd.py
+++ b/src/neunorm/pipelines/mars_ccd.py
@@ -11,6 +11,7 @@ import scipp as sc
 from loguru import logger
 
 from neunorm import __version__
+from neunorm.data_models.roi import ROILike, as_roi_bounds
 from neunorm.exporters.hdf5_writer import write_hdf5
 from neunorm.exporters.tiff_writer import write_tiff_stack
 from neunorm.filters.gamma_filter import apply_gamma_filter
@@ -27,9 +28,9 @@ def run_mars_ccd_pipeline(  # noqa: C901
     ob_paths: Sequence[Sequence[str | Path]],
     dark_paths: Optional[Sequence[Sequence[str | Path]]] = None,
     output_path: Optional[Path] = None,
-    roi: Optional[tuple] = None,
+    roi: Optional[ROILike] = None,
     gamma_filter: bool = True,
-    background_roi: Optional[tuple] = None,
+    background_roi: Optional[ROILike] = None,
 ) -> sc.DataArray:
     """Execute MARS CCD/CMOS normalization pipeline.
 
@@ -63,7 +64,7 @@ def run_mars_ccd_pipeline(  # noqa: C901
         raises ``ValueError`` (the default exists only so ``dark_paths`` can keep
         its positional slot).
     roi : Optional[tuple]
-        Region of interest to apply (x_start, y_start, x_end, y_end)
+        Region of interest to crop to — an ``ROI`` or a bare ``(x0, y0, x1, y1)`` tuple.
     gamma_filter : bool
         Whether to apply gamma filtering to the sample data (default: True)
     background_roi : Optional[tuple]
@@ -82,6 +83,12 @@ def run_mars_ccd_pipeline(  # noqa: C901
     sc.DataArray
         Final normalized transmission DataArray with metadata and masks
     """
+    # Accept an ROI or a bare (x0, y0, x1, y1) tuple for every ROI argument; coerce to bounds
+    # tuples up front so cropping and provenance see a consistent form (issue #159).
+    if roi is not None:
+        roi = as_roi_bounds(roi)
+    if background_roi is not None:
+        background_roi = as_roi_bounds(background_roi)
 
     if output_path is None:
         raise ValueError("output_path is required")

--- a/src/neunorm/pipelines/mars_ccd.py
+++ b/src/neunorm/pipelines/mars_ccd.py
@@ -68,7 +68,9 @@ def run_mars_ccd_pipeline(  # noqa: C901
         Whether to apply gamma filtering to the sample data (default: True)
     background_roi : Optional[tuple]
         Sample-free background ROI (x0, y0, x1, y1) for flux-proxy normalization when proton
-        charge is unavailable (issue #159). Mutually exclusive with proton-charge correction.
+        charge is unavailable (issue #159). Mutually exclusive with proton-charge correction. If
+        ``roi`` is also given the detector is cropped first, so ``background_roi`` indices are
+        resolved in the post-crop frame.
 
     Notes
     -----

--- a/src/neunorm/pipelines/mars_ccd.py
+++ b/src/neunorm/pipelines/mars_ccd.py
@@ -69,7 +69,7 @@ def run_mars_ccd_pipeline(  # noqa: C901
         Whether to apply gamma filtering to the sample data (default: True)
     background_roi : Optional[tuple]
         Sample-free background ROI (x0, y0, x1, y1) for flux-proxy normalization when proton
-        charge is unavailable (issue #159). Mutually exclusive with proton-charge correction. If
+        charge is unavailable. Mutually exclusive with proton-charge correction. If
         ``roi`` is also given the detector is cropped first, so ``background_roi`` indices are
         resolved in the post-crop frame.
 
@@ -84,7 +84,7 @@ def run_mars_ccd_pipeline(  # noqa: C901
         Final normalized transmission DataArray with metadata and masks
     """
     # Accept an ROI or a bare (x0, y0, x1, y1) tuple for every ROI argument; coerce to bounds
-    # tuples up front so cropping and provenance see a consistent form (issue #159).
+    # tuples up front so cropping and provenance see a consistent form.
     if roi is not None:
         roi = as_roi_bounds(roi)
     if background_roi is not None:
@@ -130,7 +130,7 @@ def run_mars_ccd_pipeline(  # noqa: C901
         normalize_by_runs=True,
     )
 
-    # Dark current is optional (issue #146): only load/combine it when dark paths are provided.
+    # Dark current is optional: only load/combine it when dark paths are provided.
     dark = None
     if dark_paths:
         dark_runs = [load_stack(paths) for paths in dark_paths]
@@ -165,10 +165,10 @@ def run_mars_ccd_pipeline(  # noqa: C901
 
     # Dark correction (optional) + normalization. With a shared dark frame, normalize_with_dark
     # subtracts the dark and normalizes in one step so the dark variance is not double-counted
-    # in the transmission uncertainty (issue #142). Without dark, normalize directly.
+    # in the transmission uncertainty. Without dark, normalize directly.
     if background_roi is not None:
-        # Flux-proxy normalization from a sample-free ROI (issue #159), in place of proton charge.
-        # With a shared dark, route through normalize_with_dark so the #142 shared-dark variance
+        # Flux-proxy normalization from a sample-free ROI, in place of proton charge.
+        # With a shared dark, route through normalize_with_dark so the shared-dark variance
         # double-count is corrected (k = co/cs); without dark, normalize directly.
         if dark is not None:
             transmission = normalize_with_dark(sample, ob, dark, background_roi=background_roi)
@@ -180,7 +180,7 @@ def run_mars_ccd_pipeline(  # noqa: C901
         logger.info("No dark current provided; skipping dark correction")
         transmission = normalize_transmission(sample, ob)
 
-    # Guarantee a float32 normalized data product (issue #147), regardless of any
+    # Guarantee a float32 normalized data product, regardless of any
     # intermediate dtype promotion. .astype converts values and variances. MARS has
     # no proton-charge division, so this is already float32; the cast keeps the two
     # CCD pipelines symmetric and is robust to future changes.

--- a/src/neunorm/pipelines/mars_ccd.py
+++ b/src/neunorm/pipelines/mars_ccd.py
@@ -15,6 +15,7 @@ from neunorm.exporters.hdf5_writer import write_hdf5
 from neunorm.exporters.tiff_writer import write_tiff_stack
 from neunorm.filters.gamma_filter import apply_gamma_filter
 from neunorm.loaders.stack_loader import load_stack
+from neunorm.processing.dark_corrector import subtract_dark
 from neunorm.processing.normalizer import normalize_transmission, normalize_with_dark
 from neunorm.processing.reference_preparer import prepare_reference
 from neunorm.processing.roi_clipper import apply_roi
@@ -29,6 +30,7 @@ def run_mars_ccd_pipeline(  # noqa: C901
     output_path: Optional[Path] = None,
     roi: Optional[tuple] = None,
     gamma_filter: bool = True,
+    background_roi: Optional[tuple] = None,
 ) -> sc.DataArray:
     """Execute MARS CCD/CMOS normalization pipeline.
 
@@ -65,6 +67,9 @@ def run_mars_ccd_pipeline(  # noqa: C901
         Region of interest to apply (x_start, y_start, x_end, y_end)
     gamma_filter : bool
         Whether to apply gamma filtering to the sample data (default: True)
+    background_roi : Optional[tuple]
+        Sample-free background ROI (x0, y0, x1, y1) for flux-proxy normalization when proton
+        charge is unavailable (issue #159). Mutually exclusive with proton-charge correction.
 
     Notes
     -----
@@ -153,7 +158,12 @@ def run_mars_ccd_pipeline(  # noqa: C901
     # Dark correction (optional) + normalization. With a shared dark frame, normalize_with_dark
     # subtracts the dark and normalizes in one step so the dark variance is not double-counted
     # in the transmission uncertainty (issue #142). Without dark, normalize directly.
-    if dark is not None:
+    if background_roi is not None:
+        # Flux-proxy normalization from a sample-free ROI (issue #159), in place of proton charge.
+        s = subtract_dark(sample, dark) if dark is not None else sample
+        o = subtract_dark(ob, dark) if dark is not None else ob
+        transmission = normalize_transmission(s, o, background_roi=background_roi)
+    elif dark is not None:
         transmission = normalize_with_dark(sample, ob, dark)
     else:
         logger.info("No dark current provided; skipping dark correction")

--- a/src/neunorm/pipelines/mars_tpx3.py
+++ b/src/neunorm/pipelines/mars_tpx3.py
@@ -11,6 +11,7 @@ import scipp as sc
 from loguru import logger
 
 from neunorm import __version__
+from neunorm.data_models.roi import ROILike, as_roi_bounds
 from neunorm.exporters.hdf5_writer import write_hdf5
 from neunorm.exporters.tiff_writer import write_tiff_stack
 from neunorm.filters.gamma_filter import apply_gamma_filter
@@ -27,10 +28,10 @@ def run_mars_tpx3_pipeline(  # noqa: C901
     sample_paths: Sequence[Sequence[str | Path]],
     ob_paths: Sequence[Sequence[str | Path]],
     output_path: Path,
-    roi: Optional[tuple] = None,
+    roi: Optional[ROILike] = None,
     gamma_filter: bool = True,
     detector_shape: tuple[int, int] = (514, 514),
-    background_roi: Optional[tuple] = None,
+    background_roi: Optional[ROILike] = None,
 ) -> sc.DataArray:
     """Execute MARS TPX3 normalization pipeline.
 
@@ -56,7 +57,7 @@ def run_mars_tpx3_pipeline(  # noqa: C901
     output_path : Path
         Path to save the output file (HDF5 or TIFF)
     roi : Optional[tuple]
-        Region of interest to apply (x_start, y_start, x_end, y_end)
+        Region of interest to crop to — an ``ROI`` or a bare ``(x0, y0, x1, y1)`` tuple.
     gamma_filter : bool
         Whether to apply gamma filtering to the sample data (default: True)
     detector_shape : tuple[int, int]
@@ -77,6 +78,12 @@ def run_mars_tpx3_pipeline(  # noqa: C901
     sc.DataArray
         Final normalized transmission DataArray with metadata and masks
     """
+    # Accept an ROI or a bare (x0, y0, x1, y1) tuple for every ROI argument; coerce to bounds
+    # tuples up front so cropping and provenance see a consistent form (issue #159).
+    if roi is not None:
+        roi = as_roi_bounds(roi)
+    if background_roi is not None:
+        background_roi = as_roi_bounds(background_roi)
 
     # Load data and convert to histogram
     samples = [

--- a/src/neunorm/pipelines/mars_tpx3.py
+++ b/src/neunorm/pipelines/mars_tpx3.py
@@ -63,7 +63,9 @@ def run_mars_tpx3_pipeline(  # noqa: C901
         Shape of the TPX3 detector (default: (514, 514))
     background_roi : Optional[tuple]
         Sample-free background ROI (x0, y0, x1, y1) for flux-proxy normalization when proton
-        charge is unavailable (issue #159). Mutually exclusive with proton-charge correction.
+        charge is unavailable (issue #159). Mutually exclusive with proton-charge correction. If
+        ``roi`` is also given the detector is cropped first, so ``background_roi`` indices are
+        resolved in the post-crop frame.
 
     Notes
     -----

--- a/src/neunorm/pipelines/mars_tpx3.py
+++ b/src/neunorm/pipelines/mars_tpx3.py
@@ -30,6 +30,7 @@ def run_mars_tpx3_pipeline(  # noqa: C901
     roi: Optional[tuple] = None,
     gamma_filter: bool = True,
     detector_shape: tuple[int, int] = (514, 514),
+    background_roi: Optional[tuple] = None,
 ) -> sc.DataArray:
     """Execute MARS TPX3 normalization pipeline.
 
@@ -60,6 +61,9 @@ def run_mars_tpx3_pipeline(  # noqa: C901
         Whether to apply gamma filtering to the sample data (default: True)
     detector_shape : tuple[int, int]
         Shape of the TPX3 detector (default: (514, 514))
+    background_roi : Optional[tuple]
+        Sample-free background ROI (x0, y0, x1, y1) for flux-proxy normalization when proton
+        charge is unavailable (issue #159). Mutually exclusive with proton-charge correction.
 
     Notes
     -----
@@ -116,8 +120,8 @@ def run_mars_tpx3_pipeline(  # noqa: C901
     if gamma_filter:
         sample = apply_gamma_filter(sample)
 
-    # Normalization
-    transmission = normalize_transmission(sample, ob)
+    # Normalization (background_roi flux proxy when provided, issue #159)
+    transmission = normalize_transmission(sample, ob, background_roi=background_roi)
 
     # Write output
     metadata = {

--- a/src/neunorm/pipelines/mars_tpx3.py
+++ b/src/neunorm/pipelines/mars_tpx3.py
@@ -135,6 +135,9 @@ def run_mars_tpx3_pipeline(  # noqa: C901
     if roi:
         metadata["roi_applied"] = roi
 
+    if background_roi is not None:
+        metadata["background_roi"] = list(background_roi)
+
     if output_path.suffix.lower() in (".hdf5", ".h5"):
         write_hdf5(
             output_path, transmission, dead_pixel_mask="dead_pixels", hot_pixel_mask="hot_pixels", metadata=metadata

--- a/src/neunorm/pipelines/mars_tpx3.py
+++ b/src/neunorm/pipelines/mars_tpx3.py
@@ -64,7 +64,7 @@ def run_mars_tpx3_pipeline(  # noqa: C901
         Shape of the TPX3 detector (default: (514, 514))
     background_roi : Optional[tuple]
         Sample-free background ROI (x0, y0, x1, y1) for flux-proxy normalization when proton
-        charge is unavailable (issue #159). Mutually exclusive with proton-charge correction. If
+        charge is unavailable. Mutually exclusive with proton-charge correction. If
         ``roi`` is also given the detector is cropped first, so ``background_roi`` indices are
         resolved in the post-crop frame.
 
@@ -79,7 +79,7 @@ def run_mars_tpx3_pipeline(  # noqa: C901
         Final normalized transmission DataArray with metadata and masks
     """
     # Accept an ROI or a bare (x0, y0, x1, y1) tuple for every ROI argument; coerce to bounds
-    # tuples up front so cropping and provenance see a consistent form (issue #159).
+    # tuples up front so cropping and provenance see a consistent form.
     if roi is not None:
         roi = as_roi_bounds(roi)
     if background_roi is not None:
@@ -129,7 +129,7 @@ def run_mars_tpx3_pipeline(  # noqa: C901
     if gamma_filter:
         sample = apply_gamma_filter(sample)
 
-    # Normalization (background_roi flux proxy when provided, issue #159)
+    # Normalization (background_roi flux proxy when provided)
     transmission = normalize_transmission(sample, ob, background_roi=background_roi)
 
     # Write output

--- a/src/neunorm/pipelines/venus_ccd.py
+++ b/src/neunorm/pipelines/venus_ccd.py
@@ -77,7 +77,9 @@ def run_venus_ccd_pipeline(  # noqa: C901
         If None, air correction is not applied.
     background_roi : Optional[tuple]
         Sample-free background ROI (x0, y0, x1, y1) for flux-proxy normalization when proton
-        charge is unavailable (issue #159). Mutually exclusive with proton-charge correction.
+        charge is unavailable (issue #159). Mutually exclusive with proton-charge correction. If
+        ``roi`` is also given the detector is cropped first, so ``background_roi`` indices are
+        resolved in the post-crop frame.
 
     Notes
     -----
@@ -161,6 +163,11 @@ def run_venus_ccd_pipeline(  # noqa: C901
             transmission = normalize_with_dark(sample, ob, dark, background_roi=background_roi)
         else:
             transmission = normalize_transmission(sample, ob, background_roi=background_roi)
+        # IntegratedPCharge was neither used nor aggregated in this mode (pc_keys=()), so the
+        # combined array still carries the first run's loaded value as an unaligned coord. Drop it
+        # so a stale, never-aggregated proton charge does not reach the output coords/provenance.
+        if "IntegratedPCharge" in transmission.coords:
+            del transmission.coords["IntegratedPCharge"]
     else:
         proton_charge_sample = sample.coords["IntegratedPCharge"].astype("float32")
         proton_charge_ob = ob.coords["IntegratedPCharge"].astype("float32")

--- a/src/neunorm/pipelines/venus_ccd.py
+++ b/src/neunorm/pipelines/venus_ccd.py
@@ -16,7 +16,6 @@ from neunorm.exporters.tiff_writer import write_tiff_stack
 from neunorm.filters.gamma_filter import apply_gamma_filter
 from neunorm.loaders.stack_loader import load_stack
 from neunorm.processing.air_region_corrector import apply_air_region_correction
-from neunorm.processing.dark_corrector import subtract_dark
 from neunorm.processing.normalizer import normalize_transmission, normalize_with_dark
 from neunorm.processing.reference_preparer import prepare_reference
 from neunorm.processing.roi_clipper import apply_roi
@@ -102,16 +101,19 @@ def run_venus_ccd_pipeline(  # noqa: C901
     # Keys to check ManufacturerStr. IntegratedPCharge is included in metadata checks and is
     # effectively averaged/normalized across runs (not summed) when normalize_by_runs=True.
 
+    # When background_roi is used (proton-charge proxy), don't require/aggregate IntegratedPCharge.
+    pc_keys = () if background_roi is not None else ("IntegratedPCharge",)
+
     sample = combine_runs(
         samples,
-        metadata_keys_to_sum=("IntegratedPCharge",),
+        metadata_keys_to_sum=pc_keys,
         metadata_check_match=["ManufacturerStr"],
         normalize_by_runs=True,
     )
 
     ob = combine_runs(
         ob,
-        metadata_keys_to_sum=("IntegratedPCharge",),
+        metadata_keys_to_sum=pc_keys,
         metadata_check_match=["ManufacturerStr"],
         normalize_by_runs=True,
     )
@@ -122,7 +124,7 @@ def run_venus_ccd_pipeline(  # noqa: C901
         dark_runs = [load_stack(paths) for paths in dark_paths]
         dark = combine_runs(
             dark_runs,
-            metadata_keys_to_sum=("IntegratedPCharge",),
+            metadata_keys_to_sum=pc_keys,
             metadata_check_match=["ManufacturerStr"],
             normalize_by_runs=True,
         )
@@ -153,10 +155,12 @@ def run_venus_ccd_pipeline(  # noqa: C901
     # variance is not double-counted in the transmission uncertainty (issue #142).
     if background_roi is not None:
         # Flux-proxy normalization from a sample-free ROI (issue #159), replacing the proton-charge
-        # correction (mutually exclusive). Dark-correct first if a dark frame was supplied.
-        s = subtract_dark(sample, dark) if dark is not None else sample
-        o = subtract_dark(ob, dark) if dark is not None else ob
-        transmission = normalize_transmission(s, o, background_roi=background_roi)
+        # correction. With a shared dark, route through normalize_with_dark so the #142 shared-dark
+        # variance double-count is corrected (k = co/cs).
+        if dark is not None:
+            transmission = normalize_with_dark(sample, ob, dark, background_roi=background_roi)
+        else:
+            transmission = normalize_transmission(sample, ob, background_roi=background_roi)
     else:
         proton_charge_sample = sample.coords["IntegratedPCharge"].astype("float32")
         proton_charge_ob = ob.coords["IntegratedPCharge"].astype("float32")
@@ -201,6 +205,9 @@ def run_venus_ccd_pipeline(  # noqa: C901
 
     if roi:
         metadata["roi_applied"] = roi
+
+    if background_roi is not None:
+        metadata["background_roi"] = list(background_roi)
 
     if output_path.suffix.lower() in (".hdf5", ".h5"):
         write_hdf5(output_path, transmission, dead_pixel_mask="dead_pixels", metadata=metadata)

--- a/src/neunorm/pipelines/venus_ccd.py
+++ b/src/neunorm/pipelines/venus_ccd.py
@@ -11,6 +11,7 @@ import scipp as sc
 from loguru import logger
 
 from neunorm import __version__
+from neunorm.data_models.roi import ROILike, as_roi_bounds
 from neunorm.exporters.hdf5_writer import write_hdf5
 from neunorm.exporters.tiff_writer import write_tiff_stack
 from neunorm.filters.gamma_filter import apply_gamma_filter
@@ -28,10 +29,10 @@ def run_venus_ccd_pipeline(  # noqa: C901
     ob_paths: Sequence[Sequence[str | Path]],
     dark_paths: Optional[Sequence[Sequence[str | Path]]] = None,
     output_path: Optional[Path] = None,
-    roi: Optional[tuple] = None,
+    roi: Optional[ROILike] = None,
     gamma_filter: bool = True,
-    air_roi: Optional[tuple] = None,
-    background_roi: Optional[tuple] = None,
+    air_roi: Optional[ROILike] = None,
+    background_roi: Optional[ROILike] = None,
 ) -> sc.DataArray:
     """Execute VENUS CCD/CMOS normalization pipeline.
 
@@ -69,11 +70,11 @@ def run_venus_ccd_pipeline(  # noqa: C901
         raises ``ValueError`` (the default exists only so ``dark_paths`` can keep
         its positional slot).
     roi : Optional[tuple]
-        Region of interest to apply (x_start, y_start, x_end, y_end)
+        Region of interest to crop to — an ``ROI`` or a bare ``(x0, y0, x1, y1)`` tuple.
     gamma_filter : bool
         Whether to apply gamma filtering to the sample data (default: True)
     air_roi : Optional[tuple]
-        Region of interest to use for air correction (x_start, y_start, x_end, y_end).
+        Region of interest for air correction — an ``ROI`` or a bare ``(x0, y0, x1, y1)`` tuple.
         If None, air correction is not applied.
     background_roi : Optional[tuple]
         Sample-free background ROI (x0, y0, x1, y1) for flux-proxy normalization when proton
@@ -91,6 +92,14 @@ def run_venus_ccd_pipeline(  # noqa: C901
     sc.DataArray
         Final normalized transmission DataArray with metadata and masks
     """
+    # Accept an ROI or a bare (x0, y0, x1, y1) tuple for every ROI argument; coerce to bounds
+    # tuples up front so cropping and provenance see a consistent form (issue #159).
+    if roi is not None:
+        roi = as_roi_bounds(roi)
+    if air_roi is not None:
+        air_roi = as_roi_bounds(air_roi)
+    if background_roi is not None:
+        background_roi = as_roi_bounds(background_roi)
 
     if output_path is None:
         raise ValueError("output_path is required")

--- a/src/neunorm/pipelines/venus_ccd.py
+++ b/src/neunorm/pipelines/venus_ccd.py
@@ -78,7 +78,7 @@ def run_venus_ccd_pipeline(  # noqa: C901
         If None, air correction is not applied.
     background_roi : Optional[tuple]
         Sample-free background ROI (x0, y0, x1, y1) for flux-proxy normalization when proton
-        charge is unavailable (issue #159). Mutually exclusive with proton-charge correction. If
+        charge is unavailable. Mutually exclusive with proton-charge correction. If
         ``roi`` is also given the detector is cropped first, so ``background_roi`` indices are
         resolved in the post-crop frame.
 
@@ -93,7 +93,7 @@ def run_venus_ccd_pipeline(  # noqa: C901
         Final normalized transmission DataArray with metadata and masks
     """
     # Accept an ROI or a bare (x0, y0, x1, y1) tuple for every ROI argument; coerce to bounds
-    # tuples up front so cropping and provenance see a consistent form (issue #159).
+    # tuples up front so cropping and provenance see a consistent form.
     if roi is not None:
         roi = as_roi_bounds(roi)
     if air_roi is not None:
@@ -129,7 +129,7 @@ def run_venus_ccd_pipeline(  # noqa: C901
         normalize_by_runs=True,
     )
 
-    # Dark current is optional (issue #146): only load/combine it when dark paths are provided.
+    # Dark current is optional: only load/combine it when dark paths are provided.
     dark = None
     if dark_paths:
         dark_runs = [load_stack(paths) for paths in dark_paths]
@@ -160,13 +160,13 @@ def run_venus_ccd_pipeline(  # noqa: C901
         sample = apply_gamma_filter(sample)
 
     # Dark correction (optional) + normalization. The proton-charge coords are cast to float32
-    # so the division does not silently re-promote the float32 image data to float64 (issue
-    # #147; the coord is float64 because metadata is parsed via float()). With a shared dark
+    # so the division does not silently re-promote the float32 image data to float64 (the coord
+    # is float64 because metadata is parsed via float()). With a shared dark
     # frame, normalize_with_dark subtracts the dark and normalizes in one step so the dark
-    # variance is not double-counted in the transmission uncertainty (issue #142).
+    # variance is not double-counted in the transmission uncertainty.
     if background_roi is not None:
-        # Flux-proxy normalization from a sample-free ROI (issue #159), replacing the proton-charge
-        # correction. With a shared dark, route through normalize_with_dark so the #142 shared-dark
+        # Flux-proxy normalization from a sample-free ROI, replacing the proton-charge
+        # correction. With a shared dark, route through normalize_with_dark so the shared-dark
         # variance double-count is corrected (k = co/cs).
         if dark is not None:
             transmission = normalize_with_dark(sample, ob, dark, background_roi=background_roi)
@@ -201,7 +201,7 @@ def run_venus_ccd_pipeline(  # noqa: C901
     if air_roi is not None:
         transmission = apply_air_region_correction(transmission, air_roi)
 
-    # Guarantee a float32 normalized data product (issue #147), regardless of any
+    # Guarantee a float32 normalized data product, regardless of any
     # intermediate dtype promotion. .astype converts values and variances.
     transmission = transmission.astype("float32")
 

--- a/src/neunorm/pipelines/venus_ccd.py
+++ b/src/neunorm/pipelines/venus_ccd.py
@@ -16,6 +16,7 @@ from neunorm.exporters.tiff_writer import write_tiff_stack
 from neunorm.filters.gamma_filter import apply_gamma_filter
 from neunorm.loaders.stack_loader import load_stack
 from neunorm.processing.air_region_corrector import apply_air_region_correction
+from neunorm.processing.dark_corrector import subtract_dark
 from neunorm.processing.normalizer import normalize_transmission, normalize_with_dark
 from neunorm.processing.reference_preparer import prepare_reference
 from neunorm.processing.roi_clipper import apply_roi
@@ -31,6 +32,7 @@ def run_venus_ccd_pipeline(  # noqa: C901
     roi: Optional[tuple] = None,
     gamma_filter: bool = True,
     air_roi: Optional[tuple] = None,
+    background_roi: Optional[tuple] = None,
 ) -> sc.DataArray:
     """Execute VENUS CCD/CMOS normalization pipeline.
 
@@ -74,6 +76,9 @@ def run_venus_ccd_pipeline(  # noqa: C901
     air_roi : Optional[tuple]
         Region of interest to use for air correction (x_start, y_start, x_end, y_end).
         If None, air correction is not applied.
+    background_roi : Optional[tuple]
+        Sample-free background ROI (x0, y0, x1, y1) for flux-proxy normalization when proton
+        charge is unavailable (issue #159). Mutually exclusive with proton-charge correction.
 
     Notes
     -----
@@ -146,24 +151,31 @@ def run_venus_ccd_pipeline(  # noqa: C901
     # #147; the coord is float64 because metadata is parsed via float()). With a shared dark
     # frame, normalize_with_dark subtracts the dark and normalizes in one step so the dark
     # variance is not double-counted in the transmission uncertainty (issue #142).
-    proton_charge_sample = sample.coords["IntegratedPCharge"].astype("float32")
-    proton_charge_ob = ob.coords["IntegratedPCharge"].astype("float32")
-    if dark is not None:
-        transmission = normalize_with_dark(
-            sample,
-            ob,
-            dark,
-            proton_charge_sample=proton_charge_sample,
-            proton_charge_ob=proton_charge_ob,
-        )
+    if background_roi is not None:
+        # Flux-proxy normalization from a sample-free ROI (issue #159), replacing the proton-charge
+        # correction (mutually exclusive). Dark-correct first if a dark frame was supplied.
+        s = subtract_dark(sample, dark) if dark is not None else sample
+        o = subtract_dark(ob, dark) if dark is not None else ob
+        transmission = normalize_transmission(s, o, background_roi=background_roi)
     else:
-        logger.info("No dark current provided; skipping dark correction")
-        transmission = normalize_transmission(
-            sample=sample,
-            ob=ob,
-            proton_charge_sample=proton_charge_sample,
-            proton_charge_ob=proton_charge_ob,
-        )
+        proton_charge_sample = sample.coords["IntegratedPCharge"].astype("float32")
+        proton_charge_ob = ob.coords["IntegratedPCharge"].astype("float32")
+        if dark is not None:
+            transmission = normalize_with_dark(
+                sample,
+                ob,
+                dark,
+                proton_charge_sample=proton_charge_sample,
+                proton_charge_ob=proton_charge_ob,
+            )
+        else:
+            logger.info("No dark current provided; skipping dark correction")
+            transmission = normalize_transmission(
+                sample=sample,
+                ob=ob,
+                proton_charge_sample=proton_charge_sample,
+                proton_charge_ob=proton_charge_ob,
+            )
 
     # Air region correction (optional)
     if air_roi is not None:

--- a/src/neunorm/pipelines/venus_tpx1.py
+++ b/src/neunorm/pipelines/venus_tpx1.py
@@ -99,7 +99,7 @@ def run_venus_tpx1_pipeline(  # noqa: C901
         Final normalized transmission DataArray with metadata and masks
     """
     # Accept an ROI or a bare (x0, y0, x1, y1) tuple for every ROI argument; coerce to bounds
-    # tuples up front so cropping and provenance see a consistent form (issue #159).
+    # tuples up front so cropping and provenance see a consistent form.
     if roi is not None:
         roi = as_roi_bounds(roi)
     if air_roi is not None:
@@ -209,7 +209,7 @@ def run_venus_tpx1_pipeline(  # noqa: C901
         transmission = apply_air_region_correction(transmission, air_roi)
 
     # Add wavelength and energy coordinates converted from TOF using the configurable flight
-    # path and the time offset from the metadata (issue #141).
+    # path and the time offset from the metadata.
     if "detector_time_offset" in sample.coords:
         time_offset = sample.coords["detector_time_offset"]
         transmission.coords["wavelength"] = convert_tof_to_wavelength(

--- a/src/neunorm/pipelines/venus_tpx1.py
+++ b/src/neunorm/pipelines/venus_tpx1.py
@@ -11,6 +11,7 @@ import scipp as sc
 from loguru import logger
 
 from neunorm import __version__
+from neunorm.data_models.roi import ROILike, as_roi_bounds
 from neunorm.exporters.hdf5_writer import write_hdf5
 from neunorm.exporters.tiff_writer import write_tiff_stack
 from neunorm.loaders.metadata_loader import load_metadata
@@ -33,8 +34,8 @@ def run_venus_tpx1_pipeline(  # noqa: C901
     sample_tiff_paths: Sequence[Sequence[str | Path]],
     ob_tiff_paths: Sequence[Sequence[str | Path]],
     output_path: Path,
-    roi: Optional[tuple] = None,
-    air_roi: Optional[tuple] = None,
+    roi: Optional[ROILike] = None,
+    air_roi: Optional[ROILike] = None,
     rebin_by_tof: Optional[bool | int] = False,
     rebin_by_spatial: Optional[int | tuple[int, int]] = None,
     flight_path: sc.Variable = sc.scalar(VENUS_FLIGHT_PATH_M, unit="m"),
@@ -72,9 +73,9 @@ def run_venus_tpx1_pipeline(  # noqa: C901
     output_path : Path
         Path to save the output file (HDF5 or TIFF)
     roi : Optional[tuple]
-        Region of interest to apply (x_start, y_start, x_end, y_end)
+        Region of interest to crop to — an ``ROI`` or a bare ``(x0, y0, x1, y1)`` tuple.
     air_roi : Optional[tuple]
-        Region of interest to use for air correction (x_start, y_start, x_end, y_end).
+        Region of interest for air correction — an ``ROI`` or a bare ``(x0, y0, x1, y1)`` tuple.
         If None, air correction is not applied.
     rebin_by_tof : Optional[Union[bool,int]]
         Whether to apply TOF rebinning based on statistics analysis. If an integer is provided,
@@ -97,6 +98,12 @@ def run_venus_tpx1_pipeline(  # noqa: C901
     sc.DataArray
         Final normalized transmission DataArray with metadata and masks
     """
+    # Accept an ROI or a bare (x0, y0, x1, y1) tuple for every ROI argument; coerce to bounds
+    # tuples up front so cropping and provenance see a consistent form (issue #159).
+    if roi is not None:
+        roi = as_roi_bounds(roi)
+    if air_roi is not None:
+        air_roi = as_roi_bounds(air_roi)
 
     # length of hdf5 paths and tiff paths should match for both sample and OB
     if len(sample_hdf5_paths) != len(sample_tiff_paths):

--- a/src/neunorm/pipelines/venus_tpx3_event.py
+++ b/src/neunorm/pipelines/venus_tpx3_event.py
@@ -11,6 +11,7 @@ import scipp as sc
 from loguru import logger
 
 from neunorm import __version__
+from neunorm.data_models.roi import ROILike, as_roi_bounds
 from neunorm.data_models.tof import BinningConfig
 from neunorm.exporters.hdf5_writer import write_hdf5
 from neunorm.exporters.tiff_writer import write_tiff_stack
@@ -34,8 +35,8 @@ def run_venus_tpx3_event_pipeline(  # noqa: C901
     ob_paths: Sequence[str | Path],
     binning: BinningConfig,
     output_path: Path,
-    roi: Optional[tuple] = None,
-    air_roi: Optional[tuple] = None,
+    roi: Optional[ROILike] = None,
+    air_roi: Optional[ROILike] = None,
     rebin_by_tof: Optional[bool | int] = False,
     rebin_by_spatial: Optional[int | tuple[int, int]] = None,
     detector_shape: tuple[int, int] = (514, 514),
@@ -72,9 +73,9 @@ def run_venus_tpx3_event_pipeline(  # noqa: C901
     output_path : Path
         Path to save the output file (HDF5 or TIFF)
     roi : Optional[tuple]
-        Region of interest to apply (x_start, y_start, x_end, y_end)
+        Region of interest to crop to — an ``ROI`` or a bare ``(x0, y0, x1, y1)`` tuple.
     air_roi : Optional[tuple]
-        Region of interest for air correction (x_start, y_start, x_end, y_end)
+        Region of interest for air correction — an ``ROI`` or a bare ``(x0, y0, x1, y1)`` tuple.
     rebin_by_tof : Optional[bool,int]
         Whether to apply TOF rebinning based on statistics analysis. If an integer is provided,
         it will be used as the rebinning factor instead of the recommended one.
@@ -104,6 +105,12 @@ def run_venus_tpx3_event_pipeline(  # noqa: C901
     sc.DataArray
         Final normalized transmission DataArray with metadata and masks
     """
+    # Accept an ROI or a bare (x0, y0, x1, y1) tuple for every ROI argument; coerce to bounds
+    # tuples up front so cropping and provenance see a consistent form (issue #159).
+    if roi is not None:
+        roi = as_roi_bounds(roi)
+    if air_roi is not None:
+        air_roi = as_roi_bounds(air_roi)
 
     x_bins, y_bins = detector_shape
 

--- a/src/neunorm/pipelines/venus_tpx3_event.py
+++ b/src/neunorm/pipelines/venus_tpx3_event.py
@@ -106,7 +106,7 @@ def run_venus_tpx3_event_pipeline(  # noqa: C901
         Final normalized transmission DataArray with metadata and masks
     """
     # Accept an ROI or a bare (x0, y0, x1, y1) tuple for every ROI argument; coerce to bounds
-    # tuples up front so cropping and provenance see a consistent form (issue #159).
+    # tuples up front so cropping and provenance see a consistent form.
     if roi is not None:
         roi = as_roi_bounds(roi)
     if air_roi is not None:
@@ -115,7 +115,7 @@ def run_venus_tpx3_event_pipeline(  # noqa: C901
     x_bins, y_bins = detector_shape
 
     # Load metadata before histogramming so the detector time offset can be applied to
-    # energy/wavelength bin edges (issue #141); a missing offset defaults to zero.
+    # energy/wavelength bin edges; a missing offset defaults to zero.
     samples = []
     for run in sample_paths:
         metadata = load_metadata(run)
@@ -216,7 +216,7 @@ def run_venus_tpx3_event_pipeline(  # noqa: C901
         transmission = apply_air_region_correction(transmission, air_roi)
 
     # Add wavelength and energy coordinates converted from TOF using the same flight path as
-    # the binning step and the time offset from the metadata (issue #141).
+    # the binning step and the time offset from the metadata.
     if "detector_time_offset" in sample.coords:
         time_offset = sample.coords["detector_time_offset"]
         transmission.coords["wavelength"] = convert_tof_to_wavelength(

--- a/src/neunorm/pipelines/venus_tpx3_histogram.py
+++ b/src/neunorm/pipelines/venus_tpx3_histogram.py
@@ -100,7 +100,7 @@ def run_venus_tpx3_histogram_pipeline(  # noqa: C901
         Final normalized transmission DataArray with metadata and masks
     """
     # Accept an ROI or a bare (x0, y0, x1, y1) tuple for every ROI argument; coerce to bounds
-    # tuples up front so cropping and provenance see a consistent form (issue #159).
+    # tuples up front so cropping and provenance see a consistent form.
     if roi is not None:
         roi = as_roi_bounds(roi)
     if air_roi is not None:
@@ -232,7 +232,7 @@ def run_venus_tpx3_histogram_pipeline(  # noqa: C901
         transmission = apply_air_region_correction(transmission, air_roi)
 
     # Add wavelength and energy coordinates converted from TOF using the configurable flight
-    # path and the time offset from the metadata (issue #141).
+    # path and the time offset from the metadata.
     if "detector_time_offset" in sample.coords:
         time_offset = sample.coords["detector_time_offset"]
         transmission.coords["wavelength"] = convert_tof_to_wavelength(

--- a/src/neunorm/pipelines/venus_tpx3_histogram.py
+++ b/src/neunorm/pipelines/venus_tpx3_histogram.py
@@ -11,6 +11,7 @@ import scipp as sc
 from loguru import logger
 
 from neunorm import __version__
+from neunorm.data_models.roi import ROILike, as_roi_bounds
 from neunorm.exporters.hdf5_writer import write_hdf5
 from neunorm.exporters.tiff_writer import write_tiff_stack
 from neunorm.loaders.metadata_loader import load_metadata
@@ -33,8 +34,8 @@ def run_venus_tpx3_histogram_pipeline(  # noqa: C901
     sample_tiff_paths: Sequence[Sequence[str | Path]],
     ob_tiff_paths: Sequence[Sequence[str | Path]],
     output_path: Path,
-    roi: Optional[tuple] = None,
-    air_roi: Optional[tuple] = None,
+    roi: Optional[ROILike] = None,
+    air_roi: Optional[ROILike] = None,
     rebin_by_tof: Optional[bool | int] = False,
     rebin_by_spatial: Optional[int | tuple[int, int]] = None,
     flight_path: sc.Variable = sc.scalar(VENUS_FLIGHT_PATH_M, unit="m"),
@@ -73,9 +74,9 @@ def run_venus_tpx3_histogram_pipeline(  # noqa: C901
     output_path : Path
         Path to save the output file (HDF5 or TIFF)
     roi : Optional[tuple]
-        Region of interest to apply (x_start, y_start, x_end, y_end)
+        Region of interest to crop to — an ``ROI`` or a bare ``(x0, y0, x1, y1)`` tuple.
     air_roi : Optional[tuple]
-        Region of interest to use for air correction (x_start, y_start, x_end, y_end).
+        Region of interest for air correction — an ``ROI`` or a bare ``(x0, y0, x1, y1)`` tuple.
         If None, air correction is not applied.
     rebin_by_tof : Optional[Union[bool,int]]
         Whether to apply TOF rebinning based on statistics analysis. If an integer is provided,
@@ -98,6 +99,12 @@ def run_venus_tpx3_histogram_pipeline(  # noqa: C901
     sc.DataArray
         Final normalized transmission DataArray with metadata and masks
     """
+    # Accept an ROI or a bare (x0, y0, x1, y1) tuple for every ROI argument; coerce to bounds
+    # tuples up front so cropping and provenance see a consistent form (issue #159).
+    if roi is not None:
+        roi = as_roi_bounds(roi)
+    if air_roi is not None:
+        air_roi = as_roi_bounds(air_roi)
 
     # length of hdf5 paths and tiff paths should match for both sample and OB
     if len(sample_hdf5_paths) != len(sample_tiff_paths):

--- a/src/neunorm/processing/air_region_corrector.py
+++ b/src/neunorm/processing/air_region_corrector.py
@@ -5,12 +5,12 @@ Air region correction.
 import scipp as sc
 from loguru import logger
 
+from neunorm.data_models.roi import ROILike, as_roi_bounds
+
 
 def apply_air_region_correction(
     transmission: sc.DataArray,
-    air_roi: tuple[
-        int, int, int, int
-    ],  # (x0, y0, x1, y1) with x1, y1 as exclusive stop indices (Python slice semantics)
+    air_roi: ROILike,  # (x0, y0, x1, y1) tuple or an ROI; x1, y1 are exclusive stops
 ) -> sc.DataArray:
     """Scale transmission so air region has mean = 1.0.
 
@@ -35,10 +35,12 @@ def apply_air_region_correction(
     ----------
     transmission : sc.DataArray
         Normalized transmission (after OB correction)
-    air_roi : tuple[int, int, int, int]
-        Coordinates of the air region (x0, y0, x1, y1), where x1 and y1 are exclusive upper bound
+    air_roi : ROI or tuple[int, int, int, int]
+        Air region as an :class:`~neunorm.data_models.roi.ROI` or a bare ``(x0, y0, x1, y1)`` tuple,
+        where x1 and y1 are exclusive upper bounds.
 
     """
+    air_roi = as_roi_bounds(air_roi)
 
     logger.info(f"Applying air region correction with ROI: {air_roi}")
 

--- a/src/neunorm/processing/normalizer.py
+++ b/src/neunorm/processing/normalizer.py
@@ -25,6 +25,11 @@ def _background_roi_means(
     semantics, matching ``apply_roi`` / ``apply_air_region_correction``). The means reduce the
     spatial ``x``/``y`` dimensions, so for 3D ``(spectral, x, y)`` data they are computed per
     spectral bin. The returned scipp scalars/arrays carry the variance of the mean.
+
+    Note: the reduction is mask-aware, so masked pixels in the ROI are excluded from the value.
+    Their variance follows scipp's masked-reduction convention, which is slightly *conservative*
+    (the ROI-mean uncertainty can be marginally larger than ``sum(unmasked var) / n_unmasked**2``);
+    it never under-states the uncertainty.
     """
     if not (
         isinstance(background_roi, (tuple, list))
@@ -46,6 +51,16 @@ def _background_roi_means(
     # then take .data to drop coords (avoids coord-mismatch in the subsequent division).
     cs = sc.mean(sample["x", x0:x1]["y", y0:y1], dim=["x", "y"]).data
     co = sc.mean(ob["x", x0:x1]["y", y0:y1], dim=["x", "y"]).data
+    # The proxy divides by these means (and uses 1/cs**2, 1/co**2 in the variance term), and
+    # normalize_with_dark forms k = co/cs, so a zero or non-finite ROI mean — e.g. an all-masked or
+    # empty-counts ROI — would silently yield inf/nan transmission. Fail loudly instead: a background
+    # ROI must be a bright, sample-free region with positive counts.
+    for name, m in (("sample", cs), ("ob", co)):
+        if not bool(sc.all(sc.isfinite(m)).value) or sc.min(m).value <= 0:
+            raise ValueError(
+                f"background_roi {background_roi} {name} mean must be strictly positive and finite "
+                f"(min={sc.min(m).value}); the ROI must contain positive counts in every image"
+            )
     return cs, co
 
 
@@ -87,7 +102,10 @@ def normalize_transmission(  # noqa: C901
         each image is normalized by its mean counts in this ROI — a proton-charge proxy for
         when proton charge is unavailable (e.g. MARS): ``T = (S/mean(S[B])) / (O/mean(O[B]))``.
         Mutually exclusive with ``proton_charge_sample`` / ``proton_charge_ob``. Uncertainty is
-        propagated first-order (the in-ROI sample/ROI-mean correlation is not corrected).
+        propagated first-order (the in-ROI sample/ROI-mean correlation is not corrected). Raises
+        ``ValueError`` if the ROI mean is not strictly positive and finite in every image. Indices
+        are resolved against the passed arrays; if a pipeline crops with ``roi`` first, give
+        ``background_roi`` in the post-crop frame.
 
     Returns
     -------

--- a/src/neunorm/processing/normalizer.py
+++ b/src/neunorm/processing/normalizer.py
@@ -183,7 +183,7 @@ def normalize_transmission(  # noqa: C901
     if background_roi is not None:
         background_roi = as_roi_bounds(background_roi)
 
-    # Background-ROI flux normalization (issue #159): when no proton charge is available
+    # Background-ROI flux normalization: when no proton charge is available
     # (e.g. MARS), scale each image by its mean counts in a sample-free ROI so per-image
     # beam-flux differences cancel: T = (S/mean(S[B])) / (O/mean(O[B])). First-order UQ.
     if background_roi is not None:
@@ -288,7 +288,7 @@ def normalize_transmission(  # noqa: C901
             co_term = co_var / (co * co)
             coeff_rel_var = co_term if coeff_rel_var is None else coeff_rel_var + co_term
         extra = sc.array(dims=list(transmission.dims), values=transmission.values**2) * coeff_rel_var
-        # Keep the variance dtype stable (issue #147 float32 pipelines), matching normalize_with_dark.
+        # Keep the variance dtype stable (float32 pipelines), matching normalize_with_dark.
         transmission.variances = transmission.variances + extra.values.astype(transmission.variances.dtype, copy=False)
 
     logger.success("✓ Transmission normalized")
@@ -311,7 +311,7 @@ def normalize_with_dark(
     correction) where the **same** averaged ``dark`` is subtracted from both sample and open
     beam. ``subtract_dark`` + ``normalize_transmission`` would treat the numerator and
     denominator as statistically independent and propagate ``Var(dark)`` twice; this function
-    removes that spurious shared-dark covariance term (issue #142).
+    removes that spurious shared-dark covariance term.
 
     The transmission **values** are identical to
     ``normalize_transmission(subtract_dark(sample, dark), subtract_dark(ob, dark), ...)`` — only
@@ -333,7 +333,7 @@ def normalize_with_dark(
         charge. The shared-dark correction then uses ``k = co/cs`` (ratio of dark-corrected ROI
         means) in place of the proton-charge ratio, and additionally removes the ROI-mean shared-dark
         covariance term ``2*T^2*Cov(cs,co)/(cs*co)`` (``Cov(cs,co) = Var(mean(D_roi))``) — the
-        ROI-mean analog of the #142 pixel-level correction. (The in-ROI pixel/ROI-mean correlation
+        ROI-mean analog of the pixel-level correction. (The in-ROI pixel/ROI-mean correlation
         remains uncorrected, as documented on ``normalize_transmission``.)
 
     Returns
@@ -350,7 +350,7 @@ def normalize_with_dark(
         sample_dc, ob_dc, proton_charge_sample, proton_charge_ob, pc_uncertainty, background_roi=background_roi
     )
 
-    # Correct the shared-dark double-count (issue #142). normalize_transmission propagated
+    # Correct the shared-dark double-count. normalize_transmission propagated
     # Var(dark) through BOTH numerator and denominator as if they were independent; the true
     # propagation (dark appears once) is smaller by 2*k^2*s*Var(D)/o^3. Subtract that term.
     if transmission.variances is None or dark.variances is None:
@@ -380,7 +380,7 @@ def normalize_with_dark(
     # same ROI dark pixels, so Cov(cs, co) = Var(mean(D_roi)) > 0. normalize_transmission added the
     # ROI-mean term T^2 * (Var(cs)/cs^2 + Var(co)/co^2) treating cs and co as independent; subtract
     # the missing covariance term 2 * T^2 * Cov(cs,co) / (cs*co) too — the ROI-mean analog of the
-    # #142 pixel-level correction. (The in-ROI pixel<->mean correlation stays uncorrected, as
+    # pixel-level correction. (The in-ROI pixel<->mean correlation stays uncorrected, as
     # documented; for a clean background ROI the dark-mean covariance is the only remaining term.)
     if background_roi is not None:
         # Cov(cs,co) is mask-consistent with cs/co (it counts only the ROI dark pixels left unmasked
@@ -396,7 +396,7 @@ def normalize_with_dark(
     over_values = np.where(np.isfinite(over_values), over_values, 0.0)
     # Clamp to >= 0 defensively; the corrected variance is a true (non-negative) variance.
     transmission.variances = np.clip(transmission.variances - over_values, 0.0, None)
-    logger.success("✓ Shared-dark variance double-count corrected (issue #142)")
+    logger.success("✓ Shared-dark variance double-count corrected")
 
     return transmission
 

--- a/src/neunorm/processing/normalizer.py
+++ b/src/neunorm/processing/normalizer.py
@@ -146,15 +146,13 @@ def normalize_transmission(  # noqa: C901
         logger.info("Applying background-ROI flux normalization with ROI {}", background_roi)
         cs, co = _background_roi_means(sample, ob, background_roi)
         # scipp refuses to broadcast a variance-bearing scalar across the image (it would introduce
-        # correlations), so divide by the variance-free means and add their variance contribution below.
-        # Only when the inputs carry variance: strip the ROI-mean variance (scipp cannot broadcast
-        # a variance-bearing scalar) and re-add its contribution after the division (below).
-        if cs.variances is not None:
-            cs_var, co_var = sc.variances(cs), sc.variances(co)
-            cs.variances = None
-            co.variances = None
-        else:
-            cs_var = co_var = None
+        # correlations), so divide by the variance-free means and re-add their variance contribution
+        # below. Handle cs and co INDEPENDENTLY — the two inputs may carry variance on one side only
+        # (a variance-bearing co would otherwise make `ob / co` raise).
+        cs_var = sc.variances(cs) if cs.variances is not None else None
+        co_var = sc.variances(co) if co.variances is not None else None
+        cs.variances = None
+        co.variances = None
         sample_corrected = sample / cs
         ob_corrected = ob / co
     else:
@@ -227,9 +225,15 @@ def normalize_transmission(  # noqa: C901
 
     # First-order contribution of the background-ROI mean uncertainty, added here because scipp
     # could not propagate it through the shared-scalar division above. Treats sample/ob/cs/co as
-    # independent: Var(T) += T^2 * (Var(cs)/cs^2 + Var(co)/co^2).
-    if background_roi is not None and transmission.variances is not None and cs_var is not None:
-        coeff_rel_var = cs_var / (cs * cs) + co_var / (co * co)
+    # independent: Var(T) += T^2 * (Var(cs)/cs^2 + Var(co)/co^2). Accumulate whichever side carries
+    # variance (inputs may be variance-bearing on one side only).
+    if background_roi is not None and transmission.variances is not None and (cs_var is not None or co_var is not None):
+        coeff_rel_var = None
+        if cs_var is not None:
+            coeff_rel_var = cs_var / (cs * cs)
+        if co_var is not None:
+            co_term = co_var / (co * co)
+            coeff_rel_var = co_term if coeff_rel_var is None else coeff_rel_var + co_term
         extra = sc.array(dims=list(transmission.dims), values=transmission.values**2) * coeff_rel_var
         transmission.variances = transmission.variances + extra.values
 

--- a/src/neunorm/processing/normalizer.py
+++ b/src/neunorm/processing/normalizer.py
@@ -64,6 +64,50 @@ def _background_roi_means(
     return cs, co
 
 
+def _roi_dark_mean_covariance(
+    sample_dc: sc.DataArray,
+    ob_dc: sc.DataArray,
+    dark: sc.DataArray,
+    background_roi: tuple[int, int, int, int],
+) -> sc.Variable:
+    """Covariance of the two background-ROI means induced by the shared dark frame.
+
+    ``cs = mean(S - D)`` and ``co = mean(O - D)`` over the ROI are mask-aware (see
+    ``_background_roi_means``) and share the ROI dark pixels, so
+    ``Cov(cs, co) = (1 / (n_s * n_o)) * sum_{k in A∩B} Var(D_k)`` where A / B are the ROI pixels left
+    unmasked in ``sample_dc`` / ``ob_dc`` (counts ``n_s`` / ``n_o``) and A∩B is their intersection.
+    With no masks this reduces to ``Var(mean(D_roi))``. Assumes spatial ``(x, y)`` masks
+    (dead/hot pixels), which is what the CCD pipelines produce.
+
+    Returns a scalar ``sc.Variable`` carrying units of ``dark**2`` (counts**2).
+    """
+    x0, y0, x1, y1 = background_roi
+    d_roi = dark["x", x0:x1]["y", y0:y1].copy()
+    s_roi = sample_dc["x", x0:x1]["y", y0:y1]
+    o_roi = ob_dc["x", x0:x1]["y", y0:y1]
+
+    def _excluded(da: sc.DataArray):  # OR of all masks over the ROI, or None when unmasked
+        m = None
+        for mask in da.masks.values():
+            m = mask if m is None else (m | mask)
+        return m
+
+    ms, mo = _excluded(s_roi), _excluded(o_roi)
+    n_xy = d_roi.sizes["x"] * d_roi.sizes["y"]
+    n_s = n_xy - (int(sc.sum(ms).value) if ms is not None else 0)
+    n_o = n_xy - (int(sc.sum(mo).value) if mo is not None else 0)
+
+    # sum Var(D) over A∩B: mask the dark with the union of both sides' masks; sc.sum is mask-aware
+    # and propagates variance as the sum of unmasked variances.
+    excl = ms if mo is None else (mo if ms is None else (ms | mo))
+    if excl is not None:
+        d_roi.masks["_bg_excl"] = excl
+    intersection_var_sum = sc.variances(sc.sum(d_roi, dim=["x", "y"]).data)  # scalar, counts**2
+
+    denom = n_s * n_o
+    return intersection_var_sum / denom if denom > 0 else 0.0 * intersection_var_sum
+
+
 def normalize_transmission(  # noqa: C901
     sample: sc.DataArray,
     ob: sc.DataArray,
@@ -330,8 +374,9 @@ def normalize_with_dark(
     # #142 pixel-level correction. (The in-ROI pixel<->mean correlation stays uncorrected, as
     # documented; for a clean background ROI the dark-mean covariance is the only remaining term.)
     if background_roi is not None:
-        x0, y0, x1, y1 = background_roi
-        cov_cs_co = sc.variances(sc.mean(dark["x", x0:x1]["y", y0:y1], dim=["x", "y"]).data)
+        # Cov(cs,co) is mask-consistent with cs/co (it counts only the ROI dark pixels left unmasked
+        # in BOTH sample and OB), so a dead/hot pixel masked from one side does not pollute it.
+        cov_cs_co = _roi_dark_mean_covariance(sample_dc, ob_dc, dark, background_roi)
         t_v = sc.values(transmission)
         over_count = over_count + 2.0 * t_v * t_v * cov_cs_co / (cs_v * co_v)
 

--- a/src/neunorm/processing/normalizer.py
+++ b/src/neunorm/processing/normalizer.py
@@ -14,12 +14,46 @@ from loguru import logger
 from neunorm.processing.dark_corrector import subtract_dark
 
 
+def _background_roi_means(
+    sample: sc.DataArray,
+    ob: sc.DataArray,
+    background_roi: tuple[int, int, int, int],
+) -> tuple[sc.Variable, sc.Variable]:
+    """Validate ``background_roi`` and return the per-image mean counts (cs, co) over it.
+
+    ``background_roi`` is ``(x0, y0, x1, y1)`` with exclusive stop indices (Python slice
+    semantics, matching ``apply_roi`` / ``apply_air_region_correction``). The means reduce the
+    spatial ``x``/``y`` dimensions, so for 3D ``(spectral, x, y)`` data they are computed per
+    spectral bin. The returned scipp scalars/arrays carry the variance of the mean.
+    """
+    if not (
+        isinstance(background_roi, (tuple, list))
+        and len(background_roi) == 4
+        and all(isinstance(i, int) for i in background_roi)
+    ):
+        raise ValueError("background_roi must be a tuple of 4 integers (x0, y0, x1, y1)")
+    x0, y0, x1, y1 = background_roi
+    if x0 < 0 or y0 < 0 or x1 <= x0 or y1 <= y0:
+        raise ValueError(f"Invalid background_roi {background_roi}: need 0 <= x0 < x1 and 0 <= y0 < y1")
+    for name, da in (("sample", sample), ("ob", ob)):
+        if "x" not in da.dims or "y" not in da.dims:
+            raise ValueError(f"{name} must have 'x' and 'y' dimensions for background_roi normalization")
+        if x1 > da.sizes["x"] or y1 > da.sizes["y"]:
+            raise ValueError(
+                f"background_roi {background_roi} exceeds {name} size (x={da.sizes['x']}, y={da.sizes['y']})"
+            )
+    cs = sc.mean(sample["x", x0:x1]["y", y0:y1].data, dim=["x", "y"])
+    co = sc.mean(ob["x", x0:x1]["y", y0:y1].data, dim=["x", "y"])
+    return cs, co
+
+
 def normalize_transmission(  # noqa: C901
     sample: sc.DataArray,
     ob: sc.DataArray,
     proton_charge_sample: Optional[Union[float, sc.Variable]] = None,
     proton_charge_ob: Optional[Union[float, sc.Variable]] = None,
     pc_uncertainty: float = 0.005,
+    background_roi: Optional[tuple[int, int, int, int]] = None,
 ) -> sc.DataArray:
     """
     Normalize sample by open beam to compute transmission.
@@ -46,6 +80,12 @@ def normalize_transmission(  # noqa: C901
     pc_uncertainty : float, optional
         Relative proton charge uncertainty (default: 0.005 = 0.5%)
         From PLEIADES measurements
+    background_roi : tuple[int, int, int, int], optional
+        Sample-free background ROI ``(x0, y0, x1, y1)`` with exclusive stops. When given,
+        each image is normalized by its mean counts in this ROI — a proton-charge proxy for
+        when proton charge is unavailable (e.g. MARS): ``T = (S/mean(S[B])) / (O/mean(O[B]))``.
+        Mutually exclusive with ``proton_charge_sample`` / ``proton_charge_ob``. Uncertainty is
+        propagated first-order (the in-ROI sample/ROI-mean correlation is not corrected).
 
     Returns
     -------
@@ -74,49 +114,69 @@ def normalize_transmission(  # noqa: C901
     """
     logger.info("Normalizing transmission: T = Sample / OB")
 
-    # Proton-charge correction must be applied to both sample and OB, or to neither: a one-sided
-    # correction leaves counts/charge uncancelled, so the transmission would not be dimensionless.
-    if (proton_charge_sample is None) != (proton_charge_ob is None):
-        raise ValueError(
-            "proton_charge_sample and proton_charge_ob must both be provided or both omitted; "
-            "a one-sided proton-charge correction yields a non-dimensionless transmission."
-        )
-
-    # Apply proton charge corrections if provided
-    if proton_charge_sample is not None:
-        if isinstance(proton_charge_sample, sc.Variable):
-            logger.info(
-                f"Applying proton charge correction: Sample mean pc={proton_charge_sample.mean().value} "
-                f"{proton_charge_sample.unit}"
+    # Background-ROI flux normalization (issue #159): when no proton charge is available
+    # (e.g. MARS), scale each image by its mean counts in a sample-free ROI so per-image
+    # beam-flux differences cancel: T = (S/mean(S[B])) / (O/mean(O[B])). First-order UQ.
+    if background_roi is not None:
+        if proton_charge_sample is not None or proton_charge_ob is not None:
+            raise ValueError(
+                "background_roi and proton_charge_sample/proton_charge_ob are mutually exclusive: "
+                "background_roi is the flux-normalization proxy for when proton charge is unavailable."
             )
-            sample_corrected = sample / proton_charge_sample
-        else:
-            logger.info(f"  Applying proton charge correction: Sample pc={proton_charge_sample} C")
-            sample_corrected = sample / sc.scalar(proton_charge_sample, unit="C")
-
-        # Add proton charge systematic uncertainty
-        if sample_corrected.variances is not None:
-            pc_contribution = (pc_uncertainty * sample_corrected.values) ** 2
-            sample_corrected.variances = sample_corrected.variances + pc_contribution
+        logger.info("Applying background-ROI flux normalization with ROI {}", background_roi)
+        cs, co = _background_roi_means(sample, ob, background_roi)
+        # scipp refuses to broadcast a variance-bearing scalar across the image (it would introduce
+        # correlations), so divide by the variance-free means and add their variance contribution below.
+        cs_var, co_var = sc.variances(cs), sc.variances(co)
+        cs.variances = None
+        co.variances = None
+        sample_corrected = sample / cs
+        ob_corrected = ob / co
     else:
-        sample_corrected = sample
-
-    if proton_charge_ob is not None:
-        if isinstance(proton_charge_ob, sc.Variable):
-            logger.info(
-                f"Applying proton charge correction: OB mean pc={proton_charge_ob.mean().value} {proton_charge_ob.unit}"
+        # Proton-charge correction must be applied to both sample and OB, or to neither: a one-sided
+        # correction leaves counts/charge uncancelled, so the transmission would not be dimensionless.
+        if (proton_charge_sample is None) != (proton_charge_ob is None):
+            raise ValueError(
+                "proton_charge_sample and proton_charge_ob must both be provided or both omitted; "
+                "a one-sided proton-charge correction yields a non-dimensionless transmission."
             )
-            ob_corrected = ob / proton_charge_ob
-        else:
-            logger.info(f"  Applying proton charge correction: OB pc={proton_charge_ob:.1f} C")
-            ob_corrected = ob / sc.scalar(proton_charge_ob, unit="C")
 
-        # Add proton charge systematic uncertainty
-        if ob_corrected.variances is not None:
-            pc_contribution = (pc_uncertainty * ob_corrected.values) ** 2
-            ob_corrected.variances = ob_corrected.variances + pc_contribution
-    else:
-        ob_corrected = ob
+        # Apply proton charge corrections if provided
+        if proton_charge_sample is not None:
+            if isinstance(proton_charge_sample, sc.Variable):
+                logger.info(
+                    f"Applying proton charge correction: Sample mean pc={proton_charge_sample.mean().value} "
+                    f"{proton_charge_sample.unit}"
+                )
+                sample_corrected = sample / proton_charge_sample
+            else:
+                logger.info(f"  Applying proton charge correction: Sample pc={proton_charge_sample} C")
+                sample_corrected = sample / sc.scalar(proton_charge_sample, unit="C")
+
+            # Add proton charge systematic uncertainty
+            if sample_corrected.variances is not None:
+                pc_contribution = (pc_uncertainty * sample_corrected.values) ** 2
+                sample_corrected.variances = sample_corrected.variances + pc_contribution
+        else:
+            sample_corrected = sample
+
+        if proton_charge_ob is not None:
+            if isinstance(proton_charge_ob, sc.Variable):
+                logger.info(
+                    f"Applying proton charge correction: OB mean pc={proton_charge_ob.mean().value} "
+                    f"{proton_charge_ob.unit}"
+                )
+                ob_corrected = ob / proton_charge_ob
+            else:
+                logger.info(f"  Applying proton charge correction: OB pc={proton_charge_ob:.1f} C")
+                ob_corrected = ob / sc.scalar(proton_charge_ob, unit="C")
+
+            # Add proton charge systematic uncertainty
+            if ob_corrected.variances is not None:
+                pc_contribution = (pc_uncertainty * ob_corrected.values) ** 2
+                ob_corrected.variances = ob_corrected.variances + pc_contribution
+        else:
+            ob_corrected = ob
 
     # Normalize
     if sample_corrected.dims == ob_corrected.dims:
@@ -139,6 +199,14 @@ def normalize_transmission(  # noqa: C901
     for coord in sample.coords:
         if not sample.coords[coord].aligned:
             transmission.coords[coord] = sample.coords[coord]
+
+    # First-order contribution of the background-ROI mean uncertainty, added here because scipp
+    # could not propagate it through the shared-scalar division above. Treats sample/ob/cs/co as
+    # independent: Var(T) += T^2 * (Var(cs)/cs^2 + Var(co)/co^2).
+    if background_roi is not None and transmission.variances is not None:
+        coeff_rel_var = cs_var / (cs * cs) + co_var / (co * co)
+        extra = sc.array(dims=list(transmission.dims), values=transmission.values**2) * coeff_rel_var
+        transmission.variances = transmission.variances + extra.values
 
     logger.success("✓ Transmission normalized")
 

--- a/src/neunorm/processing/normalizer.py
+++ b/src/neunorm/processing/normalizer.py
@@ -288,7 +288,8 @@ def normalize_transmission(  # noqa: C901
             co_term = co_var / (co * co)
             coeff_rel_var = co_term if coeff_rel_var is None else coeff_rel_var + co_term
         extra = sc.array(dims=list(transmission.dims), values=transmission.values**2) * coeff_rel_var
-        transmission.variances = transmission.variances + extra.values
+        # Keep the variance dtype stable (issue #147 float32 pipelines), matching normalize_with_dark.
+        transmission.variances = transmission.variances + extra.values.astype(transmission.variances.dtype, copy=False)
 
     logger.success("✓ Transmission normalized")
 

--- a/src/neunorm/processing/normalizer.py
+++ b/src/neunorm/processing/normalizer.py
@@ -42,8 +42,10 @@ def _background_roi_means(
             raise ValueError(
                 f"background_roi {background_roi} exceeds {name} size (x={da.sizes['x']}, y={da.sizes['y']})"
             )
-    cs = sc.mean(sample["x", x0:x1]["y", y0:y1].data, dim=["x", "y"])
-    co = sc.mean(ob["x", x0:x1]["y", y0:y1].data, dim=["x", "y"])
+    # Reduce on the DataArray (mask-aware) so masked dead/hot pixels in the ROI are excluded,
+    # then take .data to drop coords (avoids coord-mismatch in the subsequent division).
+    cs = sc.mean(sample["x", x0:x1]["y", y0:y1], dim=["x", "y"]).data
+    co = sc.mean(ob["x", x0:x1]["y", y0:y1], dim=["x", "y"]).data
     return cs, co
 
 
@@ -127,9 +129,14 @@ def normalize_transmission(  # noqa: C901
         cs, co = _background_roi_means(sample, ob, background_roi)
         # scipp refuses to broadcast a variance-bearing scalar across the image (it would introduce
         # correlations), so divide by the variance-free means and add their variance contribution below.
-        cs_var, co_var = sc.variances(cs), sc.variances(co)
-        cs.variances = None
-        co.variances = None
+        # Only when the inputs carry variance: strip the ROI-mean variance (scipp cannot broadcast
+        # a variance-bearing scalar) and re-add its contribution after the division (below).
+        if cs.variances is not None:
+            cs_var, co_var = sc.variances(cs), sc.variances(co)
+            cs.variances = None
+            co.variances = None
+        else:
+            cs_var = co_var = None
         sample_corrected = sample / cs
         ob_corrected = ob / co
     else:
@@ -203,7 +210,7 @@ def normalize_transmission(  # noqa: C901
     # First-order contribution of the background-ROI mean uncertainty, added here because scipp
     # could not propagate it through the shared-scalar division above. Treats sample/ob/cs/co as
     # independent: Var(T) += T^2 * (Var(cs)/cs^2 + Var(co)/co^2).
-    if background_roi is not None and transmission.variances is not None:
+    if background_roi is not None and transmission.variances is not None and cs_var is not None:
         coeff_rel_var = cs_var / (cs * cs) + co_var / (co * co)
         extra = sc.array(dims=list(transmission.dims), values=transmission.values**2) * coeff_rel_var
         transmission.variances = transmission.variances + extra.values
@@ -220,6 +227,7 @@ def normalize_with_dark(
     proton_charge_sample: Optional[Union[float, sc.Variable]] = None,
     proton_charge_ob: Optional[Union[float, sc.Variable]] = None,
     pc_uncertainty: float = 0.005,
+    background_roi: Optional[tuple[int, int, int, int]] = None,
 ) -> sc.DataArray:
     """Dark-correct and normalize in one step, treating the shared dark frame correctly.
 
@@ -244,6 +252,10 @@ def normalize_with_dark(
         Integrated proton charge for the SNS beam correction (see ``normalize_transmission``).
     pc_uncertainty : float, optional
         Relative proton-charge uncertainty (default 0.005).
+    background_roi : tuple[int, int, int, int], optional
+        Background-ROI flux normalization (see ``normalize_transmission``), used instead of proton
+        charge. The shared-dark correction then uses ``k = co/cs`` (ratio of dark-corrected ROI
+        means) in place of the proton-charge ratio.
 
     Returns
     -------
@@ -252,7 +264,9 @@ def normalize_with_dark(
     """
     sample_dc = subtract_dark(sample, dark)
     ob_dc = subtract_dark(ob, dark)
-    transmission = normalize_transmission(sample_dc, ob_dc, proton_charge_sample, proton_charge_ob, pc_uncertainty)
+    transmission = normalize_transmission(
+        sample_dc, ob_dc, proton_charge_sample, proton_charge_ob, pc_uncertainty, background_roi=background_roi
+    )
 
     # Correct the shared-dark double-count (issue #142). normalize_transmission propagated
     # Var(dark) through BOTH numerator and denominator as if they were independent; the true
@@ -268,7 +282,14 @@ def normalize_with_dark(
     var_d_v = sc.variances(dark)  # counts**2
     over_count = 2.0 * s_v * var_d_v / (o_v**3)
 
-    k_squared = _proton_charge_ratio_squared(proton_charge_sample, proton_charge_ob)
+    # The over-count scales with the squared flux coefficient k applied to S/O: k = pc_ob/pc_sample
+    # for proton charge, or k = co/cs (ratio of dark-corrected ROI means) for background_roi. Use
+    # the coefficient values only (variance-free) — this is a variance correction, first-order in k.
+    if background_roi is not None:
+        cs, co = _background_roi_means(sample_dc, ob_dc, background_roi)
+        k_squared = (sc.values(co) / sc.values(cs)) ** 2
+    else:
+        k_squared = _proton_charge_ratio_squared(proton_charge_sample, proton_charge_ob)
     if k_squared is not None:
         over_count = k_squared * over_count
 

--- a/src/neunorm/processing/normalizer.py
+++ b/src/neunorm/processing/normalizer.py
@@ -210,13 +210,17 @@ def normalize_transmission(  # noqa: C901
         ob_var = ob_corrected_broadcast.variances.copy() if ob_corrected_broadcast.variances is not None else None
         ob_corrected_broadcast.variances = None
         transmission = sample_corrected / ob_corrected_broadcast
-        if ob_var is not None and sample_corrected.variances is not None:
-            # Var(T) = (T^2) * (Var(Sample)/Sample^2 + Var(OB)/OB^2)
-            # which is equivalent to:
+        # Recombine variances across the broadcast (scipp cannot propagate a variance-bearing
+        # denominator here, so the OB term is added manually). Handle EITHER side carrying variance:
+        # a no-variance sample must not drop the OB contribution. When only the sample carries
+        # variance, the division above already propagated it (the OB term is zero).
+        if ob_var is not None:
             # Var(T) = (Var(Sample) / OB^2) + (Sample^2 * Var(OB) / OB^4)
-            transmission.variances = (sample_corrected.variances / ob_corrected_broadcast.values**2) + (
-                sample_corrected.values**2 * ob_var / ob_corrected_broadcast.values**4
-            )
+            ob_term = sample_corrected.values**2 * ob_var / ob_corrected_broadcast.values**4
+            if sample_corrected.variances is not None:
+                transmission.variances = sample_corrected.variances / ob_corrected_broadcast.values**2 + ob_term
+            else:
+                transmission.variances = ob_term
 
     # copy dropped unaligned coordinates from input
     for coord in sample.coords:
@@ -277,7 +281,10 @@ def normalize_with_dark(
     background_roi : tuple[int, int, int, int], optional
         Background-ROI flux normalization (see ``normalize_transmission``), used instead of proton
         charge. The shared-dark correction then uses ``k = co/cs`` (ratio of dark-corrected ROI
-        means) in place of the proton-charge ratio.
+        means) in place of the proton-charge ratio, and additionally removes the ROI-mean shared-dark
+        covariance term ``2*T^2*Cov(cs,co)/(cs*co)`` (``Cov(cs,co) = Var(mean(D_roi))``) — the
+        ROI-mean analog of the #142 pixel-level correction. (The in-ROI pixel/ROI-mean correlation
+        remains uncorrected, as documented on ``normalize_transmission``.)
 
     Returns
     -------
@@ -309,11 +316,24 @@ def normalize_with_dark(
     # the coefficient values only (variance-free) — this is a variance correction, first-order in k.
     if background_roi is not None:
         cs, co = _background_roi_means(sample_dc, ob_dc, background_roi)
-        k_squared = (sc.values(co) / sc.values(cs)) ** 2
+        cs_v, co_v = sc.values(cs), sc.values(co)
+        k_squared = (co_v / cs_v) ** 2
     else:
         k_squared = _proton_charge_ratio_squared(proton_charge_sample, proton_charge_ob)
     if k_squared is not None:
         over_count = k_squared * over_count
+
+    # background_roi shares the dark across BOTH ROI means: cs = mean(S-D) and co = mean(O-D) use the
+    # same ROI dark pixels, so Cov(cs, co) = Var(mean(D_roi)) > 0. normalize_transmission added the
+    # ROI-mean term T^2 * (Var(cs)/cs^2 + Var(co)/co^2) treating cs and co as independent; subtract
+    # the missing covariance term 2 * T^2 * Cov(cs,co) / (cs*co) too — the ROI-mean analog of the
+    # #142 pixel-level correction. (The in-ROI pixel<->mean correlation stays uncorrected, as
+    # documented; for a clean background ROI the dark-mean covariance is the only remaining term.)
+    if background_roi is not None:
+        x0, y0, x1, y1 = background_roi
+        cov_cs_co = sc.variances(sc.mean(dark["x", x0:x1]["y", y0:y1], dim=["x", "y"]).data)
+        t_v = sc.values(transmission)
+        over_count = over_count + 2.0 * t_v * t_v * cov_cs_co / (cs_v * co_v)
 
     over_values = sc.to_unit(over_count, "dimensionless").transpose(transmission.dims).values
     # Match the variance dtype so the correction never promotes a float32 pipeline to float64.

--- a/src/neunorm/processing/normalizer.py
+++ b/src/neunorm/processing/normalizer.py
@@ -11,6 +11,7 @@ import numpy as np
 import scipp as sc
 from loguru import logger
 
+from neunorm.data_models.roi import ROILike, as_roi_bounds
 from neunorm.processing.dark_corrector import subtract_dark
 
 
@@ -114,7 +115,7 @@ def normalize_transmission(  # noqa: C901
     proton_charge_sample: Optional[Union[float, sc.Variable]] = None,
     proton_charge_ob: Optional[Union[float, sc.Variable]] = None,
     pc_uncertainty: float = 0.005,
-    background_roi: Optional[tuple[int, int, int, int]] = None,
+    background_roi: Optional[ROILike] = None,
 ) -> sc.DataArray:
     """
     Normalize sample by open beam to compute transmission.
@@ -141,10 +142,11 @@ def normalize_transmission(  # noqa: C901
     pc_uncertainty : float, optional
         Relative proton charge uncertainty (default: 0.005 = 0.5%)
         From PLEIADES measurements
-    background_roi : tuple[int, int, int, int], optional
-        Sample-free background ROI ``(x0, y0, x1, y1)`` with exclusive stops. When given,
-        each image is normalized by its mean counts in this ROI — a proton-charge proxy for
-        when proton charge is unavailable (e.g. MARS): ``T = (S/mean(S[B])) / (O/mean(O[B]))``.
+    background_roi : ROI or tuple[int, int, int, int], optional
+        Sample-free background ROI — an :class:`~neunorm.data_models.roi.ROI` or a bare
+        ``(x0, y0, x1, y1)`` tuple with exclusive stops. When given, each image is normalized by its
+        mean counts in this ROI — a proton-charge proxy for when proton charge is unavailable (e.g.
+        MARS): ``T = (S/mean(S[B])) / (O/mean(O[B]))``.
         Mutually exclusive with ``proton_charge_sample`` / ``proton_charge_ob``. Uncertainty is
         propagated first-order (the in-ROI sample/ROI-mean correlation is not corrected). Raises
         ``ValueError`` if the ROI mean is not strictly positive and finite in every image. Indices
@@ -177,6 +179,9 @@ def normalize_transmission(  # noqa: C901
     - Zero OB counts produce inf/nan (handle with masks before calling)
     """
     logger.info("Normalizing transmission: T = Sample / OB")
+
+    if background_roi is not None:
+        background_roi = as_roi_bounds(background_roi)
 
     # Background-ROI flux normalization (issue #159): when no proton charge is available
     # (e.g. MARS), scale each image by its mean counts in a sample-free ROI so per-image
@@ -297,7 +302,7 @@ def normalize_with_dark(
     proton_charge_sample: Optional[Union[float, sc.Variable]] = None,
     proton_charge_ob: Optional[Union[float, sc.Variable]] = None,
     pc_uncertainty: float = 0.005,
-    background_roi: Optional[tuple[int, int, int, int]] = None,
+    background_roi: Optional[ROILike] = None,
 ) -> sc.DataArray:
     """Dark-correct and normalize in one step, treating the shared dark frame correctly.
 
@@ -335,6 +340,9 @@ def normalize_with_dark(
     sc.DataArray
         Transmission with correctly-propagated variance (no shared-dark double-counting).
     """
+    if background_roi is not None:
+        background_roi = as_roi_bounds(background_roi)
+
     sample_dc = subtract_dark(sample, dark)
     ob_dc = subtract_dark(ob, dark)
     transmission = normalize_transmission(

--- a/src/neunorm/processing/roi_clipper.py
+++ b/src/neunorm/processing/roi_clipper.py
@@ -5,10 +5,12 @@ Function for cropping spatial dimensions to a region of interest (ROI).
 import scipp as sc
 from loguru import logger
 
+from neunorm.data_models.roi import ROILike, as_roi_bounds
+
 
 def apply_roi(
     data: sc.DataArray,
-    roi: tuple[int, int, int, int],  # (x0, y0, x1, y1)
+    roi: ROILike,  # (x0, y0, x1, y1) tuple or an ROI
 ) -> sc.DataArray:
     """Crop spatial dimensions to ROI.
 
@@ -21,14 +23,17 @@ def apply_roi(
     ----------
     data : sc.DataArray
         Input data array to be cropped.
-    roi : tuple[int, int, int, int]
-        Region of interest specified as (x0, y0, x1, y1).
+    roi : ROI or tuple[int, int, int, int]
+        Region of interest as an :class:`~neunorm.data_models.roi.ROI` (e.g.
+        ``ROI(x0=10, y0=20, x1=30, y1=40)`` or ``ROI(x0=10, y0=20, width=20, height=20)``) or a bare
+        ``(x0, y0, x1, y1)`` tuple with exclusive stop indices.
 
     Returns
     -------
     sc.DataArray
         Cropped data array with updated coordinates.
     """
+    roi = as_roi_bounds(roi)
 
     logger.info("Applying ROI: {}", roi)
 

--- a/src/neunorm/tof/binning.py
+++ b/src/neunorm/tof/binning.py
@@ -223,7 +223,7 @@ def create_tof_bins(
     offset : sc.Variable, optional
         Detector time offset (e.g. TIDelay) applied so energy/wavelength bin edges live in
         raw detector-TOF space — matching the raw event TOF that is histogrammed into them
-        and the later coordinate labeling (issue #141). Default: 0 us. Ignored for 'tof' mode.
+        and the later coordinate labeling. Default: 0 us. Ignored for 'tof' mode.
 
     Returns
     -------
@@ -261,7 +261,7 @@ def _energy_bins_to_tof(
 
     Uses ``convert_energy_to_tof`` — the exact inverse of the labeling conversion — so the
     edges live in raw detector-TOF space (``t = L*sqrt(m_n/(2E)) - offset``) and match the
-    raw event TOF histogrammed into them (issue #141).
+    raw event TOF histogrammed into them.
     """
     emin, emax = config.energy_range
 
@@ -286,7 +286,7 @@ def _wavelength_bins_to_tof(
 
     Uses ``convert_wavelength_to_tof`` — the exact inverse of the labeling conversion — so the
     edges live in raw detector-TOF space (``t = λ*m_n*L/h - offset``) and match the raw event
-    TOF histogrammed into them (issue #141).
+    TOF histogrammed into them.
     """
     wl_min, wl_max = config.wavelength_range
 
@@ -343,7 +343,7 @@ def get_energy_histogram(
         Flight path in meters
     offset : sc.Variable
         Detector time offset (e.g. TIDelay) applied during TOF→energy labeling so it matches
-        offset-aware bin edges (issue #141). Default: 0 us. Pass the same offset used to build
+        offset-aware bin edges. Default: 0 us. Pass the same offset used to build
         the histogram's energy bins.
 
     Returns
@@ -403,7 +403,7 @@ def get_wavelength_histogram(
         Flight path in meters
     offset : sc.Variable
         Detector time offset (e.g. TIDelay) applied during TOF→wavelength labeling so it matches
-        offset-aware bin edges (issue #141). Default: 0 us. Pass the same offset used to build
+        offset-aware bin edges. Default: 0 us. Pass the same offset used to build
         the histogram's wavelength bins.
 
     Returns

--- a/src/neunorm/tof/event_converter.py
+++ b/src/neunorm/tof/event_converter.py
@@ -51,7 +51,7 @@ def convert_events_to_histogram(
     detector_time_offset : sc.Variable, optional
         Detector time offset (e.g. TIDelay) applied when building energy/wavelength bin edges
         so they live in raw detector-TOF space, matching the raw event TOF histogrammed into
-        them (issue #141). Default: 0 us. Has no effect for ``bin_space='tof'``.
+        them. Default: 0 us. Has no effect for ``bin_space='tof'``.
 
     Returns
     -------
@@ -75,7 +75,7 @@ def convert_events_to_histogram(
     logger.info(f"  Bin space: {binning.bin_space}, Log: {binning.use_log_bin}")
 
     # Create TOF bin edges (raw detector-TOF; detector_time_offset shifts energy/wavelength
-    # edges so binning agrees with the later coordinate labeling — issue #141).
+    # edges so binning agrees with the later coordinate labeling).
     tof_bins = create_tof_bins(binning, flight_path, detector_time_offset)
     logger.info(f"  TOF range: {tof_bins.values.min():.1f} - {tof_bins.values.max():.1f} ns")
 

--- a/tests/unit/test_binning_conversions.py
+++ b/tests/unit/test_binning_conversions.py
@@ -371,13 +371,13 @@ def test_wavelength_energy_de_broglie_constant():
         assert abs(energy.value - expected_ev) / expected_ev < 1e-6
 
 
-# --- issue #141: energy/wavelength binning must apply detector_time_offset ---
+# --- energy/wavelength binning must apply detector_time_offset ---
 
 
 def test_convert_energy_to_tof_is_inverse_of_tof_to_energy():
     """convert_energy_to_tof is the exact inverse of convert_tof_to_energy, offset included.
 
-    This is what makes the energy bin edges consistent with the coordinate labeling (#141).
+    This is what makes the energy bin edges consistent with the coordinate labeling.
     """
     from neunorm.tof.coordinate_converter import (
         convert_energy_to_tof,
@@ -401,7 +401,7 @@ def test_convert_energy_to_tof_is_inverse_of_tof_to_energy():
 def test_create_tof_bins_offset_shifts_edges_into_raw_space():
     """A non-zero detector_time_offset shifts the energy/wavelength TOF edges by exactly -offset.
 
-    Regression for #141: the bin edges must live in raw detector-TOF space so they match the
+    Regression: the bin edges must live in raw detector-TOF space so they match the
     raw event TOF histogrammed into them; offset=0 reproduces the old physical-TOF edges.
     """
     from neunorm.data_models.tof import BinningConfig
@@ -422,7 +422,7 @@ def test_create_tof_bins_offset_shifts_edges_into_raw_space():
 
 
 def test_event_energy_binning_places_events_by_raw_tof_with_offset():
-    """Events histogrammed in energy space land in the bin bracketing their RAW TOF (#141).
+    """Events histogrammed in energy space land in the bin bracketing their RAW TOF.
 
     With the offset applied, the energy bin edges are in raw detector-TOF space, so a peak at
     a known raw TOF falls in the bin whose raw-TOF edges bracket it — consistent with the
@@ -463,7 +463,7 @@ def test_event_energy_binning_places_events_by_raw_tof_with_offset():
 
 
 def test_get_energy_and_wavelength_histogram_apply_offset():
-    """get_energy_histogram / get_wavelength_histogram label TOF with detector_time_offset (#141).
+    """get_energy_histogram / get_wavelength_histogram label TOF with detector_time_offset.
 
     The public histogram-relabeling helpers must use the same offset-aware converter as the bin
     construction, so a histogram built with an offset is labeled consistently. Without the offset

--- a/tests/unit/test_event_loader.py
+++ b/tests/unit/test_event_loader.py
@@ -187,7 +187,7 @@ def test_event_data_model_total_events_mismatch():
 
 
 def test_load_event_data_fractional_tof_clock():
-    """A fractional TOF clock must use the full period, not int()-truncate it (issue #163)."""
+    """A fractional TOF clock must use the full period, not int()-truncate it."""
     from neunorm.loaders.event_loader import load_event_data
 
     with tempfile.NamedTemporaryFile(suffix=".h5", delete=False) as f:
@@ -210,7 +210,7 @@ def test_load_event_data_fractional_tof_clock():
 
 
 def test_event_data_getitem_filters_all_arrays():
-    """EventData is indexable: a mask returns a new EventData with all per-event arrays filtered (issue #163)."""
+    """EventData is indexable: a mask returns a new EventData with all per-event arrays filtered."""
     from neunorm.data_models.core import EventData
 
     events = EventData(

--- a/tests/unit/test_fits_loader.py
+++ b/tests/unit/test_fits_loader.py
@@ -32,7 +32,7 @@ def test_load_fits_stack():
     assert da.variances.shape == (3, 5, 5)
     assert da.variances.max() == 5
 
-    # float32 is sufficient for neutron imaging; loading in float32 halves memory (issue #147)
+    # float32 is sufficient for neutron imaging; loading in float32 halves memory
     assert da.values.dtype == np.float32
     assert da.variances.dtype == np.float32
 

--- a/tests/unit/test_hdf5_writer.py
+++ b/tests/unit/test_hdf5_writer.py
@@ -142,7 +142,7 @@ def _data_3d():
 def test_write_hdf5_fallback_json_for_non_native_metadata():
     """A non-nested value h5py cannot store natively (e.g. a dict) falls back to JSON.
 
-    Exercises the defensive fallback path (issue #140): the native create_dataset raises,
+    Exercises the defensive fallback path: the native create_dataset raises,
     the partial dataset is removed, and the value is JSON-encoded instead of dropped.
     """
     from neunorm.exporters.hdf5_writer import write_hdf5
@@ -162,7 +162,7 @@ def test_write_hdf5_fallback_json_for_non_native_metadata():
 
 
 def test_write_hdf5_skips_unserializable_nested_metadata_without_corrupting():
-    """A nested value json.dumps cannot encode is skipped — never aborting the write (#140).
+    """A nested value json.dumps cannot encode is skipped — never aborting the write.
 
     json.dumps can still raise (e.g. on a circular reference) even with default=str. A
     self-referential list is nested, so this exercises the *nested-branch* guard: the key is
@@ -189,7 +189,7 @@ def test_write_hdf5_skips_unserializable_nested_metadata_without_corrupting():
 
 
 def test_write_hdf5_skips_unstorable_fallback_metadata_without_corrupting():
-    """The fallback branch skips a value h5py AND json both reject — without corrupting (#140).
+    """The fallback branch skips a value h5py AND json both reject — without corrupting.
 
     A dict with a tuple key is not natively storable by h5py (TypeError) and not
     JSON-serializable (json requires str/number keys), so it exercises the native-write
@@ -211,7 +211,7 @@ def test_write_hdf5_skips_unstorable_fallback_metadata_without_corrupting():
 
 
 def test_write_hdf5_skips_malformed_key_metadata_without_corrupting():
-    """A malformed metadata key (empty / trailing-slash) is skipped, not fatal (issue #140).
+    """A malformed metadata key (empty / trailing-slash) is skipped, not fatal.
 
     h5py rejects empty or slash-bearing dataset names with ValueError. That raise happens
     inside the per-key write *after* the bulk arrays, so the loop's backstop must skip the bad
@@ -241,7 +241,7 @@ def test_write_hdf5_skips_malformed_key_metadata_without_corrupting():
 
 
 def test_write_hdf5_skips_unformattable_key_metadata_without_corrupting():
-    """A non-string key whose formatting raises is skipped, not fatal (issue #140).
+    """A non-string key whose formatting raises is skipped, not fatal.
 
     Name construction (f"metadata/{key}") runs inside the per-key backstop, so even a key
     object whose __format__/__str__/__repr__ raises is skipped with a warning rather than
@@ -280,7 +280,7 @@ def test_write_hdf5_skips_unformattable_key_metadata_without_corrupting():
 
 
 def test_write_hdf5_colliding_keys_keep_first_without_dropping_earlier():
-    """When two keys collide under str() (e.g. 1 and "1"), the first is kept (issue #140).
+    """When two keys collide under str() (e.g. 1 and "1"), the first is kept.
 
     Both int 1 and str "1" map to dataset path "metadata/1". The earlier value must survive and
     the later colliding key is skipped — cleanup must never delete the earlier valid dataset.
@@ -302,7 +302,7 @@ def test_write_hdf5_colliding_keys_keep_first_without_dropping_earlier():
 
 
 def test_write_hdf5_skips_surrogate_key_metadata_without_corrupting():
-    """A string key h5py cannot encode (lone surrogate) is skipped, not fatal (issue #140).
+    """A string key h5py cannot encode (lone surrogate) is skipped, not fatal.
 
     For a key like "\\udcff", create_dataset raises UnicodeEncodeError, and the `name in f`
     cleanup lookup would re-raise the same error — so the except-body cleanup must be guarded.
@@ -323,7 +323,7 @@ def test_write_hdf5_skips_surrogate_key_metadata_without_corrupting():
 
 
 def test_write_hdf5_skips_unstorable_string_metadata_without_corrupting():
-    """A string h5py cannot store (embedded NUL) is skipped — never aborting the write (#140).
+    """A string h5py cannot store (embedded NUL) is skipped — never aborting the write.
 
     h5py VLEN strings reject embedded NULs (ValueError) and lone surrogates
     (UnicodeEncodeError, a ValueError subclass); both raise *after* the bulk arrays are

--- a/tests/unit/test_mars_ccd.py
+++ b/tests/unit/test_mars_ccd.py
@@ -587,3 +587,44 @@ class TestMarsCCDPipelineFITS:
         assert t.shape == (5, 32, 32)
         # uniform images -> background-ROI normalization cancels to T = 1 even after dark subtraction
         np.testing.assert_allclose(t.values, 1.0, rtol=1e-5)
+
+    def test_mars_ccd_pipeline_background_roi_accepts_roi_object(self):
+        """A background_roi ROI yields the same transmission as the equivalent tuple (issue #159)."""
+        from neunorm import ROI
+
+        with (
+            tempfile.NamedTemporaryFile(suffix=".hdf5", delete=True) as f1,
+            tempfile.NamedTemporaryFile(suffix=".hdf5", delete=True) as f2,
+        ):
+            t_tuple = run_mars_ccd_pipeline(
+                sample_paths=[self.sample_paths],
+                ob_paths=[self.ob_paths],
+                output_path=Path(f1.name),
+                gamma_filter=False,
+                background_roi=(0, 0, 8, 8),
+            )
+            # width/height form, resolved to the same (0, 0, 8, 8) bounds
+            t_roi = run_mars_ccd_pipeline(
+                sample_paths=[self.sample_paths],
+                ob_paths=[self.ob_paths],
+                output_path=Path(f2.name),
+                gamma_filter=False,
+                background_roi=ROI(x0=0, y0=0, width=8, height=8),
+            )
+        np.testing.assert_array_equal(t_tuple.values, t_roi.values)
+
+    def test_mars_ccd_pipeline_crop_roi_accepts_roi_object(self):
+        """A crop roi=ROI(...) crops correctly and writes provenance (coerced to a tuple) (issue #159)."""
+        from neunorm import ROI
+
+        with tempfile.NamedTemporaryFile(suffix=".hdf5", delete=True) as f:
+            # completing the run (HDF5 write) proves the ROI was coerced for provenance, since the
+            # metadata writer rejects a raw ROI object.
+            t = run_mars_ccd_pipeline(
+                sample_paths=[self.sample_paths],
+                ob_paths=[self.ob_paths],
+                output_path=Path(f.name),
+                gamma_filter=False,
+                roi=ROI(x0=5, y0=5, x1=25, y1=25),
+            )
+        assert t.shape == (5, 20, 20)

--- a/tests/unit/test_mars_ccd.py
+++ b/tests/unit/test_mars_ccd.py
@@ -614,17 +614,28 @@ class TestMarsCCDPipelineFITS:
         np.testing.assert_array_equal(t_tuple.values, t_roi.values)
 
     def test_mars_ccd_pipeline_crop_roi_accepts_roi_object(self):
-        """A crop roi=ROI(...) crops correctly and writes provenance (coerced to a tuple) (issue #159)."""
+        """A crop roi=ROI(...) crops correctly AND is coerced to a tuple in the written provenance.
+
+        Guards the pipeline-level coercion specifically: ``apply_roi`` coerces internally (so the
+        shape is right regardless), and the HDF5 writer would NOT crash on a raw ROI — it would
+        str()-coerce it via the issue #140 JSON backstop (``encoding="json"``). So we round-trip
+        ``roi_applied`` and assert it is the native int array (the coerced tuple), which fails if a
+        raw ROI ever reaches provenance.
+        """
         from neunorm import ROI
 
         with tempfile.NamedTemporaryFile(suffix=".hdf5", delete=True) as f:
-            # completing the run (HDF5 write) proves the ROI was coerced for provenance, since the
-            # metadata writer rejects a raw ROI object.
+            output_path = Path(f.name)
             t = run_mars_ccd_pipeline(
                 sample_paths=[self.sample_paths],
                 ob_paths=[self.ob_paths],
-                output_path=Path(f.name),
+                output_path=output_path,
                 gamma_filter=False,
                 roi=ROI(x0=5, y0=5, x1=25, y1=25),
             )
-        assert t.shape == (5, 20, 20)
+            assert t.shape == (5, 20, 20)
+            with h5py.File(output_path, "r") as hf:
+                ds = hf["metadata/roi_applied"]
+                # stored as a native int array (the coerced tuple), NOT the JSON str(ROI) fallback
+                assert ds.attrs.get("encoding") != "json"
+                np.testing.assert_array_equal(ds[()], [5, 5, 25, 25])

--- a/tests/unit/test_mars_ccd.py
+++ b/tests/unit/test_mars_ccd.py
@@ -590,7 +590,7 @@ class TestMarsCCDPipelineFITS:
 
     def test_mars_ccd_pipeline_background_roi_accepts_roi_object(self):
         """A background_roi ROI yields the same transmission as the equivalent tuple."""
-        from neunorm import ROI
+        from neunorm.data_models.roi import ROI
 
         with (
             tempfile.NamedTemporaryFile(suffix=".hdf5", delete=True) as f1,
@@ -622,7 +622,7 @@ class TestMarsCCDPipelineFITS:
         ``roi_applied`` and assert it is the native int array (the coerced tuple), which fails if a
         raw ROI ever reaches provenance.
         """
-        from neunorm import ROI
+        from neunorm.data_models.roi import ROI
 
         with tempfile.NamedTemporaryFile(suffix=".hdf5", delete=True) as f:
             output_path = Path(f.name)

--- a/tests/unit/test_mars_ccd.py
+++ b/tests/unit/test_mars_ccd.py
@@ -135,7 +135,7 @@ class TestMarsCCDPipeline:
                 # Check masks
                 assert "masks/dead" in hf
                 np.testing.assert_equal(hf["masks/dead"], np.zeros((32, 32), dtype=bool))
-                # Check metadata (nested per-run paths stored as round-trippable JSON, issue #140)
+                # Check metadata (nested per-run paths stored as round-trippable JSON)
                 assert "metadata/sample_paths" in hf
                 assert json.loads(hf["metadata/sample_paths"].asstr()[()]) == [[str(p) for p in self.sample_paths]]
                 assert "metadata/ob_paths" in hf
@@ -318,7 +318,7 @@ class TestMarsCCDPipeline:
         )  # should be unchanged since it's the same for both runs
 
     def test_mars_ccd_pipeline_no_dark(self):
-        """Dark current is optional (issue #146): omitting dark_paths skips dark correction.
+        """Dark current is optional: omitting dark_paths skips dark correction.
 
         Without dark subtraction the transmission is T = S / OB = (81 + i) / 100
         for these fixtures (vs (81 + i - 5) / (100 - 5) with dark). MARS does not
@@ -351,7 +351,7 @@ class TestMarsCCDPipeline:
                 assert "metadata/dark_paths" not in hf
 
     def test_mars_ccd_pipeline_empty_dark_paths(self):
-        """An empty dark_paths list is treated the same as omitting dark (issue #146)."""
+        """An empty dark_paths list is treated the same as omitting dark."""
         with tempfile.NamedTemporaryFile(suffix=".h5", delete=True) as f:
             transmission = run_mars_ccd_pipeline(
                 sample_paths=[self.sample_paths],
@@ -372,7 +372,7 @@ class TestMarsCCDPipeline:
             )
 
     def test_mars_ccd_pipeline_no_dark_uncertainty(self):
-        """No-dark UQ equals the dark-free propagation, with no dark-frame variance term (issue #146).
+        """No-dark UQ equals the dark-free propagation, with no dark-frame variance term.
 
         Two independent checks:
         1. The pipeline's no-dark output (values AND variances) matches a direct
@@ -415,7 +415,7 @@ class TestMarsCCDPipeline:
         )
         ob = prepare_reference(ob, dim="N_image")
         expected = normalize_transmission(sample, ob)
-        # The pipeline produces float32 normalized data end-to-end (issue #147). MARS
+        # The pipeline produces float32 normalized data end-to-end. MARS
         # has no proton-charge division, so loaders being float32 keeps the whole path
         # float32 and this structural check stays bit-tight against the pipeline output.
         assert no_dark.dtype == sc.DType.float32
@@ -528,7 +528,7 @@ class TestMarsCCDPipelineFITS:
                 # Check masks
                 assert "masks/dead" in hf
                 np.testing.assert_equal(hf["masks/dead"], np.zeros((32, 32), dtype=bool))
-                # Check metadata (nested per-run paths stored as round-trippable JSON, issue #140)
+                # Check metadata (nested per-run paths stored as round-trippable JSON)
                 assert "metadata/sample_paths" in hf
                 assert json.loads(hf["metadata/sample_paths"].asstr()[()]) == [[str(p) for p in self.sample_paths]]
                 assert "metadata/ob_paths" in hf
@@ -550,7 +550,7 @@ class TestMarsCCDPipelineFITS:
                 np.testing.assert_equal(hf["MODEL"].asstr()[()], "DW936_BV")
 
     def test_mars_ccd_pipeline_background_roi(self):
-        """background_roi flux normalization runs end-to-end and changes the result (issue #159)."""
+        """background_roi flux normalization runs end-to-end and changes the result."""
         with tempfile.NamedTemporaryFile(suffix=".hdf5", delete=True) as f:
             output_path = Path(f.name)
             t_default = run_mars_ccd_pipeline(
@@ -572,7 +572,7 @@ class TestMarsCCDPipelineFITS:
         assert not np.allclose(t_bg.values, t_default.values)
 
     def test_mars_ccd_pipeline_background_roi_with_dark(self):
-        """background_roi + a dark frame routes through normalize_with_dark (issue #159 / #142)."""
+        """background_roi + a dark frame routes through normalize_with_dark."""
         with tempfile.NamedTemporaryFile(suffix=".hdf5", delete=True) as f:
             output_path = Path(f.name)
             t = run_mars_ccd_pipeline(
@@ -589,7 +589,7 @@ class TestMarsCCDPipelineFITS:
         np.testing.assert_allclose(t.values, 1.0, rtol=1e-5)
 
     def test_mars_ccd_pipeline_background_roi_accepts_roi_object(self):
-        """A background_roi ROI yields the same transmission as the equivalent tuple (issue #159)."""
+        """A background_roi ROI yields the same transmission as the equivalent tuple."""
         from neunorm import ROI
 
         with (
@@ -618,7 +618,7 @@ class TestMarsCCDPipelineFITS:
 
         Guards the pipeline-level coercion specifically: ``apply_roi`` coerces internally (so the
         shape is right regardless), and the HDF5 writer would NOT crash on a raw ROI — it would
-        str()-coerce it via the issue #140 JSON backstop (``encoding="json"``). So we round-trip
+        str()-coerce it via the JSON backstop (``encoding="json"``). So we round-trip
         ``roi_applied`` and assert it is the native int array (the coerced tuple), which fails if a
         raw ROI ever reaches provenance.
         """

--- a/tests/unit/test_mars_ccd.py
+++ b/tests/unit/test_mars_ccd.py
@@ -570,3 +570,20 @@ class TestMarsCCDPipelineFITS:
         np.testing.assert_allclose(t_bg.values, 1.0, rtol=1e-5)
         # and it differs from the plain S/OB normalization
         assert not np.allclose(t_bg.values, t_default.values)
+
+    def test_mars_ccd_pipeline_background_roi_with_dark(self):
+        """background_roi + a dark frame routes through normalize_with_dark (issue #159 / #142)."""
+        with tempfile.NamedTemporaryFile(suffix=".hdf5", delete=True) as f:
+            output_path = Path(f.name)
+            t = run_mars_ccd_pipeline(
+                sample_paths=[self.sample_paths],
+                ob_paths=[self.ob_paths],
+                dark_paths=[self.dark_paths],
+                output_path=output_path,
+                gamma_filter=False,
+                background_roi=(0, 0, 8, 8),
+            )
+        assert str(t.unit) == "dimensionless"
+        assert t.shape == (5, 32, 32)
+        # uniform images -> background-ROI normalization cancels to T = 1 even after dark subtraction
+        np.testing.assert_allclose(t.values, 1.0, rtol=1e-5)

--- a/tests/unit/test_mars_ccd.py
+++ b/tests/unit/test_mars_ccd.py
@@ -548,3 +548,25 @@ class TestMarsCCDPipelineFITS:
                 np.testing.assert_equal(hf["EXPOSURETIME"][()], 30)
                 assert "MODEL" in hf
                 np.testing.assert_equal(hf["MODEL"].asstr()[()], "DW936_BV")
+
+    def test_mars_ccd_pipeline_background_roi(self):
+        """background_roi flux normalization runs end-to-end and changes the result (issue #159)."""
+        with tempfile.NamedTemporaryFile(suffix=".hdf5", delete=True) as f:
+            output_path = Path(f.name)
+            t_default = run_mars_ccd_pipeline(
+                sample_paths=[self.sample_paths], ob_paths=[self.ob_paths], output_path=output_path, gamma_filter=False
+            )
+            t_bg = run_mars_ccd_pipeline(
+                sample_paths=[self.sample_paths],
+                ob_paths=[self.ob_paths],
+                output_path=output_path,
+                gamma_filter=False,
+                background_roi=(0, 0, 8, 8),
+            )
+        assert str(t_bg.unit) == "dimensionless"
+        assert t_bg.shape == (5, 32, 32)
+        assert t_bg.dtype == np.float32
+        # spatially-uniform images -> background-ROI normalization cancels to T = 1 everywhere
+        np.testing.assert_allclose(t_bg.values, 1.0, rtol=1e-5)
+        # and it differs from the plain S/OB normalization
+        assert not np.allclose(t_bg.values, t_default.values)

--- a/tests/unit/test_mars_tpx3.py
+++ b/tests/unit/test_mars_tpx3.py
@@ -269,3 +269,27 @@ class TestMarsTPX3Pipeline:
 
         # The variances should be less than the variance from a single run due to combining multiple runs
         np.testing.assert_allclose(transmission.variances, 0.004, atol=0.001)
+
+    def test_mars_tpx3_pipeline_background_roi(self):
+        """background_roi flux normalization runs end-to-end on TPX3 and changes the result (issue #159)."""
+        with tempfile.NamedTemporaryFile(suffix=".h5", delete=True) as f:
+            output_path = Path(f.name)
+            t_default = run_mars_tpx3_pipeline(
+                sample_paths=[self.sample_paths],
+                ob_paths=[self.ob_paths],
+                output_path=output_path,
+                detector_shape=(32, 32),
+                gamma_filter=False,
+            )
+            t_bg = run_mars_tpx3_pipeline(
+                sample_paths=[self.sample_paths],
+                ob_paths=[self.ob_paths],
+                output_path=output_path,
+                detector_shape=(32, 32),
+                gamma_filter=False,
+                background_roi=(0, 0, 8, 8),
+            )
+        assert str(t_bg.unit) == "dimensionless"
+        # spatially-uniform images -> background-ROI normalization cancels to T = 1 everywhere
+        np.testing.assert_allclose(t_bg.values, 1.0, rtol=1e-5)
+        assert not np.allclose(t_bg.values, t_default.values)

--- a/tests/unit/test_mars_tpx3.py
+++ b/tests/unit/test_mars_tpx3.py
@@ -133,7 +133,7 @@ class TestMarsTPX3Pipeline:
                 np.testing.assert_equal(hf["masks/dead"], np.zeros((32, 32), dtype=bool))
                 assert "masks/hot" in hf
                 np.testing.assert_equal(hf["masks/hot"], np.zeros((32, 32), dtype=bool))
-                # Check metadata (nested per-run paths stored as round-trippable JSON, issue #140)
+                # Check metadata (nested per-run paths stored as round-trippable JSON)
                 assert "metadata/sample_paths" in hf
                 assert json.loads(hf["metadata/sample_paths"].asstr()[()]) == [[str(p) for p in self.sample_paths]]
                 assert "metadata/ob_paths" in hf
@@ -271,7 +271,7 @@ class TestMarsTPX3Pipeline:
         np.testing.assert_allclose(transmission.variances, 0.004, atol=0.001)
 
     def test_mars_tpx3_pipeline_background_roi(self):
-        """background_roi flux normalization runs end-to-end on TPX3 and changes the result (issue #159)."""
+        """background_roi flux normalization runs end-to-end on TPX3 and changes the result."""
         with tempfile.NamedTemporaryFile(suffix=".h5", delete=True) as f:
             output_path = Path(f.name)
             t_default = run_mars_tpx3_pipeline(

--- a/tests/unit/test_normalizer.py
+++ b/tests/unit/test_normalizer.py
@@ -145,7 +145,7 @@ def test_normalize_transmission_with_proton_charge():
     assert transmission.variances is not None
 
 
-# --- issue #142: shared-dark variance must not be double-counted ---
+# --- shared-dark variance must not be double-counted ---
 
 
 def _ccd_frames(sample_counts, ob_counts, dark_counts):
@@ -158,7 +158,7 @@ def _ccd_frames(sample_counts, ob_counts, dark_counts):
 
 
 def test_normalize_with_dark_values_match_old_path():
-    """normalize_with_dark returns the SAME transmission values as subtract_dark+normalize (#142)."""
+    """normalize_with_dark returns the SAME transmission values as subtract_dark+normalize."""
     from neunorm.processing.dark_corrector import subtract_dark
     from neunorm.processing.normalizer import normalize_transmission, normalize_with_dark
 
@@ -178,7 +178,7 @@ def test_normalize_with_dark_values_match_old_path():
 
 def test_normalize_with_dark_variance_matches_monte_carlo():
     """The corrected Var(T) matches a shared-dark Monte Carlo and is smaller than the old
-    double-counted value by exactly 2*N*Var(D)/M^3 (MARS) (issue #142)."""
+    double-counted value by exactly 2*N*Var(D)/M^3 (MARS)."""
     from neunorm.processing.dark_corrector import subtract_dark
     from neunorm.processing.normalizer import normalize_transmission, normalize_with_dark
 
@@ -222,7 +222,7 @@ def test_normalize_with_dark_reduces_variance_with_proton_charge():
 
 
 def test_normalize_with_dark_pc_overcount_per_image_exact():
-    """VENUS: the removed over-count equals 2*k^2*(S-D)*Var(D)/(O-D)^3 with per-image k (#142).
+    """VENUS: the removed over-count equals 2*k^2*(S-D)*Var(D)/(O-D)^3 with per-image k.
 
     Pins the exact k^2 = (pc_ob/pc_sample)^2 magnitude and the per-image broadcast for a
     multi-image sample with VARYING per-image proton charge (not just directional reduction).
@@ -293,7 +293,7 @@ def test_normalize_transmission_2d_ob():
 
 
 def test_normalize_transmission_requires_both_proton_charges():
-    """One-sided proton charge -> non-dimensionless T, so it must raise (issue #163)."""
+    """One-sided proton charge -> non-dimensionless T, so it must raise."""
     import pytest
 
     from neunorm.processing.normalizer import normalize_transmission
@@ -314,7 +314,7 @@ def test_normalize_transmission_requires_both_proton_charges():
 
 
 # ---------------------------------------------------------------------------
-# background_roi flux normalization (proton-charge proxy, issue #159)
+# background_roi flux normalization (proton-charge proxy)
 # ---------------------------------------------------------------------------
 
 
@@ -327,7 +327,7 @@ def _bg_da(values, dims=("x", "y")):
 
 
 def test_background_roi_matches_ratio_of_means():
-    """T == (sample/ob) * (mean(ob[B]) / mean(sample[B])) — the validated 1.x formula (issue #159)."""
+    """T == (sample/ob) * (mean(ob[B]) / mean(sample[B])) — the validated 1.x formula."""
     from neunorm.processing.normalizer import normalize_transmission
 
     s_vals = np.array([[10, 10, 30, 40], [10, 10, 50, 60], [12, 14, 16, 18], [20, 22, 24, 26]], dtype=float)
@@ -344,7 +344,7 @@ def test_background_roi_matches_ratio_of_means():
 
 
 def test_background_roi_cancels_beam_flux():
-    """A sample-free background ROI makes the per-image flux factors cancel -> recovers true T (issue #159)."""
+    """A sample-free background ROI makes the per-image flux factors cancel -> recovers true T."""
     from neunorm.processing.normalizer import normalize_transmission
 
     truth = np.full((4, 4), 0.8)
@@ -358,7 +358,7 @@ def test_background_roi_cancels_beam_flux():
 
 
 def test_background_roi_mutually_exclusive_with_proton_charge():
-    """background_roi and proton_charge_* are mutually exclusive (issue #159)."""
+    """background_roi and proton_charge_* are mutually exclusive."""
     import pytest
 
     from neunorm.processing.normalizer import normalize_transmission
@@ -372,7 +372,7 @@ def test_background_roi_mutually_exclusive_with_proton_charge():
 
 
 def test_background_roi_validation():
-    """Invalid background_roi tuples / missing x,y dims raise (issue #159)."""
+    """Invalid background_roi tuples / missing x,y dims raise."""
     import pytest
 
     from neunorm.processing.normalizer import normalize_transmission
@@ -388,7 +388,7 @@ def test_background_roi_validation():
 
 
 def test_background_roi_propagates_finite_variance():
-    """background_roi normalization yields finite, non-negative propagated variance (issue #159)."""
+    """background_roi normalization yields finite, non-negative propagated variance."""
     from neunorm.processing.normalizer import normalize_transmission
 
     t = normalize_transmission(
@@ -400,7 +400,7 @@ def test_background_roi_propagates_finite_variance():
 
 
 def test_background_roi_3d_per_spectral_bin():
-    """For 3D (tof, x, y) data the ROI mean is computed per spectral bin (issue #159)."""
+    """For 3D (tof, x, y) data the ROI mean is computed per spectral bin."""
     from neunorm.processing.normalizer import normalize_transmission
 
     s = np.arange(3 * 4 * 4, dtype=float).reshape(3, 4, 4) + 10.0
@@ -416,7 +416,7 @@ def test_background_roi_3d_per_spectral_bin():
 
 
 def test_background_roi_variance_first_order_value():
-    """Propagated variance equals the hand-computed first-order combination (issue #159 review)."""
+    """Propagated variance equals the hand-computed first-order combination (review)."""
     from neunorm.processing.normalizer import normalize_transmission
 
     s = np.full((4, 4), 100.0)
@@ -432,7 +432,7 @@ def test_background_roi_variance_first_order_value():
 
 
 def test_background_roi_excludes_masked_pixels():
-    """Masked pixels inside the ROI are excluded from the ROI mean (issue #159 review, P0)."""
+    """Masked pixels inside the ROI are excluded from the ROI mean (review, P0)."""
     from neunorm.processing.normalizer import normalize_transmission
 
     s = np.full((4, 4), 100.0)
@@ -451,7 +451,7 @@ def test_background_roi_excludes_masked_pixels():
 
 def test_background_roi_with_dark_variance_matches_full_first_order():
     """dark + background_roi Var(T) matches the FULL first-order shared-dark propagation at an
-    outside-ROI pixel (issue #159 review).
+    outside-ROI pixel (review).
 
     The oracle is derived by hand, independent of the implementation's formula, to avoid circular
     validation. Spatially uniform so cs/co are exact, but S != O so k = co/cs != 1 is exercised.
@@ -469,19 +469,19 @@ def test_background_roi_with_dark_variance_matches_full_first_order():
     np.testing.assert_allclose(corrected.values, naive.values, rtol=1e-12)  # values unchanged
 
     # Independent first-order oracle for an OUTSIDE-ROI pixel with shared dark d (Poisson Var=value):
-    #   Var(T)/T^2 = [Var(s-d)/(s-d)^2 + Var(o-d)/(o-d)^2 - 2 Var(d)/((s-d)(o-d))]   (pixel, #142)
-    #              + [Var(cs)/cs^2     + Var(co)/co^2     - 2 Cov(cs,co)/(cs co)]     (ROI-mean, #159)
+    #   Var(T)/T^2 = [Var(s-d)/(s-d)^2 + Var(o-d)/(o-d)^2 - 2 Var(d)/((s-d)(o-d))]   (pixel)
+    #              + [Var(cs)/cs^2     + Var(co)/co^2     - 2 Cov(cs,co)/(cs co)]     (ROI-mean)
     # with cs=s-d, co=o-d, Var(cs)=(s+d)/n, Var(co)=(o+d)/n, Cov(cs,co)=Var(mean d_roi)=d/n.
     s_dc, o_dc = cnt_s - cnt_d, cnt_o - cnt_d
     pixel = (cnt_s + cnt_d) / s_dc**2 + (cnt_o + cnt_d) / o_dc**2 - 2 * cnt_d / (s_dc * o_dc)
     roi_mean = ((cnt_s + cnt_d) / n) / s_dc**2 + ((cnt_o + cnt_d) / n) / o_dc**2 - 2 * (cnt_d / n) / (s_dc * o_dc)
     np.testing.assert_allclose(corrected.variances[3, 3], pixel + roi_mean, rtol=1e-9)
-    # the #159 ROI-mean covariance correction strictly reduces the reported variance
+    # the ROI-mean covariance correction strictly reduces the reported variance
     assert corrected.variances[3, 3] < naive.variances[3, 3]
 
 
 def test_background_roi_with_dark_subtracts_both_shared_dark_terms():
-    """dark + background_roi removes BOTH shared-dark variance terms — the #142 pixel-level
+    """dark + background_roi removes BOTH shared-dark variance terms — the pixel-level
     over-count AND the ROI-mean covariance term — on a non-uniform fixture (k != 1, per-pixel)."""
     from neunorm.processing.dark_corrector import subtract_dark
     from neunorm.processing.normalizer import _background_roi_means, normalize_transmission, normalize_with_dark
@@ -499,9 +499,9 @@ def test_background_roi_with_dark_subtracts_both_shared_dark_terms():
     cs, co = _background_roi_means(subtract_dark(s, d), subtract_dark(o, d), roi)
     k = co.value / cs.value
     assert abs(k - 1.0) > 0.3  # fixture exercises k != 1
-    pixel_term = 2.0 * (k**2) * s_dc * d.values / (o_dc**3)  # #142 pixel-level over-count
+    pixel_term = 2.0 * (k**2) * s_dc * d.values / (o_dc**3)  # pixel-level over-count
     cov = d.values[0:2, 0:2].sum() / n**2  # Cov(cs,co) = Var(mean D_roi) = (1/n^2) sum Var(D), Var(D)=D
-    roi_mean_term = 2.0 * corrected.values**2 * cov / (cs.value * co.value)  # #159 ROI-mean over-count
+    roi_mean_term = 2.0 * corrected.values**2 * cov / (cs.value * co.value)  # ROI-mean over-count
     np.testing.assert_allclose(naive.variances - corrected.variances, pixel_term + roi_mean_term, rtol=1e-6)
     assert np.all(pixel_term > 0) and cov > 0
 
@@ -560,7 +560,7 @@ def test_background_roi_broadcast_ob_only_variance():
 
 
 def test_background_roi_with_dark_covariance_is_mask_aware():
-    """The ROI-mean shared-dark covariance excludes pixels masked from cs/co (issue #159 review).
+    """The ROI-mean shared-dark covariance excludes pixels masked from cs/co (review).
 
     A dead/hot pixel inside the background ROI, masked on one side, must not pollute Cov(cs,co) and
     over-subtract (which would under-state Var(T)).

--- a/tests/unit/test_normalizer.py
+++ b/tests/unit/test_normalizer.py
@@ -413,3 +413,52 @@ def test_background_roi_3d_per_spectral_bin():
     co = o[:, 0:2, 0:2].mean(axis=(1, 2))
     expected = (s / o) * (co / cs)[:, None, None]
     np.testing.assert_allclose(t.values, expected, rtol=1e-6)
+
+
+def test_background_roi_variance_first_order_value():
+    """Propagated variance equals the hand-computed first-order combination (issue #159 review)."""
+    from neunorm.processing.normalizer import normalize_transmission
+
+    s = np.full((4, 4), 100.0)
+    s[3, 3] = 80.0
+    o = np.full((4, 4), 200.0)
+    o[3, 3] = 160.0
+    t = normalize_transmission(_bg_da(s), _bg_da(o), background_roi=(0, 0, 2, 2))
+    # ROI means: cs=100 (Var(mean)=400/16=25), co=200 (Var=800/16=50). Pixel (3,3): S=80, O=160 -> T=1.
+    # Var(T) = T^2*(Var(S)/S^2 + Var(cs)/cs^2 + Var(O)/O^2 + Var(co)/co^2)
+    #        = 1*(80/6400 + 25/10000 + 160/25600 + 50/40000) = 0.0225
+    np.testing.assert_allclose(t.values[3, 3], 1.0, rtol=1e-6)
+    np.testing.assert_allclose(t.variances[3, 3], 0.0225, rtol=1e-6)
+
+
+def test_background_roi_excludes_masked_pixels():
+    """Masked pixels inside the ROI are excluded from the ROI mean (issue #159 review, P0)."""
+    from neunorm.processing.normalizer import normalize_transmission
+
+    s = np.full((4, 4), 100.0)
+    s[0, 0] = 1.0e6  # huge outlier inside the ROI...
+    sample = _bg_da(s)
+    mask = np.zeros((4, 4), dtype=bool)
+    mask[0, 0] = True  # ...but masked, so it must not enter cs
+    sample.masks["bad"] = sc.array(dims=["x", "y"], values=mask)
+    ob = _bg_da(np.full((4, 4), 200.0))
+
+    t = normalize_transmission(sample, ob, background_roi=(0, 0, 2, 2))
+    # mask-aware cs = mean of the 3 unmasked ROI pixels = 100 (1e6 excluded). An out-of-ROI pixel
+    # (S=100, O=200) -> T = (100/100)/(200/200) = 1. (With the masked outlier counted, T would be tiny.)
+    np.testing.assert_allclose(t.values[3, 3], 1.0, rtol=1e-6)
+
+
+def test_background_roi_with_dark_corrects_shared_dark_double_count():
+    """normalize_with_dark(background_roi) keeps values but removes the #142 shared-dark over-count."""
+    from neunorm.processing.dark_corrector import subtract_dark
+    from neunorm.processing.normalizer import normalize_transmission, normalize_with_dark
+
+    s = _bg_da(np.full((4, 4), 300.0))
+    o = _bg_da(np.full((4, 4), 500.0))
+    d = _bg_da(np.full((4, 4), 15.0))
+    naive = normalize_transmission(subtract_dark(s, d), subtract_dark(o, d), background_roi=(0, 0, 2, 2))
+    corrected = normalize_with_dark(s, o, d, background_roi=(0, 0, 2, 2))
+    np.testing.assert_allclose(corrected.values, naive.values, rtol=1e-6)  # values unchanged
+    assert np.all(corrected.variances <= naive.variances + 1e-12)  # over-count removed -> never larger
+    assert np.any(corrected.variances < naive.variances - 1e-12)  # strictly smaller somewhere

--- a/tests/unit/test_normalizer.py
+++ b/tests/unit/test_normalizer.py
@@ -450,15 +450,42 @@ def test_background_roi_excludes_masked_pixels():
 
 
 def test_background_roi_with_dark_corrects_shared_dark_double_count():
-    """normalize_with_dark(background_roi) keeps values but removes the #142 shared-dark over-count."""
-    from neunorm.processing.dark_corrector import subtract_dark
-    from neunorm.processing.normalizer import normalize_transmission, normalize_with_dark
+    """normalize_with_dark(background_roi) keeps values and removes EXACTLY the #142 over-count.
 
-    s = _bg_da(np.full((4, 4), 300.0))
-    o = _bg_da(np.full((4, 4), 500.0))
-    d = _bg_da(np.full((4, 4), 15.0))
-    naive = normalize_transmission(subtract_dark(s, d), subtract_dark(o, d), background_roi=(0, 0, 2, 2))
-    corrected = normalize_with_dark(s, o, d, background_roi=(0, 0, 2, 2))
+    Uses a non-uniform fixture so the dark-corrected ROI means differ (k = co/cs != 1); a uniform
+    fixture would make k = 1 and could not distinguish the correct k = co/cs scaling from k = 1.
+    """
+    from neunorm.processing.dark_corrector import subtract_dark
+    from neunorm.processing.normalizer import _background_roi_means, normalize_transmission, normalize_with_dark
+
+    roi = (0, 0, 2, 2)
+    s = _bg_da(300.0 + np.arange(16).reshape(4, 4))  # 300..315
+    o = _bg_da(500.0 + 2.0 * np.arange(16).reshape(4, 4))  # 500..530
+    d = _bg_da(10.0 + 0.5 * np.arange(16).reshape(4, 4))  # small darks 10..17.5
+    naive = normalize_transmission(subtract_dark(s, d), subtract_dark(o, d), background_roi=roi)
+    corrected = normalize_with_dark(s, o, d, background_roi=roi)
+
     np.testing.assert_allclose(corrected.values, naive.values, rtol=1e-6)  # values unchanged
-    assert np.all(corrected.variances <= naive.variances + 1e-12)  # over-count removed -> never larger
-    assert np.any(corrected.variances < naive.variances - 1e-12)  # strictly smaller somewhere
+
+    # Exact oracle: naive - corrected == over_count = 2 * k^2 * (S-D) * Var(D) / (O-D)^3, k = co/cs.
+    s_dc = s.values - d.values
+    o_dc = o.values - d.values
+    cs, co = _background_roi_means(subtract_dark(s, d), subtract_dark(o, d), roi)
+    k = co.value / cs.value
+    assert abs(k - 1.0) > 0.3  # fixture really exercises k != 1
+    over_count = 2.0 * (k**2) * s_dc * d.values / (o_dc**3)
+    np.testing.assert_allclose(naive.variances - corrected.variances, over_count, rtol=1e-6)
+    assert np.all(over_count > 0)  # the correction strictly reduces the reported variance
+
+
+def test_background_roi_zero_mean_raises():
+    """A zero (or non-finite) ROI mean is rejected with a clear error, not silent inf/nan output."""
+    import pytest
+
+    from neunorm.processing.normalizer import normalize_transmission
+
+    s = _bg_da(np.full((4, 4), 100.0))
+    o = np.full((4, 4), 200.0)
+    o[0:2, 0:2] = 0.0  # open-beam ROI has zero counts -> co == 0
+    with pytest.raises(ValueError, match="strictly positive and finite"):
+        normalize_transmission(s, _bg_da(o), background_roi=(0, 0, 2, 2))

--- a/tests/unit/test_normalizer.py
+++ b/tests/unit/test_normalizer.py
@@ -311,3 +311,105 @@ def test_normalize_transmission_requires_both_proton_charges():
     # both provided is fine and stays dimensionless
     t = normalize_transmission(sample, ob, proton_charge_sample=500.0, proton_charge_ob=505.0)
     assert t.unit == sc.units.one
+
+
+# ---------------------------------------------------------------------------
+# background_roi flux normalization (proton-charge proxy, issue #159)
+# ---------------------------------------------------------------------------
+
+
+def _bg_da(values, dims=("x", "y")):
+    """Helper: scipp DataArray in counts with Poisson variance = values."""
+    values = np.asarray(values, dtype=float)
+    da = sc.DataArray(data=sc.array(dims=list(dims), values=values, unit="counts"))
+    da.variances = values.copy()
+    return da
+
+
+def test_background_roi_matches_ratio_of_means():
+    """T == (sample/ob) * (mean(ob[B]) / mean(sample[B])) — the validated 1.x formula (issue #159)."""
+    from neunorm.processing.normalizer import normalize_transmission
+
+    s_vals = np.array([[10, 10, 30, 40], [10, 10, 50, 60], [12, 14, 16, 18], [20, 22, 24, 26]], dtype=float)
+    o_vals = np.array([[20, 20, 25, 35], [20, 20, 45, 55], [22, 24, 26, 28], [30, 32, 34, 36]], dtype=float)
+    roi = (0, 0, 2, 2)  # (x0, y0, x1, y1), exclusive stops -> the [0:2, 0:2] block
+
+    t = normalize_transmission(_bg_da(s_vals), _bg_da(o_vals), background_roi=roi)
+
+    cs = s_vals[0:2, 0:2].mean()
+    co = o_vals[0:2, 0:2].mean()
+    expected = (s_vals / o_vals) * (co / cs)
+    np.testing.assert_allclose(t.values, expected, rtol=1e-6)
+    assert t.unit == sc.units.one
+
+
+def test_background_roi_cancels_beam_flux():
+    """A sample-free background ROI makes the per-image flux factors cancel -> recovers true T (issue #159)."""
+    from neunorm.processing.normalizer import normalize_transmission
+
+    truth = np.full((4, 4), 0.8)
+    truth[0:2, 0:2] = 1.0  # background quadrant: no sample, transmission = 1
+    flux_s, flux_o = 3.0, 5.0  # different beam intensity for sample vs open-beam acquisition
+    sample = _bg_da(flux_s * truth * 100.0)
+    ob = _bg_da(flux_o * np.ones((4, 4)) * 100.0)
+
+    t = normalize_transmission(sample, ob, background_roi=(0, 0, 2, 2))
+    np.testing.assert_allclose(t.values, truth, rtol=1e-6)
+
+
+def test_background_roi_mutually_exclusive_with_proton_charge():
+    """background_roi and proton_charge_* are mutually exclusive (issue #159)."""
+    import pytest
+
+    from neunorm.processing.normalizer import normalize_transmission
+
+    sample = _bg_da(np.full((4, 4), 100.0))
+    ob = _bg_da(np.full((4, 4), 100.0))
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        normalize_transmission(
+            sample, ob, proton_charge_sample=500.0, proton_charge_ob=505.0, background_roi=(0, 0, 2, 2)
+        )
+
+
+def test_background_roi_validation():
+    """Invalid background_roi tuples / missing x,y dims raise (issue #159)."""
+    import pytest
+
+    from neunorm.processing.normalizer import normalize_transmission
+
+    sample = _bg_da(np.full((4, 4), 100.0))
+    ob = _bg_da(np.full((4, 4), 100.0))
+    with pytest.raises(ValueError):
+        normalize_transmission(sample, ob, background_roi=(0, 0, 2))  # not 4 ints
+    with pytest.raises(ValueError):
+        normalize_transmission(sample, ob, background_roi=(0, 0, 100, 100))  # out of bounds
+    with pytest.raises(ValueError):
+        normalize_transmission(sample, ob, background_roi=(2, 0, 1, 2))  # x1 <= x0
+
+
+def test_background_roi_propagates_finite_variance():
+    """background_roi normalization yields finite, non-negative propagated variance (issue #159)."""
+    from neunorm.processing.normalizer import normalize_transmission
+
+    t = normalize_transmission(
+        _bg_da(np.full((4, 4), 100.0)), _bg_da(np.full((4, 4), 200.0)), background_roi=(0, 0, 2, 2)
+    )
+    assert t.variances is not None
+    assert np.all(np.isfinite(t.variances))
+    assert np.all(t.variances >= 0)
+
+
+def test_background_roi_3d_per_spectral_bin():
+    """For 3D (tof, x, y) data the ROI mean is computed per spectral bin (issue #159)."""
+    from neunorm.processing.normalizer import normalize_transmission
+
+    s = np.arange(3 * 4 * 4, dtype=float).reshape(3, 4, 4) + 10.0
+    o = np.arange(3 * 4 * 4, dtype=float).reshape(3, 4, 4) + 20.0
+    t = normalize_transmission(
+        _bg_da(s, dims=("tof", "x", "y")), _bg_da(o, dims=("tof", "x", "y")), background_roi=(0, 0, 2, 2)
+    )
+    assert t.shape == (3, 4, 4)
+    cs = s[:, 0:2, 0:2].mean(axis=(1, 2))
+    co = o[:, 0:2, 0:2].mean(axis=(1, 2))
+    expected = (s / o) * (co / cs)[:, None, None]
+    np.testing.assert_allclose(t.values, expected, rtol=1e-6)

--- a/tests/unit/test_normalizer.py
+++ b/tests/unit/test_normalizer.py
@@ -489,3 +489,28 @@ def test_background_roi_zero_mean_raises():
     o[0:2, 0:2] = 0.0  # open-beam ROI has zero counts -> co == 0
     with pytest.raises(ValueError, match="strictly positive and finite"):
         normalize_transmission(s, _bg_da(o), background_roi=(0, 0, 2, 2))
+
+
+def test_background_roi_mixed_variance_inputs():
+    """One-sided-variance inputs must not raise; the extra term uses only the side with variance."""
+    from neunorm.processing.normalizer import normalize_transmission
+
+    roi = (0, 0, 2, 2)
+
+    def _no_var(values):
+        v = np.asarray(values, dtype=float)
+        return sc.DataArray(data=sc.array(dims=["x", "y"], values=v, unit="counts"))
+
+    s_vals = np.full((4, 4), 100.0)
+    o_vals = np.full((4, 4), 200.0)
+
+    # sample has variance, ob does not -> output carries variance (from the sample side only)
+    t1 = normalize_transmission(_bg_da(s_vals), _no_var(o_vals), background_roi=roi)
+    assert t1.variances is not None
+    # ob has variance, sample does not -> this is the case that previously raised in `ob / co`
+    t2 = normalize_transmission(_no_var(s_vals), _bg_da(o_vals), background_roi=roi)
+    assert t2.variances is not None
+    # neither side has variance -> no output variance, and no crash
+    t3 = normalize_transmission(_no_var(s_vals), _no_var(o_vals), background_roi=roi)
+    assert t3.variances is None
+    np.testing.assert_allclose(t3.values, 1.0, rtol=1e-6)

--- a/tests/unit/test_normalizer.py
+++ b/tests/unit/test_normalizer.py
@@ -557,3 +557,30 @@ def test_background_roi_broadcast_ob_only_variance():
     t = normalize_transmission(s3, o2, background_roi=(0, 0, 2, 2))
     assert t.variances is not None
     assert np.all(t.variances > 0)  # OB pixel variance + co ROI-mean term, not silently dropped
+
+
+def test_background_roi_with_dark_covariance_is_mask_aware():
+    """The ROI-mean shared-dark covariance excludes pixels masked from cs/co (issue #159 review).
+
+    A dead/hot pixel inside the background ROI, masked on one side, must not pollute Cov(cs,co) and
+    over-subtract (which would under-state Var(T)).
+    """
+    from neunorm.processing.dark_corrector import subtract_dark
+    from neunorm.processing.normalizer import _roi_dark_mean_covariance, normalize_with_dark
+
+    roi = (0, 0, 2, 2)
+    darkvals = np.ones((4, 4))
+    darkvals[0, 0] = 199.0  # hot dark pixel inside the ROI
+    smask = np.zeros((4, 4), dtype=bool)
+    smask[0, 0] = True  # masked on the sample side, not the OB side
+    s = _bg_da(np.full((4, 4), 2.0))
+    s.masks["dead"] = sc.array(dims=["x", "y"], values=smask)
+    o = _bg_da(np.full((4, 4), 200.0))
+    d = _bg_da(darkvals)
+
+    # intersection covariance = sum Var(D over A∩B) / (n_s * n_o) = (1+1+1)/(3*4) = 0.25,
+    # NOT the unmasked Var(mean(D_roi)) = (199+1+1+1)/16 = 12.625 that includes the masked hot pixel
+    cov = _roi_dark_mean_covariance(subtract_dark(s, d), subtract_dark(o, d), d, roi)
+    np.testing.assert_allclose(cov.value, 0.25, rtol=1e-12)
+    corrected = normalize_with_dark(s, o, d, background_roi=roi)
+    np.testing.assert_allclose(corrected.variances[3, 3], 2.3249784653905294, rtol=1e-9)

--- a/tests/unit/test_normalizer.py
+++ b/tests/unit/test_normalizer.py
@@ -449,16 +449,44 @@ def test_background_roi_excludes_masked_pixels():
     np.testing.assert_allclose(t.values[3, 3], 1.0, rtol=1e-6)
 
 
-def test_background_roi_with_dark_corrects_shared_dark_double_count():
-    """normalize_with_dark(background_roi) keeps values and removes EXACTLY the #142 over-count.
+def test_background_roi_with_dark_variance_matches_full_first_order():
+    """dark + background_roi Var(T) matches the FULL first-order shared-dark propagation at an
+    outside-ROI pixel (issue #159 review).
 
-    Uses a non-uniform fixture so the dark-corrected ROI means differ (k = co/cs != 1); a uniform
-    fixture would make k = 1 and could not distinguish the correct k = co/cs scaling from k = 1.
+    The oracle is derived by hand, independent of the implementation's formula, to avoid circular
+    validation. Spatially uniform so cs/co are exact, but S != O so k = co/cs != 1 is exercised.
     """
+    from neunorm.processing.dark_corrector import subtract_dark
+    from neunorm.processing.normalizer import normalize_transmission, normalize_with_dark
+
+    cnt_s, cnt_o, cnt_d, n = 100.0, 200.0, 10.0, 4  # 2x2 ROI -> n = 4; k = co/cs = 190/90 != 1
+    s, o, d = _bg_da(np.full((4, 4), cnt_s)), _bg_da(np.full((4, 4), cnt_o)), _bg_da(np.full((4, 4), cnt_d))
+    roi = (0, 0, 2, 2)
+    corrected = normalize_with_dark(s, o, d, background_roi=roi)
+    naive = normalize_transmission(subtract_dark(s, d), subtract_dark(o, d), background_roi=roi)
+
+    np.testing.assert_allclose(corrected.values, 1.0, rtol=1e-12)  # uniform -> T = 1
+    np.testing.assert_allclose(corrected.values, naive.values, rtol=1e-12)  # values unchanged
+
+    # Independent first-order oracle for an OUTSIDE-ROI pixel with shared dark d (Poisson Var=value):
+    #   Var(T)/T^2 = [Var(s-d)/(s-d)^2 + Var(o-d)/(o-d)^2 - 2 Var(d)/((s-d)(o-d))]   (pixel, #142)
+    #              + [Var(cs)/cs^2     + Var(co)/co^2     - 2 Cov(cs,co)/(cs co)]     (ROI-mean, #159)
+    # with cs=s-d, co=o-d, Var(cs)=(s+d)/n, Var(co)=(o+d)/n, Cov(cs,co)=Var(mean d_roi)=d/n.
+    s_dc, o_dc = cnt_s - cnt_d, cnt_o - cnt_d
+    pixel = (cnt_s + cnt_d) / s_dc**2 + (cnt_o + cnt_d) / o_dc**2 - 2 * cnt_d / (s_dc * o_dc)
+    roi_mean = ((cnt_s + cnt_d) / n) / s_dc**2 + ((cnt_o + cnt_d) / n) / o_dc**2 - 2 * (cnt_d / n) / (s_dc * o_dc)
+    np.testing.assert_allclose(corrected.variances[3, 3], pixel + roi_mean, rtol=1e-9)
+    # the #159 ROI-mean covariance correction strictly reduces the reported variance
+    assert corrected.variances[3, 3] < naive.variances[3, 3]
+
+
+def test_background_roi_with_dark_subtracts_both_shared_dark_terms():
+    """dark + background_roi removes BOTH shared-dark variance terms — the #142 pixel-level
+    over-count AND the ROI-mean covariance term — on a non-uniform fixture (k != 1, per-pixel)."""
     from neunorm.processing.dark_corrector import subtract_dark
     from neunorm.processing.normalizer import _background_roi_means, normalize_transmission, normalize_with_dark
 
-    roi = (0, 0, 2, 2)
+    roi, n = (0, 0, 2, 2), 4
     s = _bg_da(300.0 + np.arange(16).reshape(4, 4))  # 300..315
     o = _bg_da(500.0 + 2.0 * np.arange(16).reshape(4, 4))  # 500..530
     d = _bg_da(10.0 + 0.5 * np.arange(16).reshape(4, 4))  # small darks 10..17.5
@@ -467,15 +495,15 @@ def test_background_roi_with_dark_corrects_shared_dark_double_count():
 
     np.testing.assert_allclose(corrected.values, naive.values, rtol=1e-6)  # values unchanged
 
-    # Exact oracle: naive - corrected == over_count = 2 * k^2 * (S-D) * Var(D) / (O-D)^3, k = co/cs.
-    s_dc = s.values - d.values
-    o_dc = o.values - d.values
+    s_dc, o_dc = s.values - d.values, o.values - d.values
     cs, co = _background_roi_means(subtract_dark(s, d), subtract_dark(o, d), roi)
     k = co.value / cs.value
-    assert abs(k - 1.0) > 0.3  # fixture really exercises k != 1
-    over_count = 2.0 * (k**2) * s_dc * d.values / (o_dc**3)
-    np.testing.assert_allclose(naive.variances - corrected.variances, over_count, rtol=1e-6)
-    assert np.all(over_count > 0)  # the correction strictly reduces the reported variance
+    assert abs(k - 1.0) > 0.3  # fixture exercises k != 1
+    pixel_term = 2.0 * (k**2) * s_dc * d.values / (o_dc**3)  # #142 pixel-level over-count
+    cov = d.values[0:2, 0:2].sum() / n**2  # Cov(cs,co) = Var(mean D_roi) = (1/n^2) sum Var(D), Var(D)=D
+    roi_mean_term = 2.0 * corrected.values**2 * cov / (cs.value * co.value)  # #159 ROI-mean over-count
+    np.testing.assert_allclose(naive.variances - corrected.variances, pixel_term + roi_mean_term, rtol=1e-6)
+    assert np.all(pixel_term > 0) and cov > 0
 
 
 def test_background_roi_zero_mean_raises():
@@ -514,3 +542,18 @@ def test_background_roi_mixed_variance_inputs():
     t3 = normalize_transmission(_no_var(s_vals), _no_var(o_vals), background_roi=roi)
     assert t3.variances is None
     np.testing.assert_allclose(t3.values, 1.0, rtol=1e-6)
+
+
+def test_background_roi_broadcast_ob_only_variance():
+    """3D no-variance sample + 2D variance OB (broadcast path): OB variance must still propagate.
+
+    Regression for the broadcast-branch gate that dropped the OB-variance term (and the co
+    ROI-mean term) when the sample carried no variance — under-stating the reported error.
+    """
+    from neunorm.processing.normalizer import normalize_transmission
+
+    s3 = sc.DataArray(sc.array(dims=["t", "x", "y"], values=np.full((2, 4, 4), 100.0), unit="counts"))
+    o2 = _bg_da(np.full((4, 4), 200.0))  # 2D, carries Poisson variance
+    t = normalize_transmission(s3, o2, background_roi=(0, 0, 2, 2))
+    assert t.variances is not None
+    assert np.all(t.variances > 0)  # OB pixel variance + co ROI-mean term, not silently dropped

--- a/tests/unit/test_pulse_reconstruction.py
+++ b/tests/unit/test_pulse_reconstruction.py
@@ -175,7 +175,7 @@ class TestPulseReconstruction:
 
 
 def test_assign_chip_ids_quadrants():
-    """assign_chip_ids maps pixel quadrants to chip 0-3 for a 2x2 quad detector (issue #163)."""
+    """assign_chip_ids maps pixel quadrants to chip 0-3 for a 2x2 quad detector."""
     import pytest
 
     from neunorm.tof.pulse_reconstruction import assign_chip_ids

--- a/tests/unit/test_roi.py
+++ b/tests/unit/test_roi.py
@@ -1,4 +1,4 @@
-"""Unit tests for the ROI data model (issue #159, Jean's named-ROI request)."""
+"""Unit tests for the ROI data model (Jean's named-ROI request)."""
 
 import pytest
 

--- a/tests/unit/test_roi.py
+++ b/tests/unit/test_roi.py
@@ -5,11 +5,11 @@ import pytest
 from neunorm.data_models.roi import ROI, as_roi_bounds
 
 
-def test_roi_exported_from_top_level():
-    """ROI is importable from the package root (mirrors 1.x `from NeuNorm.roi import ROI`)."""
-    import neunorm
+def test_roi_exported_from_data_models():
+    """ROI is exported from the data_models package (like BinningConfig) and its submodule."""
+    import neunorm.data_models as dm
 
-    assert neunorm.ROI is ROI
+    assert dm.ROI is ROI
 
 
 def test_roi_stops_form():

--- a/tests/unit/test_roi.py
+++ b/tests/unit/test_roi.py
@@ -66,6 +66,13 @@ def test_as_roi_bounds_accepts_roi_and_tuple():
     assert as_roi_bounds([1, 2, 3, 4]) == (1, 2, 3, 4)
 
 
+@pytest.mark.parametrize("bad", [(1, 2, 3), (1, 2, 3, 4, 5), (), [1, 2]])
+def test_as_roi_bounds_rejects_wrong_length(bad):
+    """A bare sequence that is not 4 elements fails fast at the single coercion point."""
+    with pytest.raises(ValueError, match="ROI must be a tuple of 4 integers"):
+        as_roi_bounds(bad)
+
+
 def _da(values, unit="counts"):
     import numpy as np
     import scipp as sc

--- a/tests/unit/test_roi.py
+++ b/tests/unit/test_roi.py
@@ -1,0 +1,118 @@
+"""Unit tests for the ROI data model (issue #159, Jean's named-ROI request)."""
+
+import pytest
+
+from neunorm.data_models.roi import ROI, as_roi_bounds
+
+
+def test_roi_exported_from_top_level():
+    """ROI is importable from the package root (mirrors 1.x `from NeuNorm.roi import ROI`)."""
+    import neunorm
+
+    assert neunorm.ROI is ROI
+
+
+def test_roi_stops_form():
+    """ROI(x0, y0, x1, y1) yields the exclusive-stop bounds tuple."""
+    assert ROI(x0=10, y0=20, x1=30, y1=40).as_bounds() == (10, 20, 30, 40)
+
+
+def test_roi_size_form_equivalent_to_stops():
+    """ROI(..., width, height) resolves to x1=x0+width, y1=y0+height — equal to the stop form."""
+    assert ROI(x0=10, y0=20, width=20, height=20).as_bounds() == (10, 20, 30, 40)
+    assert ROI(x0=10, y0=20, width=20, height=20).as_bounds() == ROI(x0=10, y0=20, x1=30, y1=40).as_bounds()
+
+
+def test_roi_mixed_forms_per_axis():
+    """A stop on one axis and a size on the other is allowed."""
+    assert ROI(x0=0, y0=5, x1=8, height=10).as_bounds() == (0, 5, 8, 15)
+    assert ROI(x0=0, y0=5, width=8, y1=15).as_bounds() == (0, 5, 8, 15)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"x0": 0, "y0": 0, "x1": 10, "width": 10, "y1": 10},  # both x1 and width
+        {"x0": 0, "y0": 0, "y1": 10},  # neither x1 nor width
+        {"x0": 0, "y0": 0, "x1": 10, "height": 10, "width": 10},  # both y1 and height (via height+width)
+        {"x0": 0, "y0": 0, "x1": 10},  # neither y1 nor height
+    ],
+)
+def test_roi_requires_exactly_one_per_axis(kwargs):
+    """Providing both (or neither) of stop/size on an axis raises."""
+    with pytest.raises(ValueError, match="exactly one"):
+        ROI(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"x0": -1, "y0": 0, "x1": 10, "y1": 10},  # negative origin
+        {"x0": 10, "y0": 0, "x1": 10, "y1": 10},  # x1 == x0 (empty)
+        {"x0": 0, "y0": 0, "x1": 10, "height": 0},  # zero height -> y1 == y0
+        {"x0": 0, "y0": 0, "width": -5, "y1": 10},  # negative width -> x1 < x0
+    ],
+)
+def test_roi_rejects_degenerate_rectangles(kwargs):
+    """Non-positive extents / out-of-order or negative bounds raise."""
+    with pytest.raises(ValueError, match="Invalid ROI"):
+        ROI(**kwargs)
+
+
+def test_as_roi_bounds_accepts_roi_and_tuple():
+    """as_roi_bounds coerces both an ROI and a bare (x0, y0, x1, y1) tuple/list."""
+    assert as_roi_bounds(ROI(x0=1, y0=2, x1=3, y1=4)) == (1, 2, 3, 4)
+    assert as_roi_bounds((1, 2, 3, 4)) == (1, 2, 3, 4)
+    assert as_roi_bounds([1, 2, 3, 4]) == (1, 2, 3, 4)
+
+
+def _da(values, unit="counts"):
+    import numpy as np
+    import scipp as sc
+
+    v = np.asarray(values, dtype=float)
+    da = sc.DataArray(sc.array(dims=["x", "y"], values=v, unit=unit))
+    da.variances = v.copy()
+    return da
+
+
+def test_roi_matches_tuple_in_apply_roi():
+    """apply_roi gives identical results for an ROI and the equivalent (x0,y0,x1,y1) tuple."""
+    import numpy as np
+
+    from neunorm.processing.roi_clipper import apply_roi
+
+    data = _da(np.arange(100.0).reshape(10, 10))
+    a = apply_roi(data, (2, 3, 7, 8))
+    b = apply_roi(data, ROI(x0=2, y0=3, x1=7, y1=8))
+    c = apply_roi(data, ROI(x0=2, y0=3, width=5, height=5))
+    assert a.sizes == b.sizes == c.sizes
+    np.testing.assert_array_equal(a.values, b.values)
+    np.testing.assert_array_equal(a.values, c.values)
+
+
+def test_roi_matches_tuple_in_background_roi_normalization():
+    """normalize_transmission(background_roi=ROI(...)) == background_roi=(x0,y0,x1,y1)."""
+    import numpy as np
+
+    from neunorm.processing.normalizer import normalize_transmission
+
+    s, o = _da(np.full((6, 6), 80.0)), _da(np.full((6, 6), 100.0))
+    t_tuple = normalize_transmission(s, o, background_roi=(0, 0, 3, 3))
+    t_roi = normalize_transmission(s, o, background_roi=ROI(x0=0, y0=0, x1=3, y1=3))
+    t_size = normalize_transmission(s, o, background_roi=ROI(x0=0, y0=0, width=3, height=3))
+    np.testing.assert_array_equal(t_tuple.values, t_roi.values)
+    np.testing.assert_array_equal(t_tuple.variances, t_roi.variances)
+    np.testing.assert_array_equal(t_tuple.values, t_size.values)
+
+
+def test_roi_matches_tuple_in_air_region_correction():
+    """apply_air_region_correction gives identical results for an ROI and the equivalent tuple."""
+    import numpy as np
+
+    from neunorm.processing.air_region_corrector import apply_air_region_correction
+
+    t = _da(np.linspace(0.8, 1.2, 36).reshape(6, 6), unit="dimensionless")
+    a = apply_air_region_correction(t, (0, 0, 3, 3))
+    b = apply_air_region_correction(t, ROI(x0=0, y0=0, width=3, height=3))
+    np.testing.assert_array_equal(a.values, b.values)

--- a/tests/unit/test_run_combiner.py
+++ b/tests/unit/test_run_combiner.py
@@ -275,7 +275,7 @@ def test_combine_runs_missing():
 
 
 def test_combine_runs_single_run():
-    """Test that combining a single run returns an equal but independent copy (issue #163)."""
+    """Test that combining a single run returns an equal but independent copy."""
     from neunorm.processing.run_combiner import combine_runs
 
     run = sc.DataArray(

--- a/tests/unit/test_tiff_loader.py
+++ b/tests/unit/test_tiff_loader.py
@@ -31,7 +31,7 @@ def test_load_tiff_stack():
     assert da.variances.shape == (3, 5, 5)
     assert da.variances.max() == 5
 
-    # float32 is sufficient for neutron imaging; loading in float32 halves memory (issue #147)
+    # float32 is sufficient for neutron imaging; loading in float32 halves memory
     assert da.values.dtype == np.float32
     assert da.variances.dtype == np.float32
 

--- a/tests/unit/test_venus_ccd.py
+++ b/tests/unit/test_venus_ccd.py
@@ -124,7 +124,7 @@ class TestVenusCCDPipeline:
                 # T = (S - AVERAGE(D)) / (AVERAGE(OB) - AVERAGE(D))
                 # but will be two times because of the difference proton charge between sample and OB
                 for i in range(5):
-                    # rtol consistent with float32 compute precision (issue #147)
+                    # rtol consistent with float32 compute precision
                     np.testing.assert_allclose(hf["transmission"][i], (81 + i - 5) / (100 - 5) * 2, rtol=1e-5)
                 assert hf["transmission"].attrs["units"] == "dimensionless"
                 assert hf["transmission"].dtype == np.float32
@@ -140,7 +140,7 @@ class TestVenusCCDPipeline:
                 # Check masks
                 assert "masks/dead" in hf
                 np.testing.assert_equal(hf["masks/dead"], np.zeros((32, 32), dtype=bool))
-                # Check metadata (nested per-run paths stored as round-trippable JSON, issue #140)
+                # Check metadata (nested per-run paths stored as round-trippable JSON)
                 assert "metadata/sample_paths" in hf
                 assert json.loads(hf["metadata/sample_paths"].asstr()[()]) == [[str(p) for p in self.sample_paths]]
                 assert "metadata/ob_paths" in hf
@@ -194,7 +194,7 @@ class TestVenusCCDPipeline:
         # T = (S - AVERAGE(D)) / (AVERAGE(OB) - AVERAGE(D))
         # but will be two times because of the difference proton charge between sample and OB
         for i in range(5):
-            # rtol consistent with float32 compute precision (issue #147)
+            # rtol consistent with float32 compute precision
             np.testing.assert_allclose(image.values[i], (81 + i - 5) / (100 - 5) * 2, rtol=1e-5)
         # Check uncertainty data exists and is reasonable
         np.testing.assert_allclose(image.variances, 0.047, rtol=0.1)
@@ -290,7 +290,7 @@ class TestVenusCCDPipeline:
 
         # Variances are reasonable and reduced by combining runs. Pinned to the corrected
         # values (~0.0168–0.0180 across the 5 images) after fixing the shared-dark variance
-        # double-count (issue #142); previously ~0.018 with the over-counted Var(dark).
+        # double-count; previously ~0.018 with the over-counted Var(dark).
         np.testing.assert_allclose(transmission.variances, 0.0174, atol=0.0006)
 
         # The mask should only have the dead pixel masked
@@ -327,7 +327,7 @@ class TestVenusCCDPipeline:
             assert output_path.exists()
 
         assert transmission.shape == (1, 32, 32)
-        # air region should equal 1.0 (rtol consistent with float32 compute precision, issue #147)
+        # air region should equal 1.0 (rtol consistent with float32 compute precision)
         np.testing.assert_allclose(transmission.values[:, 6:11, 6:11], 1, rtol=1e-5)
         # check all values
         expected_value = np.full((1, 32, 32), (80 - 5) / (100 - 5) * 2)
@@ -351,7 +351,7 @@ class TestVenusCCDPipeline:
         )  # should be unchanged since we are normalizing by the number of runs
 
     def test_venus_ccd_pipeline_no_dark(self):
-        """Dark current is optional (issue #146): omitting dark_paths skips dark correction.
+        """Dark current is optional: omitting dark_paths skips dark correction.
 
         Without dark subtraction the transmission is T = (S / pc_s) / (OB / pc_ob),
         i.e. (81 + i) / 100 * 2 for these fixtures (vs (81 + i - 5) / (100 - 5) * 2 with dark).
@@ -383,7 +383,7 @@ class TestVenusCCDPipeline:
                 assert "metadata/dark_paths" not in hf
 
     def test_venus_ccd_pipeline_empty_dark_paths(self):
-        """An empty dark_paths list is treated the same as omitting dark (issue #146)."""
+        """An empty dark_paths list is treated the same as omitting dark."""
         with tempfile.NamedTemporaryFile(suffix=".h5", delete=True) as f:
             transmission = run_venus_ccd_pipeline(
                 sample_paths=[self.sample_paths],
@@ -404,7 +404,7 @@ class TestVenusCCDPipeline:
             )
 
     def test_venus_ccd_pipeline_no_dark_uncertainty(self):
-        """No-dark UQ equals the dark-free propagation, with no dark-frame variance term (issue #146).
+        """No-dark UQ equals the dark-free propagation, with no dark-frame variance term.
 
         Two independent checks:
         1. The pipeline's no-dark output (values AND variances) matches a direct
@@ -438,7 +438,7 @@ class TestVenusCCDPipeline:
             normalize_by_runs=True,
         )
         ob = prepare_reference(ob, dim="N_image")
-        # Mirror the pipeline's float32 handling (issue #147): cast the proton-charge
+        # Mirror the pipeline's float32 handling: cast the proton-charge
         # coords to float32 and the result to float32, so this structural check stays
         # bit-tight against the float32 pipeline output (the independent first-principles
         # guard is the pinned-constant oracle below, at rtol=1e-3).
@@ -471,12 +471,12 @@ class TestVenusCCDPipeline:
                 gamma_filter=False,
             )
         # The with-dark, proton-charge path is the one that would silently re-promote
-        # to float64 if the pc coord were not cast to float32 (issue #147).
+        # to float64 if the pc coord were not cast to float32.
         assert with_dark.dtype == sc.DType.float32
         assert np.all(no_dark.variances < with_dark.variances)
 
     def test_venus_ccd_pipeline_background_roi(self):
-        """background_roi flux proxy replaces proton-charge normalization end-to-end (issue #159)."""
+        """background_roi flux proxy replaces proton-charge normalization end-to-end."""
         with tempfile.NamedTemporaryFile(suffix=".hdf5", delete=True) as f:
             output_path = Path(f.name)
             t_pc = run_venus_ccd_pipeline(

--- a/tests/unit/test_venus_ccd.py
+++ b/tests/unit/test_venus_ccd.py
@@ -495,3 +495,25 @@ class TestVenusCCDPipeline:
         np.testing.assert_allclose(t_bg.values, 1.0, rtol=1e-5)
         # and it differs from the proton-charge normalization
         assert not np.allclose(t_bg.values, t_pc.values)
+
+    def test_venus_ccd_pipeline_background_roi_drops_proton_charge(self):
+        """In background_roi mode the (unused, un-aggregated) IntegratedPCharge must not leak to output.
+
+        Uses multiple runs: with pc_keys=() the combined array would otherwise retain the first run's
+        loaded IntegratedPCharge, surfacing a stale, never-aggregated proton charge in the coords and
+        the on-disk provenance. The pipeline drops it; this test inspects the output coords + HDF5.
+        """
+        with tempfile.NamedTemporaryFile(suffix=".h5", delete=True) as f:
+            output_path = Path(f.name)
+            transmission = run_venus_ccd_pipeline(
+                sample_paths=[self.sample_paths, self.sample_paths],  # multi-run: exercises the leak path
+                ob_paths=[self.ob_paths, self.ob_paths],
+                output_path=output_path,
+                gamma_filter=False,
+                background_roi=(0, 0, 8, 8),
+            )
+            # not in the returned coords...
+            assert "IntegratedPCharge" not in transmission.coords
+            # ...nor persisted to the HDF5 file
+            with h5py.File(output_path, "r") as hf:
+                assert "IntegratedPCharge" not in hf

--- a/tests/unit/test_venus_ccd.py
+++ b/tests/unit/test_venus_ccd.py
@@ -474,3 +474,24 @@ class TestVenusCCDPipeline:
         # to float64 if the pc coord were not cast to float32 (issue #147).
         assert with_dark.dtype == sc.DType.float32
         assert np.all(no_dark.variances < with_dark.variances)
+
+    def test_venus_ccd_pipeline_background_roi(self):
+        """background_roi flux proxy replaces proton-charge normalization end-to-end (issue #159)."""
+        with tempfile.NamedTemporaryFile(suffix=".hdf5", delete=True) as f:
+            output_path = Path(f.name)
+            t_pc = run_venus_ccd_pipeline(
+                sample_paths=[self.sample_paths], ob_paths=[self.ob_paths], output_path=output_path, gamma_filter=False
+            )
+            t_bg = run_venus_ccd_pipeline(
+                sample_paths=[self.sample_paths],
+                ob_paths=[self.ob_paths],
+                output_path=output_path,
+                gamma_filter=False,
+                background_roi=(0, 0, 8, 8),
+            )
+        assert str(t_bg.unit) == "dimensionless"
+        assert t_bg.shape == (5, 32, 32)
+        # uniform images -> background-ROI normalization cancels to T = 1 (proton charge skipped)
+        np.testing.assert_allclose(t_bg.values, 1.0, rtol=1e-5)
+        # and it differs from the proton-charge normalization
+        assert not np.allclose(t_bg.values, t_pc.values)


### PR DESCRIPTION
Resolves #159. Implemented **test-first (TDD)**.

Adds a `background_roi=(x0, y0, x1, y1)` parameter to `normalize_transmission`: each image is normalized by its mean counts in a **sample-free ROI** so per-image beam-flux differences cancel —

`T = (S / mean(S[B])) / (O / mean(O[B]))`

the validated 1.x formula (ratio of ROI means). This is the approximation to proton-charge normalization used **when proton charge is unavailable (e.g. MARS)**, restoring the 1.x `.normalization(roi=…)` capability that iBeatles re-implements downstream.

## Behavior (per Jean's confirmation)
- **Estimator:** ratio of ROI means (1.x-compatible).
- **Mutually exclusive** with `proton_charge_sample`/`_ob` (raises `ValueError`).
- **Uncertainty: first-order.** scipp refuses to divide an array by a variance-bearing scalar (correlation guard), so the ROI means are stripped of variance before the division and their contribution is added back: `Var(T) += T²·(Var(cs)/cs² + Var(co)/co²)`. The in-ROI sample/ROI-mean correlation is left uncorrected (documented in the docstring) — appropriate for a flux proxy.
- **Pipelines:** exposed on `run_mars_ccd_pipeline`, `run_mars_tpx3_pipeline`, `run_venus_ccd_pipeline`. On the CCD pipelines it dark-corrects first; on VENUS it replaces the proton-charge correction.

## Tests (written first → red → green)
- 6 core: ratio-of-means values, beam-flux cancellation, mutual exclusion, ROI validation, finite/non-negative variance, 3D per-spectral-bin.
- 3 end-to-end pipeline tests (MARS CCD, MARS TPX3, VENUS CCD): `background_roi` runs and changes the result vs the default/PC path.
- Full suite **392 passed**; `build-docs` (sphinx `-W`) + pre-commit clean.

## Follow-up (tracked on #159, not in this PR)
Once released, **update iBeatles** to consume `normalize_transmission(…, background_roi=…)` and drop its local re-implementation (value-match before/after).

`/review-pipeline` (dual-family) + Copilot review to follow before this is marked ready.

Assisted-With: Claude Opus 4.8 <noreply@anthropic.com>