### PR TITLE
grype: accept CVE-2026-15308 (python) + CVE-2026-58203 (pydantic)

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -32,3 +32,13 @@ ignore:
   - vulnerability: CVE-2026-12003
     package:
       name: python
+  # high; fixed in 3.15.0, no stable 3.14 conda-forge backport yet
+  - vulnerability: CVE-2026-15308 # high
+    package:
+      name: python
+  # pydantic 2.13.4 is the newest conda-forge build; the fix is in 2.14.2,
+  # not yet packaged on conda-forge. Remove once conda-forge ships >= 2.14.2
+  # (the lockfile-update workflow will pick it up).
+  - vulnerability: CVE-2026-58203 # medium
+    package:
+      name: pydantic


### PR DESCRIPTION
Resolves the failing `dependency-scan` Grype gate on `next` (the scheduled run went red 2026-07-13 on the fresh vuln DB v6.1.7).

## Failing set (from the gate's SARIF / code-scanning alerts)
| CVE | Package | Severity | Fix | Installable on conda-forge? |
|---|---|---|---|---|
| CVE-2026-15308 | python 3.14.6 | HIGH | 3.15.0 | No — prerelease, no stable 3.14 backport |
| CVE-2026-58203 | pydantic 2.13.4 | MEDIUM | 2.14.2 | No — verified conda-forge/noarch tops out at 2.13.4 |

Neither is remediable by a relock today, so both are added as scoped `.grype.yaml` ignores with revisit conditions (the monthly lockfile-update removes them once fixed builds land). Same pair accepted in CylindricalGeometryCorrection #76.

yamllint passes (only the file's pre-existing non-fatal warnings). CI's dependency-scan gate is the authoritative verification.