### PR TITLE
MaskROI: arbitrary-shape ROIs for background/air normalization (#180)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,19 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Arbitrary-shape (mask-based) ROI regions** — `MaskROI`
   ([#180](https://github.com/ornlneutronimaging/NeuNorm/issues/180)). A pixel **selection** mask
   (same `(y, x)` size as the image; 1/nonzero = pixel *in* the region — the opposite polarity of
-  scipp's exclusion masks) accepted **anywhere a rectangular ROI is accepted**:
-  `normalize_transmission(background_roi=)` / `normalize_with_dark` / `apply_background_roi`
-  (poolable with rectangles in one list, including the shared-dark ROI-mean covariance
-  correction), `apply_air_region_correction`, `apply_roi`, and the pipeline
-  `roi=`/`air_roi=`/`background_roi=` parameters. Construct from a numpy/scipp array
-  (`MaskROI(selection=...)`), an image file drawn in e.g. ImageJ
-  (`MaskROI.from_file("mask.tif")`, nonzero selects), or a mask already on a DataArray
-  (`MaskROI.from_dataarray_mask(da, name, invert=...)`). A `MaskROI` **crop** keeps the
-  selection's bounding box and attaches the outside pixels as an `outside_roi` exclusion mask,
-  which `write_hdf5` persists (`/masks/outside_roi`) and the TIFF `scitiff-mask` merge folds in;
-  region statistics stay mask-aware (dead/hot pixels excluded exactly as for rectangles).
-  Output-file provenance records a JSON summary (shape, selected-pixel count, source, sha256).
-  Rectangle-only inputs are bit-identical to 2.2.x.
+  scipp's exclusion masks) accepted by the **region-statistics** operations, anywhere they take a
+  rectangular ROI: `normalize_transmission(background_roi=)` / `normalize_with_dark` /
+  `apply_background_roi` (poolable with rectangles in one list, including the shared-dark ROI-mean
+  covariance correction), `apply_air_region_correction`, and the pipeline `air_roi=`/`background_roi=`
+  parameters. Construct from a numpy/scipp array (`MaskROI(selection=...)`), an image file drawn in
+  e.g. ImageJ (`MaskROI.from_file("mask.tif")`, nonzero selects), or a mask already on a DataArray
+  (`MaskROI.from_dataarray_mask(da, name, invert=...)`). Region statistics are mask-aware (dead/hot
+  pixels excluded exactly as for rectangles). Cropping (`apply_roi` / the pipeline `roi=`) stays
+  rectangle-only — an arbitrary shape has no rectangular crop, so a `MaskROI` is rejected there with
+  a pointer to the region-statistics parameters. Output-file provenance records a JSON summary
+  (shape, selected-pixel count, source, sha256), including `air_roi`. Rectangle-only inputs are
+  bit-identical to 2.2.x.
 
 ### Fixed
 
@@ -33,10 +32,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dead/hot-masked pixels in the air region it weighted rows unequally (a slightly wrong estimator
   and uncertainty), and a fully-masked row made the whole correction NaN. The air mean is now the
   mask-aware pooled mean shared with `background_roi` (`sum(T)/count(unmasked)`); values change
-  only for masked air regions. The propagated variance at `T == 0` pixels is now finite (the old
-  formula produced `0 * inf = NaN`), a non-positive/non-finite air mean now raises `ValueError`
-  instead of silently corrupting the scale, and errors name `air_roi`. Multiple pooled air
-  regions are supported.
+  only for masked air regions (unmasked regions agree to floating-point round-off). The propagated
+  variance at `T == 0` pixels is now finite (the old formula produced `0 * inf = NaN`), a
+  non-positive/non-finite air mean now raises `ValueError` instead of silently corrupting the
+  scale, and errors name `air_roi`. Multiple pooled air regions are supported.
+- **Overlapping pooled ROIs no longer understate their uncertainty.** When a pooled
+  `background_roi` / `air_roi` list contained regions that overlap, the shared pixels were counted
+  more than once — this not only inflated the pooled mean but understated its variance (and the
+  shared-dark covariance) by adding the repeated pixels' variances as if from independent samples.
+  Pooled statistics now reduce over the **union** of the regions (each selected, unmasked pixel
+  counted once); non-overlapping lists are unchanged, bit-for-bit.
 
 ## [2.2.3] - 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to NeuNorm are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Arbitrary-shape (mask-based) ROI regions** — `MaskROI`
+  ([#180](https://github.com/ornlneutronimaging/NeuNorm/issues/180)). A pixel **selection** mask
+  (same `(y, x)` size as the image; 1/nonzero = pixel *in* the region — the opposite polarity of
+  scipp's exclusion masks) accepted **anywhere a rectangular ROI is accepted**:
+  `normalize_transmission(background_roi=)` / `normalize_with_dark` / `apply_background_roi`
+  (poolable with rectangles in one list, including the shared-dark ROI-mean covariance
+  correction), `apply_air_region_correction`, `apply_roi`, and the pipeline
+  `roi=`/`air_roi=`/`background_roi=` parameters. Construct from a numpy/scipp array
+  (`MaskROI(selection=...)`), an image file drawn in e.g. ImageJ
+  (`MaskROI.from_file("mask.tif")`, nonzero selects), or a mask already on a DataArray
+  (`MaskROI.from_dataarray_mask(da, name, invert=...)`). A `MaskROI` **crop** keeps the
+  selection's bounding box and attaches the outside pixels as an `outside_roi` exclusion mask,
+  which `write_hdf5` persists (`/masks/outside_roi`) and the TIFF `scitiff-mask` merge folds in;
+  region statistics stay mask-aware (dead/hot pixels excluded exactly as for rectangles).
+  Output-file provenance records a JSON summary (shape, selected-pixel count, source, sha256).
+  Rectangle-only inputs are bit-identical to 2.2.x.
+
+### Fixed
+
+- **Air-region correction now uses the true (pooled) region mean.** The previous implementation
+  averaged with `sc.mean` over a dim list, which reduces sequentially (a mean of row-means): with
+  dead/hot-masked pixels in the air region it weighted rows unequally (a slightly wrong estimator
+  and uncertainty), and a fully-masked row made the whole correction NaN. The air mean is now the
+  mask-aware pooled mean shared with `background_roi` (`sum(T)/count(unmasked)`); values change
+  only for masked air regions. The propagated variance at `T == 0` pixels is now finite (the old
+  formula produced `0 * inf = NaN`), a non-positive/non-finite air mean now raises `ValueError`
+  instead of silently corrupting the scale, and errors name `air_roi`. Multiple pooled air
+  regions are supported.
+
 ## [2.2.3] - 2026-07-14
 
 Maintenance release — CI, documentation-build, and dependency updates only. There are

--- a/docs/workflows/mars_ccd_cmos.md
+++ b/docs/workflows/mars_ccd_cmos.md
@@ -112,7 +112,24 @@ flowchart TD
 | Sample images | TIFF/FITS stack | Yes | Raw neutron transmission images |
 | Open Beam (OB) | TIFF/FITS stack | Yes | Reference without sample |
 | Dark Current | TIFF/FITS stack | No | Electronic noise baseline (beam off). Optional — omit `dark_paths` (or pass `[]`) to skip dark correction. |
-| ROI | (x0, y0, x1, y1) | No | Region of interest to crop |
+| ROI | (x0, y0, x1, y1) or `MaskROI` | No | Region of interest to crop. A `MaskROI` crops to the selection's bounding box and masks the outside pixels (`outside_roi`). |
+
+**Arbitrary-shape regions.** Every ROI parameter (`roi`, `background_roi`, and the VENUS
+pipelines' `air_roi`) also accepts a `MaskROI` — a pixel **selection** mask the same size as the
+image, where 1 marks a pixel *inside* the region (note: the opposite polarity of scipp's
+exclusion masks). Draw the region in e.g. ImageJ, save it as TIFF/PNG, and load it directly;
+rectangles and masks can be pooled together for `background_roi`:
+
+```python
+from neunorm.data_models import MaskROI
+from neunorm.data_models.roi import ROI
+
+region = MaskROI.from_file("background_mask.tif")   # nonzero pixels = in the region
+transmission = run_mars_ccd_pipeline(
+    sample_paths=[...], ob_paths=[...], output_path="out.h5",
+    background_roi=[region, ROI(x0=0, y0=0, width=64, height=64)],  # pooled together
+)
+```
 
 **Metadata** (from files or user):
 - Acquisition time per image

--- a/docs/workflows/mars_ccd_cmos.md
+++ b/docs/workflows/mars_ccd_cmos.md
@@ -112,13 +112,14 @@ flowchart TD
 | Sample images | TIFF/FITS stack | Yes | Raw neutron transmission images |
 | Open Beam (OB) | TIFF/FITS stack | Yes | Reference without sample |
 | Dark Current | TIFF/FITS stack | No | Electronic noise baseline (beam off). Optional — omit `dark_paths` (or pass `[]`) to skip dark correction. |
-| ROI | (x0, y0, x1, y1) or `MaskROI` | No | Region of interest to crop. A `MaskROI` crops to the selection's bounding box and masks the outside pixels (`outside_roi`). |
+| ROI | (x0, y0, x1, y1) or `ROI` | No | Rectangular region of interest to **crop**. Cropping is rectangle-only; to restrict *statistics* to an arbitrary shape use a `MaskROI` with `background_roi=`/`air_roi=` instead. |
 
-**Arbitrary-shape regions.** Every ROI parameter (`roi`, `background_roi`, and the VENUS
-pipelines' `air_roi`) also accepts a `MaskROI` — a pixel **selection** mask the same size as the
+**Arbitrary-shape regions.** The region-statistics parameters (`background_roi` and the VENUS
+pipelines' `air_roi`) accept a `MaskROI` — a pixel **selection** mask the same size as the
 image, where 1 marks a pixel *inside* the region (note: the opposite polarity of scipp's
 exclusion masks). Draw the region in e.g. ImageJ, save it as TIFF/PNG, and load it directly;
-rectangles and masks can be pooled together for `background_roi`:
+rectangles and masks can be pooled together for `background_roi`. Cropping (`roi=`) stays
+rectangle-only — an arbitrary shape has no rectangular crop:
 
 ```python
 from neunorm.data_models import MaskROI

--- a/src/neunorm/data_models/__init__.py
+++ b/src/neunorm/data_models/__init__.py
@@ -4,7 +4,16 @@ Data models for NeuNorm 2.0.
 Pydantic models for type-safe data handling throughout the processing pipeline.
 """
 
-from neunorm.data_models.roi import ROI, as_roi_bounds
+from neunorm.data_models.roi import ROI, MaskROI, RegionLike, RegionsLike, ROILike, as_region_list, as_roi_bounds
 from neunorm.data_models.tof import BinningConfig
 
-__all__ = ["ROI", "BinningConfig", "as_roi_bounds"]
+__all__ = [
+    "ROI",
+    "MaskROI",
+    "ROILike",
+    "RegionLike",
+    "RegionsLike",
+    "BinningConfig",
+    "as_region_list",
+    "as_roi_bounds",
+]

--- a/src/neunorm/data_models/roi.py
+++ b/src/neunorm/data_models/roi.py
@@ -311,6 +311,9 @@ def as_region_list(regions: RegionsLike, arg_name: str = "region") -> list[Union
         )
     if len(regions) == 4 and all(isinstance(i, (int, np.integer)) for i in regions):
         return [_plain_int_bounds(as_roi_bounds(tuple(regions)))]
+    if len(regions) == 4 and all(isinstance(i, (int, float, np.integer, np.floating)) for i in regions):
+        # a 4-number sequence with non-integer entries is a malformed rectangle, not a region list
+        raise ValueError(f"{arg_name} must be a tuple of 4 integers (x0, y0, x1, y1); got {regions!r}")
     if len(regions) == 0:
         raise ValueError(f"{arg_name} list must contain at least one ROI")
     # a bare sequence of ints is a SINGLE rectangle (handled above when len == 4); an int element
@@ -318,3 +321,31 @@ def as_region_list(regions: RegionsLike, arg_name: str = "region") -> list[Union
     if any(isinstance(e, (int, np.integer)) for e in regions):
         raise ValueError(f"{arg_name} must be a tuple of 4 integers (x0, y0, x1, y1); got {regions!r}")
     return [r if isinstance(r, MaskROI) else _plain_int_bounds(as_roi_bounds(r)) for r in regions]
+
+
+def region_provenance(region: Union[tuple, MaskROI]):
+    """JSON-writer-safe provenance for ONE normalized region.
+
+    A rectangle passes through unchanged (the pinned flat ``(x0, y0, x1, y1)`` form); a
+    :class:`MaskROI` becomes a **JSON string** ``'{"mask": {...summary...}}'`` — never a bare dict,
+    which the TIFF metadata writer rejects at export time.
+    """
+    import json
+
+    if isinstance(region, MaskROI):
+        return json.dumps({"mask": region.provenance_summary()})
+    return region
+
+
+def as_region_provenance(regions: list):
+    """JSON-writer-safe provenance for a normalized region list (from :func:`as_region_list`).
+
+    A single rectangle stays a flat ``[x0, y0, x1, y1]`` int list (the pinned HDF5 native form);
+    anything else becomes a list whose entries are ``[x0, y0, x1, y1]`` lists or
+    ``{"mask": {shape, n_selected, source, sha256}}`` dicts — a **list** of dicts JSON-encodes
+    losslessly in both the HDF5 and TIFF writers (a bare top-level dict would not).
+    """
+    entries = [({"mask": r.provenance_summary()} if isinstance(r, MaskROI) else list(r)) for r in regions]
+    if len(entries) == 1 and not isinstance(regions[0], MaskROI):
+        return entries[0]
+    return entries

--- a/src/neunorm/data_models/roi.py
+++ b/src/neunorm/data_models/roi.py
@@ -137,8 +137,12 @@ class MaskROI(BaseModel):
     @classmethod
     def _canonicalize(cls, data):
         """Coerce any accepted input to a read-only C-contiguous bool array in (y, x) order."""
-        if not isinstance(data, dict):
+        if not isinstance(data, collections.abc.Mapping):
             return data
+        # Pydantic accepts any Mapping (e.g. UserDict), not just dict; copy into a mutable dict so
+        # the canonicalization below (bool dtype, non-empty check, owned writable buffer) is
+        # enforced for every Mapping input, not only literal dicts.
+        data = dict(data)
         sel = data.get("selection")
         dims = tuple(data.get("dims", ("y", "x")))
         if isinstance(sel, sc.Variable):

--- a/src/neunorm/data_models/roi.py
+++ b/src/neunorm/data_models/roi.py
@@ -94,11 +94,12 @@ class MaskROI(BaseModel):
         region. Use :meth:`from_dataarray_mask` (with its required ``invert`` flag) to convert
         between the two conventions explicitly.
 
-    A ``MaskROI`` is accepted anywhere a rectangular :class:`ROI` is accepted (``background_roi``,
-    air-region correction, cropping, and the pipeline ``roi``/``background_roi`` parameters), and
-    may be pooled together with rectangles in one region list. Selected pixels that are masked in
-    the data (dead/hot pixels) are excluded from region statistics exactly as they are for
-    rectangular ROIs.
+    A ``MaskROI`` is accepted by the **region-statistics** operations that take a rectangular
+    :class:`ROI` (``background_roi``, air-region correction, and the pipeline
+    ``air_roi``/``background_roi`` parameters), and may be pooled together with rectangles in one
+    region list. Selected pixels that are masked in the data (dead/hot pixels) are excluded from
+    region statistics exactly as they are for rectangular ROIs. Cropping (``apply_roi`` / the
+    pipeline ``roi=``) stays rectangle-only — an arbitrary shape has no rectangular crop.
 
     The selection is canonicalized at construction to a C-contiguous, read-only boolean array in
     ``(y, x)`` row-major order (the same layout as loaded TIFF/FITS frames), regardless of the

--- a/src/neunorm/data_models/roi.py
+++ b/src/neunorm/data_models/roi.py
@@ -7,6 +7,7 @@ from typing import Any, Optional, Sequence, Union
 
 import numpy as np
 import scipp as sc
+from loguru import logger
 from pydantic import BaseModel, ConfigDict, field_serializer, model_validator
 
 
@@ -104,6 +105,9 @@ class MaskROI(BaseModel):
     The selection is canonicalized at construction to a C-contiguous, read-only boolean array in
     ``(y, x)`` row-major order (the same layout as loaded TIFF/FITS frames), regardless of the
     input form. Any nonzero value selects: integer or float arrays are thresholded ``!= 0``.
+    Non-finite (``NaN``/``inf``) values in a float array are treated as **unselected** (not in the
+    region) and a warning is logged — they are not meaningful "in-region" markers, yet ``NaN != 0``
+    is ``True``, so selecting them would silently corrupt the region statistics.
 
     Parameters
     ----------
@@ -157,11 +161,29 @@ class MaskROI(BaseModel):
                 raise ValueError(f"MaskROI dims must be ('y', 'x') or ('x', 'y'); got {dims}")
         if arr.ndim != 2:
             raise ValueError(f"MaskROI selection must be a 2D (y, x) array; got shape {arr.shape}")
-        # One thresholding rule for every input path: nonzero selects. `!= 0` also copies, so the
-        # caller's array can never mutate the (frozen, read-only) canonical buffer.
-        canonical = np.ascontiguousarray(arr != 0)
+        # Nonzero selects. `!= 0` also copies, so the caller's array can never mutate the (frozen,
+        # read-only) canonical buffer.
+        selected = arr != 0
+        # A non-finite value in a float mask (NaN/inf — e.g. a no-data sentinel in a float TIFF) is
+        # not a meaningful "in-region" marker, yet `NaN != 0` and `inf != 0` both evaluate True. So
+        # rather than silently select it (corrupting the region mean/variance) or reject the whole
+        # mask over one bad pixel, drop non-finite pixels from the selection and warn — the run
+        # continues over the valid pixels. Integer/bool masks cannot be non-finite, so skip the check.
+        if np.issubdtype(arr.dtype, np.floating):
+            non_finite = ~np.isfinite(arr)
+            n_bad = int(non_finite.sum())
+            if n_bad:
+                logger.warning(
+                    f"MaskROI selection has {n_bad} non-finite (NaN/inf) value(s); treating them as "
+                    "unselected (not in the region)."
+                )
+                selected = selected & ~non_finite
+        canonical = np.ascontiguousarray(selected)
         if not canonical.any():
-            raise ValueError("MaskROI selection must select at least one pixel (it is all zeros/False)")
+            raise ValueError(
+                "MaskROI selection must select at least one pixel (it is all zeros/False, "
+                "or every nonzero value was non-finite)"
+            )
         canonical.setflags(write=False)
         data["selection"] = canonical
         data["dims"] = ("y", "x")

--- a/src/neunorm/data_models/roi.py
+++ b/src/neunorm/data_models/roi.py
@@ -1,8 +1,13 @@
-"""Region-of-interest data model for NeuNorm 2.0."""
+"""Region-of-interest data models for NeuNorm 2.0: rectangular ``ROI`` and mask-based ``MaskROI``."""
 
-from typing import Optional, Union
+import collections.abc
+import hashlib
+from pathlib import Path
+from typing import Any, Optional, Sequence, Union
 
-from pydantic import BaseModel, model_validator
+import numpy as np
+import scipp as sc
+from pydantic import BaseModel, ConfigDict, field_serializer, model_validator
 
 
 class ROI(BaseModel):
@@ -77,9 +82,178 @@ class ROI(BaseModel):
         return (self.x0, self.y0, self.x1, self.y1)
 
 
+class MaskROI(BaseModel):
+    """Arbitrary-shape region of interest defined by a pixel **selection** mask.
+
+    ``selection`` is a 2D boolean array the same spatial size as the images, where **True (or any
+    nonzero value) means the pixel IS in the region** and False/0 means it is not.
+
+    .. warning::
+        This is the **opposite polarity of scipp masks**: ``DataArray.masks`` mark pixels to
+        *exclude* from reductions, while ``MaskROI.selection`` marks pixels to *include* in the
+        region. Use :meth:`from_dataarray_mask` (with its required ``invert`` flag) to convert
+        between the two conventions explicitly.
+
+    A ``MaskROI`` is accepted anywhere a rectangular :class:`ROI` is accepted (``background_roi``,
+    air-region correction, cropping, and the pipeline ``roi``/``background_roi`` parameters), and
+    may be pooled together with rectangles in one region list. Selected pixels that are masked in
+    the data (dead/hot pixels) are excluded from region statistics exactly as they are for
+    rectangular ROIs.
+
+    The selection is canonicalized at construction to a C-contiguous, read-only boolean array in
+    ``(y, x)`` row-major order (the same layout as loaded TIFF/FITS frames), regardless of the
+    input form. Any nonzero value selects: integer or float arrays are thresholded ``!= 0``.
+
+    Parameters
+    ----------
+    selection : numpy.ndarray or scipp.Variable
+        2D selection array. A scipp Variable must have dims ``y`` and ``x`` (either order — it is
+        transposed by name). A bare numpy array is interpreted per ``dims``.
+    dims : tuple[str, str], optional
+        Axis order of a bare numpy ``selection`` — ``("y", "x")`` (default, row-major image
+        convention) or ``("x", "y")``. Ignored for scipp input (named dims win). Note that for a
+        square detector a transposed numpy mask cannot be detected — prefer scipp Variables or the
+        default row-major layout.
+    source : str, optional
+        Provenance label (set automatically by :meth:`from_file` / :meth:`from_dataarray_mask`).
+
+    Examples
+    --------
+    >>> sel = np.zeros((256, 256), dtype=bool)
+    >>> sel[100:120, 40:200] = True    # any shape works, not just rectangles
+    >>> region = MaskROI(selection=sel)
+    >>> region.n_selected
+    3200
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
+
+    selection: Any
+    dims: tuple[str, str] = ("y", "x")
+    source: str = "array"
+
+    @model_validator(mode="before")
+    @classmethod
+    def _canonicalize(cls, data):
+        """Coerce any accepted input to a read-only C-contiguous bool array in (y, x) order."""
+        if not isinstance(data, dict):
+            return data
+        sel = data.get("selection")
+        dims = tuple(data.get("dims", ("y", "x")))
+        if isinstance(sel, sc.Variable):
+            if set(sel.dims) != {"y", "x"}:
+                raise ValueError(f"MaskROI scipp selection must have dims {{'y', 'x'}}; got {sel.dims}")
+            arr = np.asarray(sel.transpose(("y", "x")).values)
+        else:
+            arr = np.asarray(sel)
+            if dims == ("x", "y"):
+                arr = arr.T
+            elif dims != ("y", "x"):
+                raise ValueError(f"MaskROI dims must be ('y', 'x') or ('x', 'y'); got {dims}")
+        if arr.ndim != 2:
+            raise ValueError(f"MaskROI selection must be a 2D (y, x) array; got shape {arr.shape}")
+        # One thresholding rule for every input path: nonzero selects. `!= 0` also copies, so the
+        # caller's array can never mutate the (frozen, read-only) canonical buffer.
+        canonical = np.ascontiguousarray(arr != 0)
+        if not canonical.any():
+            raise ValueError("MaskROI selection must select at least one pixel (it is all zeros/False)")
+        canonical.setflags(write=False)
+        data["selection"] = canonical
+        data["dims"] = ("y", "x")
+        return data
+
+    @classmethod
+    def from_file(cls, path: Union[str, Path]) -> "MaskROI":
+        """Load a selection mask from an image file (TIFF/PNG/...; any nonzero pixel selects).
+
+        Matches the mask images users draw in e.g. ImageJ and save alongside their data. RGB(A)
+        images select where any channel is nonzero; only the first frame of a multi-frame file is
+        read. The file's row-major ``(y, x)`` layout is used as-is.
+        """
+        from PIL import Image
+
+        p = Path(path)
+        with Image.open(p) as img:
+            arr = np.asarray(img)
+        if arr.ndim == 3:  # RGB / RGBA: any nonzero channel selects
+            arr = arr.any(axis=-1)
+        return cls(selection=arr, source=str(p))
+
+    @classmethod
+    def from_dataarray_mask(cls, da: sc.DataArray, name: str, *, invert: bool) -> "MaskROI":
+        """Build a selection from a mask already carried on a scipp DataArray.
+
+        scipp masks are **exclusion** masks (True = pixel excluded), while ``MaskROI`` is a
+        **selection** (True = pixel in the region) — so ``invert`` is required, with no default:
+
+        - ``invert=True``: select the pixels the scipp mask *keeps* (region = NOT masked).
+        - ``invert=False``: select the pixels the scipp mask *flags* (region = the masked pixels).
+        """
+        if name not in da.masks:
+            raise ValueError(f"DataArray has no mask named {name!r}; available: {list(da.masks.keys())}")
+        mask = da.masks[name]
+        if set(mask.dims) != {"y", "x"}:
+            raise ValueError(f"mask {name!r} must be spatial with dims {{'y', 'x'}}; got {mask.dims}")
+        sel = ~mask if invert else mask
+        return cls(selection=sel, source=f"dataarray_mask:{name}")
+
+    @property
+    def n_selected(self) -> int:
+        """Number of selected pixels."""
+        return int(self.selection.sum())
+
+    @property
+    def shape(self) -> tuple[int, int]:
+        """Selection shape as ``(ny, nx)``."""
+        return tuple(self.selection.shape)
+
+    def sha256(self) -> str:
+        """Hex digest of the canonical (y, x) boolean buffer — stable across input forms."""
+        return hashlib.sha256(self.selection.tobytes()).hexdigest()
+
+    def bounding_box(self) -> tuple[int, int, int, int]:
+        """Tight bounding box of the selection as ``(x0, y0, x1, y1)`` with exclusive stops."""
+        ys, xs = np.nonzero(self.selection)
+        return (int(xs.min()), int(ys.min()), int(xs.max()) + 1, int(ys.max()) + 1)
+
+    def provenance_summary(self) -> dict:
+        """JSON-safe summary for output-file provenance (shape, n_selected, source, sha256)."""
+        return {
+            "shape": [int(s) for s in self.selection.shape],
+            "n_selected": self.n_selected,
+            "source": self.source,
+            "sha256": self.sha256(),
+        }
+
+    @field_serializer("selection")
+    def _serialize_selection(self, _value: np.ndarray, _info):
+        """Serialize the array field as its provenance summary so model_dump_json works."""
+        return self.provenance_summary()
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, MaskROI):
+            return NotImplemented
+        return np.array_equal(self.selection, other.selection)
+
+    def __hash__(self) -> int:
+        return hash((self.shape, self.sha256()))
+
+    def __repr__(self) -> str:
+        ny, nx = self.shape
+        return f"MaskROI(shape=(ny={ny}, nx={nx}), n_selected={self.n_selected}, source={self.source!r})"
+
+    __str__ = __repr__
+
+
 # An ``ROI`` or a bare 4-element ``(x0, y0, x1, y1)`` tuple/list — accepted interchangeably by
 # ROI-taking APIs (``as_roi_bounds`` coerces either form to a bounds tuple).
 ROILike = Union[ROI, tuple[int, int, int, int], list[int]]
+
+# Any single region: a rectangle (in any ROILike spelling) or a mask.
+RegionLike = Union[ROILike, MaskROI]
+
+# One region or a sequence of regions (pooled). A bare 4-int tuple/list is a single rectangle.
+RegionsLike = Union[RegionLike, Sequence[RegionLike]]
 
 
 def as_roi_bounds(roi: ROILike) -> tuple[int, int, int, int]:
@@ -88,11 +262,59 @@ def as_roi_bounds(roi: ROILike) -> tuple[int, int, int, int]:
     A bare sequence is returned as a plain tuple so downstream code sees a consistent
     ``(x0, y0, x1, y1)`` form regardless of how the ROI was specified. Element-type/bounds validation
     is left to the consumer (and to :class:`ROI` for the named form); only the 4-element length is
-    enforced here so a malformed bare sequence fails fast at one place.
+    enforced here so a malformed bare sequence fails fast at one place. Pydantic models other than
+    :class:`ROI` (e.g. a :class:`MaskROI`) are rejected explicitly — iterating a model would yield
+    meaningless ``(field, value)`` pairs.
     """
     if isinstance(roi, ROI):
         return roi.as_bounds()
+    if isinstance(roi, BaseModel):
+        raise ValueError(
+            f"expected a rectangular ROI or an (x0, y0, x1, y1) sequence; got {type(roi).__name__} — "
+            "mask regions are only accepted by APIs documented to take a MaskROI"
+        )
     bounds = tuple(roi)
     if len(bounds) != 4:
         raise ValueError(f"ROI must be a tuple of 4 integers (x0, y0, x1, y1), or an ROI; got {bounds!r}")
     return bounds
+
+
+def _plain_int_bounds(bounds: tuple) -> tuple[int, int, int, int]:
+    """Coerce NumPy integer bounds to built-in ``int`` (JSON provenance stays numeric)."""
+    return tuple(int(v) if isinstance(v, np.integer) else v for v in bounds)
+
+
+def as_region_list(regions: RegionsLike, arg_name: str = "region") -> list[Union[tuple[int, int, int, int], MaskROI]]:
+    """Normalize a region argument to a list of exclusive ``(x0, y0, x1, y1)`` bounds and/or ``MaskROI``.
+
+    The unified-region generalization of ``as_roi_bounds_list``: accepts a single region — an
+    :class:`ROI`, a :class:`MaskROI`, or a bare 4-int ``(x0, y0, x1, y1)`` sequence — or a
+    **sequence** of those (pooled). A bare 4-int sequence is always ONE rectangle (so ``[0, 0, 1, 1]``
+    is a rectangle, never a tiny mask). Raw numpy/scipp arrays and file paths are **not** accepted
+    here — wrap them explicitly: ``MaskROI(selection=...)`` / ``MaskROI.from_file(...)``.
+    Idempotent on its own output. NumPy integer bounds are coerced to built-in ``int``.
+
+    Parameters
+    ----------
+    regions : RegionsLike
+        The region argument to normalize.
+    arg_name : str, optional
+        Name used in error messages (e.g. ``"background_roi"``, ``"air_roi"``).
+    """
+    if isinstance(regions, MaskROI):
+        return [regions]
+    if isinstance(regions, ROI):
+        return [_plain_int_bounds(regions.as_bounds())]
+    if isinstance(regions, (str, bytes)) or not isinstance(regions, collections.abc.Sequence):
+        raise ValueError(
+            f"{arg_name} must be an ROI, a MaskROI, an (x0, y0, x1, y1) tuple, or a sequence of those; got {regions!r}"
+        )
+    if len(regions) == 4 and all(isinstance(i, (int, np.integer)) for i in regions):
+        return [_plain_int_bounds(as_roi_bounds(tuple(regions)))]
+    if len(regions) == 0:
+        raise ValueError(f"{arg_name} list must contain at least one ROI")
+    # a bare sequence of ints is a SINGLE rectangle (handled above when len == 4); an int element
+    # here means a malformed single ROI (wrong length), not a sequence of regions.
+    if any(isinstance(e, (int, np.integer)) for e in regions):
+        raise ValueError(f"{arg_name} must be a tuple of 4 integers (x0, y0, x1, y1); got {regions!r}")
+    return [r if isinstance(r, MaskROI) else _plain_int_bounds(as_roi_bounds(r)) for r in regions]

--- a/src/neunorm/exporters/hdf5_writer.py
+++ b/src/neunorm/exporters/hdf5_writer.py
@@ -87,7 +87,6 @@ def write_hdf5(  # noqa: C901
     transmission: sc.DataArray,
     dead_pixel_mask: str = "dead",
     hot_pixel_mask: str = "hot",
-    roi_mask: str = "outside_roi",
     metadata: Optional[dict] = None,
 ) -> None:
     """Write processed data to HDF5 with full provenance.
@@ -102,9 +101,8 @@ def write_hdf5(  # noqa: C901
 
         /transmission     # (θ, [TOF,] y, x) float32
         /uncertainty      # (θ, [TOF,] y, x) float32 (only if variances are present)
-        /masks/dead        # (y, x) bool (only if the named dead-pixel mask exists)
-        /masks/hot         # (y, x) bool (only if the named hot-pixel mask exists)
-        /masks/outside_roi # (y, x) bool (only after a MaskROI crop: True = outside the region)
+        /masks/dead       # (y, x) bool (only if the named dead-pixel mask exists)
+        /masks/hot        # (y, x) bool (only if the named hot-pixel mask exists)
         /tof              # (N+1,) float64 (only if the data carries a "tof" coordinate)
         /metadata/        # processing provenance (only when metadata is supplied)
 
@@ -134,10 +132,6 @@ def write_hdf5(  # noqa: C901
         Name of the dead pixel mask in transmission.masks (default: "dead")
     hot_pixel_mask : str
         Name of the hot pixel mask in transmission.masks (default: "hot")
-    roi_mask : str
-        Name of the outside-region exclusion mask left by a ``MaskROI`` crop (default:
-        "outside_roi"). ``/transmission`` keeps the raw (unmasked) values under it — consumers
-        should treat pixels flagged in ``/masks/outside_roi`` as outside the analysis region.
     metadata : Optional[dict]
         Dictionary of metadata to store in the file (default: None)
     """
@@ -172,8 +166,6 @@ def write_hdf5(  # noqa: C901
             f.create_dataset("masks/dead", data=transmission.masks[dead_pixel_mask].values)
         if hot_pixel_mask in transmission.masks:
             f.create_dataset("masks/hot", data=transmission.masks[hot_pixel_mask].values)
-        if roi_mask in transmission.masks:
-            f.create_dataset("masks/outside_roi", data=transmission.masks[roi_mask].values)
 
         # Write metadata. Provenance is best-effort: a single un-writable key — a bad value
         # (ragged/unserializable) or a malformed/colliding name — must never abort the write or

--- a/src/neunorm/exporters/hdf5_writer.py
+++ b/src/neunorm/exporters/hdf5_writer.py
@@ -87,6 +87,7 @@ def write_hdf5(  # noqa: C901
     transmission: sc.DataArray,
     dead_pixel_mask: str = "dead",
     hot_pixel_mask: str = "hot",
+    roi_mask: str = "outside_roi",
     metadata: Optional[dict] = None,
 ) -> None:
     """Write processed data to HDF5 with full provenance.
@@ -101,8 +102,9 @@ def write_hdf5(  # noqa: C901
 
         /transmission     # (θ, [TOF,] y, x) float32
         /uncertainty      # (θ, [TOF,] y, x) float32 (only if variances are present)
-        /masks/dead       # (y, x) bool (only if the named dead-pixel mask exists)
-        /masks/hot        # (y, x) bool (only if the named hot-pixel mask exists)
+        /masks/dead        # (y, x) bool (only if the named dead-pixel mask exists)
+        /masks/hot         # (y, x) bool (only if the named hot-pixel mask exists)
+        /masks/outside_roi # (y, x) bool (only after a MaskROI crop: True = outside the region)
         /tof              # (N+1,) float64 (only if the data carries a "tof" coordinate)
         /metadata/        # processing provenance (only when metadata is supplied)
 
@@ -132,6 +134,10 @@ def write_hdf5(  # noqa: C901
         Name of the dead pixel mask in transmission.masks (default: "dead")
     hot_pixel_mask : str
         Name of the hot pixel mask in transmission.masks (default: "hot")
+    roi_mask : str
+        Name of the outside-region exclusion mask left by a ``MaskROI`` crop (default:
+        "outside_roi"). ``/transmission`` keeps the raw (unmasked) values under it — consumers
+        should treat pixels flagged in ``/masks/outside_roi`` as outside the analysis region.
     metadata : Optional[dict]
         Dictionary of metadata to store in the file (default: None)
     """
@@ -166,6 +172,8 @@ def write_hdf5(  # noqa: C901
             f.create_dataset("masks/dead", data=transmission.masks[dead_pixel_mask].values)
         if hot_pixel_mask in transmission.masks:
             f.create_dataset("masks/hot", data=transmission.masks[hot_pixel_mask].values)
+        if roi_mask in transmission.masks:
+            f.create_dataset("masks/outside_roi", data=transmission.masks[roi_mask].values)
 
         # Write metadata. Provenance is best-effort: a single un-writable key — a bad value
         # (ragged/unserializable) or a malformed/colliding name — must never abort the write or

--- a/src/neunorm/pipelines/mars_ccd.py
+++ b/src/neunorm/pipelines/mars_ccd.py
@@ -12,8 +12,7 @@ from loguru import logger
 
 from neunorm import __version__
 from neunorm.data_models.roi import (
-    MaskROI,
-    RegionLike,
+    ROILike,
     as_region_list,
     as_region_provenance,
     as_roi_bounds,
@@ -39,7 +38,7 @@ def run_mars_ccd_pipeline(  # noqa: C901
     ob_paths: Sequence[Sequence[str | Path]],
     dark_paths: Optional[Sequence[Sequence[str | Path]]] = None,
     output_path: Optional[Path] = None,
-    roi: Optional[RegionLike] = None,
+    roi: Optional[ROILike] = None,
     gamma_filter: bool = True,
     background_roi: Optional[BackgroundROILike] = None,
 ) -> sc.DataArray:
@@ -98,7 +97,7 @@ def run_mars_ccd_pipeline(  # noqa: C901
     # Accept an ROI or a bare (x0, y0, x1, y1) tuple for every ROI argument; coerce to bounds
     # tuples up front so cropping and provenance see a consistent form.
     if roi is not None:
-        roi = roi if isinstance(roi, MaskROI) else as_roi_bounds(roi)
+        roi = as_roi_bounds(roi)
     if background_roi is not None:
         background_roi = as_region_list(background_roi, arg_name="background_roi")
 

--- a/src/neunorm/pipelines/mars_ccd.py
+++ b/src/neunorm/pipelines/mars_ccd.py
@@ -77,12 +77,12 @@ def run_mars_ccd_pipeline(  # noqa: C901
         Region of interest to crop to — an ``ROI`` or a bare ``(x0, y0, x1, y1)`` tuple.
     gamma_filter : bool
         Whether to apply gamma filtering to the sample data (default: True)
-    background_roi : ROI/tuple or a sequence of them
-        Sample-free background region(s) — one ROI or a pooled sequence of ROIs (see
-        ``normalize_transmission``) — for flux-proxy normalization when proton charge is
-        unavailable. Mutually exclusive with proton-charge correction. If
-        ``roi`` is also given the detector is cropped first, so ``background_roi`` indices are
-        resolved in the post-crop frame.
+    background_roi : ROI, MaskROI, tuple, or a sequence of them
+        Sample-free background region(s) — one region or a pooled sequence (rectangles and/or
+        arbitrary-shape ``MaskROI`` selections; see ``normalize_transmission``) — for flux-proxy
+        normalization when proton charge is unavailable. Mutually exclusive with proton-charge
+        correction. If ``roi`` is also given the detector is cropped first, so ``background_roi``
+        indices are resolved in the post-crop frame.
 
     Notes
     -----

--- a/src/neunorm/pipelines/mars_ccd.py
+++ b/src/neunorm/pipelines/mars_ccd.py
@@ -11,14 +11,20 @@ import scipp as sc
 from loguru import logger
 
 from neunorm import __version__
-from neunorm.data_models.roi import ROILike, as_roi_bounds
+from neunorm.data_models.roi import (
+    MaskROI,
+    RegionLike,
+    as_region_list,
+    as_region_provenance,
+    as_roi_bounds,
+    region_provenance,
+)
 from neunorm.exporters.hdf5_writer import write_hdf5
 from neunorm.exporters.tiff_writer import write_tiff_stack
 from neunorm.filters.gamma_filter import apply_gamma_filter
 from neunorm.loaders.stack_loader import load_stack
 from neunorm.processing.normalizer import (
     BackgroundROILike,
-    as_roi_bounds_list,
     normalize_transmission,
     normalize_with_dark,
 )
@@ -33,7 +39,7 @@ def run_mars_ccd_pipeline(  # noqa: C901
     ob_paths: Sequence[Sequence[str | Path]],
     dark_paths: Optional[Sequence[Sequence[str | Path]]] = None,
     output_path: Optional[Path] = None,
-    roi: Optional[ROILike] = None,
+    roi: Optional[RegionLike] = None,
     gamma_filter: bool = True,
     background_roi: Optional[BackgroundROILike] = None,
 ) -> sc.DataArray:
@@ -92,9 +98,9 @@ def run_mars_ccd_pipeline(  # noqa: C901
     # Accept an ROI or a bare (x0, y0, x1, y1) tuple for every ROI argument; coerce to bounds
     # tuples up front so cropping and provenance see a consistent form.
     if roi is not None:
-        roi = as_roi_bounds(roi)
+        roi = roi if isinstance(roi, MaskROI) else as_roi_bounds(roi)
     if background_roi is not None:
-        background_roi = as_roi_bounds_list(background_roi)
+        background_roi = as_region_list(background_roi, arg_name="background_roi")
 
     if output_path is None:
         raise ValueError("output_path is required")
@@ -207,12 +213,10 @@ def run_mars_ccd_pipeline(  # noqa: C901
         metadata["dark_paths"] = [[str(p) for p in run] for run in dark_paths]
 
     if roi:
-        metadata["roi_applied"] = roi
+        metadata["roi_applied"] = region_provenance(roi)
 
     if background_roi is not None:
-        metadata["background_roi"] = (
-            list(background_roi[0]) if len(background_roi) == 1 else [list(b) for b in background_roi]
-        )
+        metadata["background_roi"] = as_region_provenance(background_roi)
 
     if output_path.suffix.lower() in (".hdf5", ".h5"):
         write_hdf5(output_path, transmission, dead_pixel_mask="dead_pixels", metadata=metadata)

--- a/src/neunorm/pipelines/mars_tpx3.py
+++ b/src/neunorm/pipelines/mars_tpx3.py
@@ -11,12 +11,19 @@ import scipp as sc
 from loguru import logger
 
 from neunorm import __version__
-from neunorm.data_models.roi import ROILike, as_roi_bounds
+from neunorm.data_models.roi import (
+    MaskROI,
+    RegionLike,
+    as_region_list,
+    as_region_provenance,
+    as_roi_bounds,
+    region_provenance,
+)
 from neunorm.exporters.hdf5_writer import write_hdf5
 from neunorm.exporters.tiff_writer import write_tiff_stack
 from neunorm.filters.gamma_filter import apply_gamma_filter
 from neunorm.loaders.event_loader import load_event_nexus
-from neunorm.processing.normalizer import BackgroundROILike, as_roi_bounds_list, normalize_transmission
+from neunorm.processing.normalizer import BackgroundROILike, normalize_transmission
 from neunorm.processing.reference_preparer import prepare_reference
 from neunorm.processing.roi_clipper import apply_roi
 from neunorm.processing.run_combiner import combine_runs
@@ -28,7 +35,7 @@ def run_mars_tpx3_pipeline(  # noqa: C901
     sample_paths: Sequence[Sequence[str | Path]],
     ob_paths: Sequence[Sequence[str | Path]],
     output_path: Path,
-    roi: Optional[ROILike] = None,
+    roi: Optional[RegionLike] = None,
     gamma_filter: bool = True,
     detector_shape: tuple[int, int] = (514, 514),
     background_roi: Optional[BackgroundROILike] = None,
@@ -82,9 +89,9 @@ def run_mars_tpx3_pipeline(  # noqa: C901
     # Accept an ROI or a bare (x0, y0, x1, y1) tuple for every ROI argument; coerce to bounds
     # tuples up front so cropping and provenance see a consistent form.
     if roi is not None:
-        roi = as_roi_bounds(roi)
+        roi = roi if isinstance(roi, MaskROI) else as_roi_bounds(roi)
     if background_roi is not None:
-        background_roi = as_roi_bounds_list(background_roi)
+        background_roi = as_region_list(background_roi, arg_name="background_roi")
 
     # Load data and convert to histogram
     samples = [
@@ -143,12 +150,10 @@ def run_mars_tpx3_pipeline(  # noqa: C901
     }
 
     if roi:
-        metadata["roi_applied"] = roi
+        metadata["roi_applied"] = region_provenance(roi)
 
     if background_roi is not None:
-        metadata["background_roi"] = (
-            list(background_roi[0]) if len(background_roi) == 1 else [list(b) for b in background_roi]
-        )
+        metadata["background_roi"] = as_region_provenance(background_roi)
 
     if output_path.suffix.lower() in (".hdf5", ".h5"):
         write_hdf5(

--- a/src/neunorm/pipelines/mars_tpx3.py
+++ b/src/neunorm/pipelines/mars_tpx3.py
@@ -68,12 +68,12 @@ def run_mars_tpx3_pipeline(  # noqa: C901
         Whether to apply gamma filtering to the sample data (default: True)
     detector_shape : tuple[int, int]
         Shape of the TPX3 detector (default: (514, 514))
-    background_roi : ROI/tuple or a sequence of them
-        Sample-free background region(s) — one ROI or a pooled sequence of ROIs (see
-        ``normalize_transmission``) — for flux-proxy normalization when proton charge is
-        unavailable. Mutually exclusive with proton-charge correction. If
-        ``roi`` is also given the detector is cropped first, so ``background_roi`` indices are
-        resolved in the post-crop frame.
+    background_roi : ROI, MaskROI, tuple, or a sequence of them
+        Sample-free background region(s) — one region or a pooled sequence (rectangles and/or
+        arbitrary-shape ``MaskROI`` selections; see ``normalize_transmission``) — for flux-proxy
+        normalization when proton charge is unavailable. Mutually exclusive with proton-charge
+        correction. If ``roi`` is also given the detector is cropped first, so ``background_roi``
+        indices are resolved in the post-crop frame.
 
     Notes
     -----

--- a/src/neunorm/pipelines/mars_tpx3.py
+++ b/src/neunorm/pipelines/mars_tpx3.py
@@ -12,8 +12,7 @@ from loguru import logger
 
 from neunorm import __version__
 from neunorm.data_models.roi import (
-    MaskROI,
-    RegionLike,
+    ROILike,
     as_region_list,
     as_region_provenance,
     as_roi_bounds,
@@ -35,7 +34,7 @@ def run_mars_tpx3_pipeline(  # noqa: C901
     sample_paths: Sequence[Sequence[str | Path]],
     ob_paths: Sequence[Sequence[str | Path]],
     output_path: Path,
-    roi: Optional[RegionLike] = None,
+    roi: Optional[ROILike] = None,
     gamma_filter: bool = True,
     detector_shape: tuple[int, int] = (514, 514),
     background_roi: Optional[BackgroundROILike] = None,
@@ -89,7 +88,7 @@ def run_mars_tpx3_pipeline(  # noqa: C901
     # Accept an ROI or a bare (x0, y0, x1, y1) tuple for every ROI argument; coerce to bounds
     # tuples up front so cropping and provenance see a consistent form.
     if roi is not None:
-        roi = roi if isinstance(roi, MaskROI) else as_roi_bounds(roi)
+        roi = as_roi_bounds(roi)
     if background_roi is not None:
         background_roi = as_region_list(background_roi, arg_name="background_roi")
 

--- a/src/neunorm/pipelines/venus_ccd.py
+++ b/src/neunorm/pipelines/venus_ccd.py
@@ -11,7 +11,14 @@ import scipp as sc
 from loguru import logger
 
 from neunorm import __version__
-from neunorm.data_models.roi import ROILike, as_roi_bounds
+from neunorm.data_models.roi import (
+    MaskROI,
+    RegionLike,
+    as_region_list,
+    as_region_provenance,
+    as_roi_bounds,
+    region_provenance,
+)
 from neunorm.exporters.hdf5_writer import write_hdf5
 from neunorm.exporters.tiff_writer import write_tiff_stack
 from neunorm.filters.gamma_filter import apply_gamma_filter
@@ -19,7 +26,6 @@ from neunorm.loaders.stack_loader import load_stack
 from neunorm.processing.air_region_corrector import apply_air_region_correction
 from neunorm.processing.normalizer import (
     BackgroundROILike,
-    as_roi_bounds_list,
     normalize_transmission,
     normalize_with_dark,
 )
@@ -34,9 +40,9 @@ def run_venus_ccd_pipeline(  # noqa: C901
     ob_paths: Sequence[Sequence[str | Path]],
     dark_paths: Optional[Sequence[Sequence[str | Path]]] = None,
     output_path: Optional[Path] = None,
-    roi: Optional[ROILike] = None,
+    roi: Optional[RegionLike] = None,
     gamma_filter: bool = True,
-    air_roi: Optional[ROILike] = None,
+    air_roi: Optional[RegionLike] = None,
     background_roi: Optional[BackgroundROILike] = None,
 ) -> sc.DataArray:
     """Execute VENUS CCD/CMOS normalization pipeline.
@@ -101,11 +107,11 @@ def run_venus_ccd_pipeline(  # noqa: C901
     # Accept an ROI or a bare (x0, y0, x1, y1) tuple for every ROI argument; coerce to bounds
     # tuples up front so cropping and provenance see a consistent form.
     if roi is not None:
-        roi = as_roi_bounds(roi)
+        roi = roi if isinstance(roi, MaskROI) else as_roi_bounds(roi)
     if air_roi is not None:
-        air_roi = as_roi_bounds(air_roi)
+        air_roi = air_roi if isinstance(air_roi, MaskROI) else as_roi_bounds(air_roi)
     if background_roi is not None:
-        background_roi = as_roi_bounds_list(background_roi)
+        background_roi = as_region_list(background_roi, arg_name="background_roi")
 
     if output_path is None:
         raise ValueError("output_path is required")
@@ -226,12 +232,10 @@ def run_venus_ccd_pipeline(  # noqa: C901
         metadata["dark_paths"] = [[str(p) for p in run] for run in dark_paths]
 
     if roi:
-        metadata["roi_applied"] = roi
+        metadata["roi_applied"] = region_provenance(roi)
 
     if background_roi is not None:
-        metadata["background_roi"] = (
-            list(background_roi[0]) if len(background_roi) == 1 else [list(b) for b in background_roi]
-        )
+        metadata["background_roi"] = as_region_provenance(background_roi)
 
     if output_path.suffix.lower() in (".hdf5", ".h5"):
         write_hdf5(output_path, transmission, dead_pixel_mask="dead_pixels", metadata=metadata)

--- a/src/neunorm/pipelines/venus_ccd.py
+++ b/src/neunorm/pipelines/venus_ccd.py
@@ -14,6 +14,7 @@ from neunorm import __version__
 from neunorm.data_models.roi import (
     MaskROI,
     RegionLike,
+    ROILike,
     as_region_list,
     as_region_provenance,
     as_roi_bounds,
@@ -40,7 +41,7 @@ def run_venus_ccd_pipeline(  # noqa: C901
     ob_paths: Sequence[Sequence[str | Path]],
     dark_paths: Optional[Sequence[Sequence[str | Path]]] = None,
     output_path: Optional[Path] = None,
-    roi: Optional[RegionLike] = None,
+    roi: Optional[ROILike] = None,
     gamma_filter: bool = True,
     air_roi: Optional[RegionLike] = None,
     background_roi: Optional[BackgroundROILike] = None,
@@ -107,7 +108,7 @@ def run_venus_ccd_pipeline(  # noqa: C901
     # Accept an ROI or a bare (x0, y0, x1, y1) tuple for every ROI argument; coerce to bounds
     # tuples up front so cropping and provenance see a consistent form.
     if roi is not None:
-        roi = roi if isinstance(roi, MaskROI) else as_roi_bounds(roi)
+        roi = as_roi_bounds(roi)
     if air_roi is not None:
         air_roi = air_roi if isinstance(air_roi, MaskROI) else as_roi_bounds(air_roi)
     if background_roi is not None:
@@ -233,6 +234,9 @@ def run_venus_ccd_pipeline(  # noqa: C901
 
     if roi:
         metadata["roi_applied"] = region_provenance(roi)
+
+    if air_roi is not None:
+        metadata["air_roi"] = region_provenance(air_roi)
 
     if background_roi is not None:
         metadata["background_roi"] = as_region_provenance(background_roi)

--- a/src/neunorm/pipelines/venus_ccd.py
+++ b/src/neunorm/pipelines/venus_ccd.py
@@ -85,15 +85,15 @@ def run_venus_ccd_pipeline(  # noqa: C901
         Region of interest to crop to — an ``ROI`` or a bare ``(x0, y0, x1, y1)`` tuple.
     gamma_filter : bool
         Whether to apply gamma filtering to the sample data (default: True)
-    air_roi : Optional[tuple]
-        Region of interest for air correction — an ``ROI`` or a bare ``(x0, y0, x1, y1)`` tuple.
-        If None, air correction is not applied.
-    background_roi : ROI/tuple or a sequence of them
-        Sample-free background region(s) — one ROI or a pooled sequence of ROIs (see
-        ``normalize_transmission``) — for flux-proxy normalization when proton charge is
-        unavailable. Mutually exclusive with proton-charge correction. If
-        ``roi`` is also given the detector is cropped first, so ``background_roi`` indices are
-        resolved in the post-crop frame.
+    air_roi : ROI, MaskROI, or tuple, optional
+        Region of interest for air correction — an ``ROI``, a bare ``(x0, y0, x1, y1)`` tuple, or an
+        arbitrary-shape ``MaskROI`` selection. If None, air correction is not applied.
+    background_roi : ROI, MaskROI, tuple, or a sequence of them
+        Sample-free background region(s) — one region or a pooled sequence (rectangles and/or
+        arbitrary-shape ``MaskROI`` selections; see ``normalize_transmission``) — for flux-proxy
+        normalization when proton charge is unavailable. Mutually exclusive with proton-charge
+        correction. If ``roi`` is also given the detector is cropped first, so ``background_roi``
+        indices are resolved in the post-crop frame.
 
     Notes
     -----

--- a/src/neunorm/pipelines/venus_tpx1.py
+++ b/src/neunorm/pipelines/venus_tpx1.py
@@ -14,6 +14,7 @@ from neunorm import __version__
 from neunorm.data_models.roi import (
     MaskROI,
     RegionLike,
+    ROILike,
     as_roi_bounds,
     region_provenance,
 )
@@ -56,7 +57,7 @@ def run_venus_tpx1_pipeline(  # noqa: C901
     sample_tiff_paths: Sequence[Sequence[str | Path]],
     ob_tiff_paths: Sequence[Sequence[str | Path]],
     output_path: Path,
-    roi: Optional[RegionLike] = None,
+    roi: Optional[ROILike] = None,
     air_roi: Optional[RegionLike] = None,
     rebin_by_tof: Optional[bool | int] = False,
     rebin_by_spatial: Optional[int | tuple[int, int]] = None,
@@ -123,7 +124,7 @@ def run_venus_tpx1_pipeline(  # noqa: C901
     # Accept an ROI or a bare (x0, y0, x1, y1) tuple for every ROI argument; coerce to bounds
     # tuples up front so cropping and provenance see a consistent form.
     if roi is not None:
-        roi = roi if isinstance(roi, MaskROI) else as_roi_bounds(roi)
+        roi = as_roi_bounds(roi)
     if air_roi is not None:
         air_roi = air_roi if isinstance(air_roi, MaskROI) else as_roi_bounds(air_roi)
 
@@ -263,6 +264,9 @@ def run_venus_tpx1_pipeline(  # noqa: C901
 
     if roi:
         metadata["roi_applied"] = region_provenance(roi)
+
+    if air_roi is not None:
+        metadata["air_roi"] = region_provenance(air_roi)
 
     if output_path.suffix.lower() in (".hdf5", ".h5"):
         write_hdf5(output_path, transmission, dead_pixel_mask="dead_pixels", metadata=metadata)

--- a/src/neunorm/pipelines/venus_tpx1.py
+++ b/src/neunorm/pipelines/venus_tpx1.py
@@ -11,7 +11,12 @@ import scipp as sc
 from loguru import logger
 
 from neunorm import __version__
-from neunorm.data_models.roi import ROILike, as_roi_bounds
+from neunorm.data_models.roi import (
+    MaskROI,
+    RegionLike,
+    as_roi_bounds,
+    region_provenance,
+)
 from neunorm.exporters.hdf5_writer import write_hdf5
 from neunorm.exporters.tiff_writer import write_tiff_stack
 from neunorm.loaders.metadata_loader import load_metadata
@@ -51,8 +56,8 @@ def run_venus_tpx1_pipeline(  # noqa: C901
     sample_tiff_paths: Sequence[Sequence[str | Path]],
     ob_tiff_paths: Sequence[Sequence[str | Path]],
     output_path: Path,
-    roi: Optional[ROILike] = None,
-    air_roi: Optional[ROILike] = None,
+    roi: Optional[RegionLike] = None,
+    air_roi: Optional[RegionLike] = None,
     rebin_by_tof: Optional[bool | int] = False,
     rebin_by_spatial: Optional[int | tuple[int, int]] = None,
     flight_path: sc.Variable = sc.scalar(VENUS_FLIGHT_PATH_M, unit="m"),
@@ -118,9 +123,9 @@ def run_venus_tpx1_pipeline(  # noqa: C901
     # Accept an ROI or a bare (x0, y0, x1, y1) tuple for every ROI argument; coerce to bounds
     # tuples up front so cropping and provenance see a consistent form.
     if roi is not None:
-        roi = as_roi_bounds(roi)
+        roi = roi if isinstance(roi, MaskROI) else as_roi_bounds(roi)
     if air_roi is not None:
-        air_roi = as_roi_bounds(air_roi)
+        air_roi = air_roi if isinstance(air_roi, MaskROI) else as_roi_bounds(air_roi)
 
     # length of hdf5 paths and tiff paths should match for both sample and OB
     if len(sample_hdf5_paths) != len(sample_tiff_paths):
@@ -257,7 +262,7 @@ def run_venus_tpx1_pipeline(  # noqa: C901
     }
 
     if roi:
-        metadata["roi_applied"] = roi
+        metadata["roi_applied"] = region_provenance(roi)
 
     if output_path.suffix.lower() in (".hdf5", ".h5"):
         write_hdf5(output_path, transmission, dead_pixel_mask="dead_pixels", metadata=metadata)

--- a/src/neunorm/pipelines/venus_tpx1.py
+++ b/src/neunorm/pipelines/venus_tpx1.py
@@ -97,9 +97,9 @@ def run_venus_tpx1_pipeline(  # noqa: C901
         Path to save the output file (HDF5 or TIFF)
     roi : Optional[tuple]
         Region of interest to crop to — an ``ROI`` or a bare ``(x0, y0, x1, y1)`` tuple.
-    air_roi : Optional[tuple]
-        Region of interest for air correction — an ``ROI`` or a bare ``(x0, y0, x1, y1)`` tuple.
-        If None, air correction is not applied.
+    air_roi : ROI, MaskROI, or tuple, optional
+        Region of interest for air correction — an ``ROI``, a bare ``(x0, y0, x1, y1)`` tuple, or an
+        arbitrary-shape ``MaskROI`` selection. If None, air correction is not applied.
     rebin_by_tof : Optional[Union[bool,int]]
         Whether to apply TOF rebinning based on statistics analysis. If an integer is provided,
         it will be used as the rebinning factor instead of the recommended one.

--- a/src/neunorm/pipelines/venus_tpx3_event.py
+++ b/src/neunorm/pipelines/venus_tpx3_event.py
@@ -80,8 +80,9 @@ def run_venus_tpx3_event_pipeline(  # noqa: C901
         Path to save the output file (HDF5 or TIFF)
     roi : Optional[tuple]
         Region of interest to crop to — an ``ROI`` or a bare ``(x0, y0, x1, y1)`` tuple.
-    air_roi : Optional[tuple]
-        Region of interest for air correction — an ``ROI`` or a bare ``(x0, y0, x1, y1)`` tuple.
+    air_roi : ROI, MaskROI, or tuple, optional
+        Region of interest for air correction — an ``ROI``, a bare ``(x0, y0, x1, y1)`` tuple, or an
+        arbitrary-shape ``MaskROI`` selection. If None, air correction is not applied.
     rebin_by_tof : Optional[bool,int]
         Whether to apply TOF rebinning based on statistics analysis. If an integer is provided,
         it will be used as the rebinning factor instead of the recommended one.

--- a/src/neunorm/pipelines/venus_tpx3_event.py
+++ b/src/neunorm/pipelines/venus_tpx3_event.py
@@ -14,6 +14,7 @@ from neunorm import __version__
 from neunorm.data_models.roi import (
     MaskROI,
     RegionLike,
+    ROILike,
     as_roi_bounds,
     region_provenance,
 )
@@ -40,7 +41,7 @@ def run_venus_tpx3_event_pipeline(  # noqa: C901
     ob_paths: Sequence[str | Path],
     binning: BinningConfig,
     output_path: Path,
-    roi: Optional[RegionLike] = None,
+    roi: Optional[ROILike] = None,
     air_roi: Optional[RegionLike] = None,
     rebin_by_tof: Optional[bool | int] = False,
     rebin_by_spatial: Optional[int | tuple[int, int]] = None,
@@ -113,7 +114,7 @@ def run_venus_tpx3_event_pipeline(  # noqa: C901
     # Accept an ROI or a bare (x0, y0, x1, y1) tuple for every ROI argument; coerce to bounds
     # tuples up front so cropping and provenance see a consistent form.
     if roi is not None:
-        roi = roi if isinstance(roi, MaskROI) else as_roi_bounds(roi)
+        roi = as_roi_bounds(roi)
     if air_roi is not None:
         air_roi = air_roi if isinstance(air_roi, MaskROI) else as_roi_bounds(air_roi)
 
@@ -241,6 +242,9 @@ def run_venus_tpx3_event_pipeline(  # noqa: C901
 
     if roi:
         metadata["roi_applied"] = region_provenance(roi)
+
+    if air_roi is not None:
+        metadata["air_roi"] = region_provenance(air_roi)
 
     if output_path.suffix.lower() in (".hdf5", ".h5"):
         write_hdf5(

--- a/src/neunorm/pipelines/venus_tpx3_event.py
+++ b/src/neunorm/pipelines/venus_tpx3_event.py
@@ -11,7 +11,12 @@ import scipp as sc
 from loguru import logger
 
 from neunorm import __version__
-from neunorm.data_models.roi import ROILike, as_roi_bounds
+from neunorm.data_models.roi import (
+    MaskROI,
+    RegionLike,
+    as_roi_bounds,
+    region_provenance,
+)
 from neunorm.data_models.tof import BinningConfig
 from neunorm.exporters.hdf5_writer import write_hdf5
 from neunorm.exporters.tiff_writer import write_tiff_stack
@@ -35,8 +40,8 @@ def run_venus_tpx3_event_pipeline(  # noqa: C901
     ob_paths: Sequence[str | Path],
     binning: BinningConfig,
     output_path: Path,
-    roi: Optional[ROILike] = None,
-    air_roi: Optional[ROILike] = None,
+    roi: Optional[RegionLike] = None,
+    air_roi: Optional[RegionLike] = None,
     rebin_by_tof: Optional[bool | int] = False,
     rebin_by_spatial: Optional[int | tuple[int, int]] = None,
     detector_shape: tuple[int, int] = (514, 514),
@@ -108,9 +113,9 @@ def run_venus_tpx3_event_pipeline(  # noqa: C901
     # Accept an ROI or a bare (x0, y0, x1, y1) tuple for every ROI argument; coerce to bounds
     # tuples up front so cropping and provenance see a consistent form.
     if roi is not None:
-        roi = as_roi_bounds(roi)
+        roi = roi if isinstance(roi, MaskROI) else as_roi_bounds(roi)
     if air_roi is not None:
-        air_roi = as_roi_bounds(air_roi)
+        air_roi = air_roi if isinstance(air_roi, MaskROI) else as_roi_bounds(air_roi)
 
     x_bins, y_bins = detector_shape
 
@@ -235,7 +240,7 @@ def run_venus_tpx3_event_pipeline(  # noqa: C901
     }
 
     if roi:
-        metadata["roi_applied"] = roi
+        metadata["roi_applied"] = region_provenance(roi)
 
     if output_path.suffix.lower() in (".hdf5", ".h5"):
         write_hdf5(

--- a/src/neunorm/pipelines/venus_tpx3_histogram.py
+++ b/src/neunorm/pipelines/venus_tpx3_histogram.py
@@ -11,7 +11,12 @@ import scipp as sc
 from loguru import logger
 
 from neunorm import __version__
-from neunorm.data_models.roi import ROILike, as_roi_bounds
+from neunorm.data_models.roi import (
+    MaskROI,
+    RegionLike,
+    as_roi_bounds,
+    region_provenance,
+)
 from neunorm.exporters.hdf5_writer import write_hdf5
 from neunorm.exporters.tiff_writer import write_tiff_stack
 from neunorm.loaders.metadata_loader import load_metadata
@@ -34,8 +39,8 @@ def run_venus_tpx3_histogram_pipeline(  # noqa: C901
     sample_tiff_paths: Sequence[Sequence[str | Path]],
     ob_tiff_paths: Sequence[Sequence[str | Path]],
     output_path: Path,
-    roi: Optional[ROILike] = None,
-    air_roi: Optional[ROILike] = None,
+    roi: Optional[RegionLike] = None,
+    air_roi: Optional[RegionLike] = None,
     rebin_by_tof: Optional[bool | int] = False,
     rebin_by_spatial: Optional[int | tuple[int, int]] = None,
     flight_path: sc.Variable = sc.scalar(VENUS_FLIGHT_PATH_M, unit="m"),
@@ -102,9 +107,9 @@ def run_venus_tpx3_histogram_pipeline(  # noqa: C901
     # Accept an ROI or a bare (x0, y0, x1, y1) tuple for every ROI argument; coerce to bounds
     # tuples up front so cropping and provenance see a consistent form.
     if roi is not None:
-        roi = as_roi_bounds(roi)
+        roi = roi if isinstance(roi, MaskROI) else as_roi_bounds(roi)
     if air_roi is not None:
-        air_roi = as_roi_bounds(air_roi)
+        air_roi = air_roi if isinstance(air_roi, MaskROI) else as_roi_bounds(air_roi)
 
     # length of hdf5 paths and tiff paths should match for both sample and OB
     if len(sample_hdf5_paths) != len(sample_tiff_paths):
@@ -253,7 +258,7 @@ def run_venus_tpx3_histogram_pipeline(  # noqa: C901
     }
 
     if roi:
-        metadata["roi_applied"] = roi
+        metadata["roi_applied"] = region_provenance(roi)
 
     if output_path.suffix.lower() in (".hdf5", ".h5"):
         write_hdf5(

--- a/src/neunorm/pipelines/venus_tpx3_histogram.py
+++ b/src/neunorm/pipelines/venus_tpx3_histogram.py
@@ -81,9 +81,9 @@ def run_venus_tpx3_histogram_pipeline(  # noqa: C901
         Path to save the output file (HDF5 or TIFF)
     roi : Optional[tuple]
         Region of interest to crop to — an ``ROI`` or a bare ``(x0, y0, x1, y1)`` tuple.
-    air_roi : Optional[tuple]
-        Region of interest for air correction — an ``ROI`` or a bare ``(x0, y0, x1, y1)`` tuple.
-        If None, air correction is not applied.
+    air_roi : ROI, MaskROI, or tuple, optional
+        Region of interest for air correction — an ``ROI``, a bare ``(x0, y0, x1, y1)`` tuple, or an
+        arbitrary-shape ``MaskROI`` selection. If None, air correction is not applied.
     rebin_by_tof : Optional[Union[bool,int]]
         Whether to apply TOF rebinning based on statistics analysis. If an integer is provided,
         it will be used as the rebinning factor instead of the recommended one.

--- a/src/neunorm/pipelines/venus_tpx3_histogram.py
+++ b/src/neunorm/pipelines/venus_tpx3_histogram.py
@@ -14,6 +14,7 @@ from neunorm import __version__
 from neunorm.data_models.roi import (
     MaskROI,
     RegionLike,
+    ROILike,
     as_roi_bounds,
     region_provenance,
 )
@@ -39,7 +40,7 @@ def run_venus_tpx3_histogram_pipeline(  # noqa: C901
     sample_tiff_paths: Sequence[Sequence[str | Path]],
     ob_tiff_paths: Sequence[Sequence[str | Path]],
     output_path: Path,
-    roi: Optional[RegionLike] = None,
+    roi: Optional[ROILike] = None,
     air_roi: Optional[RegionLike] = None,
     rebin_by_tof: Optional[bool | int] = False,
     rebin_by_spatial: Optional[int | tuple[int, int]] = None,
@@ -107,7 +108,7 @@ def run_venus_tpx3_histogram_pipeline(  # noqa: C901
     # Accept an ROI or a bare (x0, y0, x1, y1) tuple for every ROI argument; coerce to bounds
     # tuples up front so cropping and provenance see a consistent form.
     if roi is not None:
-        roi = roi if isinstance(roi, MaskROI) else as_roi_bounds(roi)
+        roi = as_roi_bounds(roi)
     if air_roi is not None:
         air_roi = air_roi if isinstance(air_roi, MaskROI) else as_roi_bounds(air_roi)
 
@@ -259,6 +260,9 @@ def run_venus_tpx3_histogram_pipeline(  # noqa: C901
 
     if roi:
         metadata["roi_applied"] = region_provenance(roi)
+
+    if air_roi is not None:
+        metadata["air_roi"] = region_provenance(air_roi)
 
     if output_path.suffix.lower() in (".hdf5", ".h5"):
         write_hdf5(

--- a/src/neunorm/processing/air_region_corrector.py
+++ b/src/neunorm/processing/air_region_corrector.py
@@ -5,83 +5,68 @@ Air region correction.
 import scipp as sc
 from loguru import logger
 
-from neunorm.data_models.roi import ROILike, as_roi_bounds
+from neunorm.data_models.roi import RegionsLike, as_region_list
+from neunorm.processing.normalizer import _pooled_roi_coefficient
 
 
 def apply_air_region_correction(
     transmission: sc.DataArray,
-    air_roi: ROILike,  # (x0, y0, x1, y1) tuple or an ROI; x1, y1 are exclusive stops
+    air_roi: RegionsLike,
 ) -> sc.DataArray:
-    """Scale transmission so air region has mean = 1.0.
+    """Scale transmission so the air region has mean = 1.0.
 
     Requirements
     ------------
 
-    - Calculate mean transmission in user-specified air region
-    - Scale entire image so air region = 1.0
+    - Calculate mean transmission in the user-specified air region(s)
+    - Scale entire image so the air-region mean = 1.0
     - Support per-image correction (radiography) and per-TOF-bin correction (hyperspectral)
-    - Propagate uncertainty from air region mean
+    - Propagate uncertainty from the air-region mean
 
     Formula
     -------
 
-    T_final = T / mean(T[air_ROI])
+    T_final = T / mean(T[air region])
 
-    Uncertainty:
+    Uncertainty (first order):
     σ_T_final = T_final × √[(σ_T/T)² + (σ_air/<T_air>)²]
 
+    The mean is the mask-aware **pooled** region mean (``sum(T) / count(unmasked pixels)``, per
+    spectral bin), shared with the ``background_roi`` machinery. For a masked air region this is
+    the true region mean — dead/hot pixels are excluded from numerator and denominator — and a
+    region is valid even when a full row of it is masked. Raises ``ValueError`` if the air mean is
+    not strictly positive and finite in every image (a non-positive mean transmission in the air
+    region is pathological and would silently corrupt the scale).
 
     Parameters
     ----------
     transmission : sc.DataArray
         Normalized transmission (after OB correction)
-    air_roi : ROI or tuple[int, int, int, int]
-        Air region as an :class:`~neunorm.data_models.roi.ROI` or a bare ``(x0, y0, x1, y1)`` tuple,
-        where x1 and y1 are exclusive upper bounds.
+    air_roi : ROI, MaskROI, tuple, or a sequence of them
+        Air region as an :class:`~neunorm.data_models.roi.ROI` (or a bare ``(x0, y0, x1, y1)``
+        tuple, exclusive stops), an arbitrary-shape :class:`~neunorm.data_models.roi.MaskROI`
+        (selection mask: 1 = pixel in the region), or a sequence mixing those (pooled).
 
     """
-    air_roi = as_roi_bounds(air_roi)
+    regions = as_region_list(air_roi, arg_name="air_roi")
 
-    logger.info(f"Applying air region correction with ROI: {air_roi}")
+    logger.info(f"Applying air region correction with region(s): {regions}")
 
-    if len(air_roi) != 4 or not all(isinstance(i, int) for i in air_roi):
-        raise ValueError("ROI must be a tuple of 4 integers (x0, y0, x1, y1)")
+    coeff = _pooled_roi_coefficient(transmission, regions, "transmission", strict=True, region_arg="air_roi")
 
-    x0, y0, x1, y1 = air_roi
+    # scipp refuses to divide by a variance-bearing scalar (it would introduce correlations), so
+    # divide by the variance-free mean and add its first-order contribution manually — the same
+    # scheme as apply_background_roi. At T == 0 pixels this keeps the variance finite (Var(T)/m²),
+    # where the previous corrected**2 * (Var(T)/T**2 + ...) form produced 0 * inf = NaN.
+    coeff_var = sc.variances(coeff) if coeff.variances is not None else None
+    coeff = coeff.copy()
+    coeff.variances = None
+    corrected = transmission / coeff
 
-    # Validate ROI
-    if x0 < 0 or y0 < 0 or x1 <= x0 or y1 <= y0:
-        raise ValueError("Invalid ROI: (x0, y0, x1, y1) must satisfy 0 <= x0 < x1 and 0 <= y0 < y1")
-
-    # Get current dimensions
-    if "x" not in transmission.dims or "y" not in transmission.dims:
-        raise ValueError("DataArray must have 'x' and 'y' dimensions for ROI cropping")
-
-    # Validate ROI against current sizes
-    if x1 > transmission.sizes["x"] or y1 > transmission.sizes["y"]:
-        raise ValueError(
-            f"ROI (x1={x1}, y1={y1}) exceeds data size (x={transmission.sizes['x']}, y={transmission.sizes['y']})"
-        )
-
-    # Extract air region
-    air_region = transmission["x", slice(x0, x1)]["y", slice(y0, y1)]
-
-    # Calculate mean transmission in air region
-    mean_air = sc.mean(air_region, dim=["x", "y"])
-    if transmission.variances is not None:
-        mean_air_variance = sc.variances(mean_air)
-        mean_air.variances = None  # Temporarily remove variance to avoid issues with division
-
-    # Scale entire image so mean of the air region = 1.0
-    corrected_transmission = transmission / mean_air
-
-    # Propagate uncertainty from air region mean
-    if transmission.variances is not None:
-        variances = corrected_transmission**2 * (
-            sc.variances(transmission) / transmission**2 + mean_air_variance / mean_air**2
-        )
-
-        corrected_transmission.variances = variances.values
+    if coeff_var is not None and corrected.variances is not None:
+        rel = coeff_var / (coeff * coeff)
+        extra = sc.array(dims=list(corrected.dims), values=corrected.values**2) * rel
+        corrected.variances = corrected.variances + extra.values.astype(corrected.variances.dtype, copy=False)
 
     logger.success("✓ Air region correction applied")
-    return corrected_transmission
+    return corrected

--- a/src/neunorm/processing/normalizer.py
+++ b/src/neunorm/processing/normalizer.py
@@ -131,7 +131,19 @@ def _pooled_union_selection(rois_bounds, ny: int, nx: int) -> np.ndarray:
 
 
 def _pooled_regions_overlap(rois_bounds, ny: int, nx: int) -> bool:
-    """True if any pixel is selected by more than one region in a pooled list (validated bounds)."""
+    """True if any pixel is selected by more than one region in a pooled list (validated bounds).
+
+    Rectangle-only lists (the common pooled case) use a cheap pairwise interval-overlap test with no
+    per-frame allocation; a per-pixel ``ny*nx`` coverage map is built only when a ``MaskROI`` is
+    present, where arbitrary shapes make pairwise geometry insufficient.
+    """
+    if not any(isinstance(r, MaskROI) for r in rois_bounds):
+        # exclusive-stop rectangles overlap iff they intersect on both axes
+        for i, (ax0, ay0, ax1, ay1) in enumerate(rois_bounds):
+            for bx0, by0, bx1, by1 in rois_bounds[i + 1 :]:
+                if ax0 < bx1 and bx0 < ax1 and ay0 < by1 and by0 < ay1:
+                    return True
+        return False
     coverage = np.zeros((ny, nx), dtype=np.int32)
     for region_spec in rois_bounds:
         if isinstance(region_spec, MaskROI):

--- a/src/neunorm/processing/normalizer.py
+++ b/src/neunorm/processing/normalizer.py
@@ -90,7 +90,9 @@ def _unique_mask_name(existing, base: str = "_region_sel") -> str:
     return name
 
 
-def _mask_region_view(data: sc.DataArray, region: MaskROI, name: str) -> sc.DataArray:
+def _mask_region_view(
+    data: sc.DataArray, region: MaskROI, name: str, region_arg: str = "background_roi"
+) -> sc.DataArray:
     """Bounding-box view of ``data`` with the region's inverse selection attached as a scipp mask.
 
     The bbox slice keeps temporaries proportional to the region, not the frame; the shallow copy
@@ -99,7 +101,7 @@ def _mask_region_view(data: sc.DataArray, region: MaskROI, name: str) -> sc.Data
     mask-aware reductions used for rectangles yield sum/count over ``selected & unmasked`` pixels.
     """
     if "x" not in data.dims or "y" not in data.dims:
-        raise ValueError(f"{name} must have 'x' and 'y' dimensions for background_roi normalization")
+        raise ValueError(f"{name} must have 'x' and 'y' dimensions for {region_arg} normalization")
     ny, nx = region.shape
     if ny != data.sizes["y"] or nx != data.sizes["x"]:
         raise ValueError(
@@ -117,6 +119,7 @@ def _pooled_roi_coefficient(
     rois_bounds: list,
     name: str,
     strict: bool = True,
+    region_arg: str = "background_roi",
 ) -> sc.Variable:
     """Per-image **pooled** background coefficient over one or more regions (rectangles or masks).
 
@@ -138,12 +141,12 @@ def _pooled_roi_coefficient(
     propagates inf/nan.)
     """
     if "x" not in data.dims or "y" not in data.dims:
-        raise ValueError(f"{name} must have 'x' and 'y' dimensions for background_roi normalization")
+        raise ValueError(f"{name} must have 'x' and 'y' dimensions for {region_arg} normalization")
     total = None
     n_unmasked = None
     for region_spec in rois_bounds:
         if isinstance(region_spec, MaskROI):
-            region = _mask_region_view(data, region_spec, name)
+            region = _mask_region_view(data, region_spec, name, region_arg=region_arg)
             roi_sum = sc.sum(region, dim=["x", "y"]).data  # selected & unmasked (mask-aware)
             roi_n = _masked_ones_count(region)
             total = roi_sum if total is None else total + roi_sum
@@ -151,11 +154,10 @@ def _pooled_roi_coefficient(
             continue
         x0, y0, x1, y1 = region_spec
         if x0 < 0 or y0 < 0 or x1 <= x0 or y1 <= y0:
-            raise ValueError(f"Invalid background_roi ({x0}, {y0}, {x1}, {y1}): need 0 <= x0 < x1 and 0 <= y0 < y1")
+            raise ValueError(f"Invalid {region_arg} ({x0}, {y0}, {x1}, {y1}): need 0 <= x0 < x1 and 0 <= y0 < y1")
         if x1 > data.sizes["x"] or y1 > data.sizes["y"]:
             raise ValueError(
-                f"background_roi ({x0}, {y0}, {x1}, {y1}) exceeds {name} size "
-                f"(x={data.sizes['x']}, y={data.sizes['y']})"
+                f"{region_arg} ({x0}, {y0}, {x1}, {y1}) exceeds {name} size (x={data.sizes['x']}, y={data.sizes['y']})"
             )
         region = data["x", x0:x1]["y", y0:y1]
         roi_sum = sc.sum(region, dim=["x", "y"]).data  # per-spectral (mask-aware; var = sum of unmasked var)
@@ -170,7 +172,7 @@ def _pooled_roi_coefficient(
     coeff = total / n_unmasked
     if strict and (not bool(sc.all(sc.isfinite(coeff)).value) or sc.min(coeff).value <= 0):
         raise ValueError(
-            f"background_roi {name} pooled mean must be strictly positive and finite "
+            f"{region_arg} {name} pooled mean must be strictly positive and finite "
             f"(min={sc.min(coeff).value}); the ROI(s) must contain positive counts in every image"
         )
     return coeff

--- a/src/neunorm/processing/normalizer.py
+++ b/src/neunorm/processing/normalizer.py
@@ -157,8 +157,10 @@ def _pooled_roi_coefficient(
     from both the summed counts and the pixel count (spatial ``(x, y)`` masks assumed). Rectangle
     entries are exclusive-stop ``(x0, y0, x1, y1)`` bounds and keep the sliced fast path
     bit-for-bit; ``MaskROI`` entries contribute their selected pixels through the same mask-aware
-    reductions (regions overlapping in a pooled list double-count, for masks exactly as for
-    rectangles). Returns a variance-bearing scipp Variable (the variance of the pooled mean).
+    reductions. Regions that **overlap** in a pooled list are reduced over their **union** (each
+    selected, unmasked pixel counted once) so the pooled mean and its variance are correct; a
+    non-overlapping (or single-region) list keeps the per-region accumulation bit-for-bit. Returns a
+    variance-bearing scipp Variable (the variance of the pooled mean).
 
     Raises ``ValueError`` on an invalid/out-of-bounds rectangle, a selection shape not matching the
     data, or missing ``x``/``y`` dims. With ``strict`` (default) it also rejects a
@@ -222,7 +224,7 @@ def _pooled_roi_coefficient(
 def _background_roi_means(
     sample: sc.DataArray,
     ob: sc.DataArray,
-    rois_bounds: list[tuple[int, int, int, int]],
+    rois_bounds: list[Union[tuple[int, int, int, int], MaskROI]],
     strict: bool = True,
 ) -> tuple[sc.Variable, sc.Variable]:
     """Per-image pooled background means (cs, co) for sample and OB over the same ROI list."""
@@ -235,7 +237,7 @@ def _roi_dark_mean_covariance(
     sample_dc: sc.DataArray,
     ob_dc: sc.DataArray,
     dark: sc.DataArray,
-    rois_bounds: list[tuple[int, int, int, int]],
+    rois_bounds: list[Union[tuple[int, int, int, int], MaskROI]],
 ) -> sc.Variable:
     """Covariance of the two **pooled** background-ROI means induced by the shared dark frame.
 
@@ -655,8 +657,9 @@ def apply_background_roi(
 
     Returns ``data / pooled_mean(data over background_roi)`` — the **sample-only** form of the
     background-ROI flux proxy, for when there is no open beam to normalize against. ``background_roi``
-    is a single ROI or a sequence of ROIs (pooled as ``sum(counts) / sum(pixels)``); see
-    ``normalize_transmission(..., background_roi=)`` for the with-open-beam transmission form.
+    is a single region or a sequence of them — rectangles and/or arbitrary-shape ``MaskROI``
+    selections — pooled as ``sum(counts) / sum(pixels)`` (overlapping regions are de-duplicated to
+    their union); see ``normalize_transmission(..., background_roi=)`` for the with-open-beam form.
 
     First-order uncertainty from the pooled ROI mean is propagated
     (``Var += corrected**2 * Var(coeff) / coeff**2``); the in-ROI pixel/ROI-mean correlation is not
@@ -667,8 +670,9 @@ def apply_background_roi(
     ----------
     data : sc.DataArray
         Image stack with ``x``/``y`` dims (e.g. ``(spectral, x, y)``), optionally carrying variance.
-    background_roi : ROI/tuple or a sequence of them
-        Sample-free background region(s), pooled.
+    background_roi : ROI, MaskROI, tuple, or a sequence of them
+        Sample-free background region(s), pooled — rectangles and/or arbitrary-shape ``MaskROI``
+        selections, mixable in one list.
     strict : bool, optional
         With the default ``True``, a non-positive/non-finite pooled mean raises ``ValueError``.
         ``False`` skips only that guard and lets zeros propagate through the division (inf/nan

--- a/src/neunorm/processing/normalizer.py
+++ b/src/neunorm/processing/normalizer.py
@@ -6,17 +6,18 @@ with proper uncertainty propagation and beam corrections.
 """
 
 import collections.abc
-from typing import Optional, Sequence, Union
+from typing import Optional, Union
 
 import numpy as np
 import scipp as sc
 from loguru import logger
 
-from neunorm.data_models.roi import ROI, ROILike, as_roi_bounds
+from neunorm.data_models.roi import ROI, MaskROI, RegionsLike, as_region_list, as_roi_bounds
 from neunorm.processing.dark_corrector import subtract_dark
 
-# One ROI or a sequence of ROIs (pooled). A bare 4-int tuple/list is a single ROI.
-BackgroundROILike = Union[ROILike, Sequence[ROILike]]
+# One region (rectangle or MaskROI) or a sequence of regions (pooled). A bare 4-int tuple/list is a
+# single rectangle. Kept as a named alias for backward compatibility with existing imports.
+BackgroundROILike = RegionsLike
 
 
 def _as_plain_int_bounds(bounds: tuple) -> tuple[int, int, int, int]:
@@ -60,31 +61,95 @@ def _unmasked_count(region: sc.DataArray) -> sc.Variable:
     return sc.sum(counter, dim=["x", "y"]).data
 
 
+def _masked_ones_count(region: sc.DataArray) -> sc.Variable:
+    """Unmasked-pixel count like ``_unmasked_count``, but sharing buffers instead of deep-copying.
+
+    Used on the MaskROI path, where ``region`` can be a large bounding-box view: builds the ones
+    counter directly (no copy of values/variances). When every mask is spatial the counter is 2D —
+    the count is then a scalar rather than ``_unmasked_count``'s constant per-spectral vector, which
+    divides/broadcasts identically.
+    """
+    if all(set(m.dims) <= {"x", "y"} for m in region.masks.values()):
+        sizes = {d: s for d, s in region.sizes.items() if d in ("x", "y")}
+    else:
+        sizes = dict(region.data.sizes)
+    counter = sc.DataArray(
+        sc.ones(sizes=sizes, dtype="int64", unit="one"),
+        masks={k: m for k, m in region.masks.items()},
+    )
+    return sc.sum(counter, dim=["x", "y"]).data
+
+
+def _unique_mask_name(existing, base: str = "_region_sel") -> str:
+    """A mask name not colliding with ``existing`` (a same-named user mask must never be replaced)."""
+    name = base
+    i = 1
+    while name in existing:
+        name = f"{base}_{i}"
+        i += 1
+    return name
+
+
+def _mask_region_view(data: sc.DataArray, region: MaskROI, name: str) -> sc.DataArray:
+    """Bounding-box view of ``data`` with the region's inverse selection attached as a scipp mask.
+
+    The bbox slice keeps temporaries proportional to the region, not the frame; the shallow copy
+    shares data/variance buffers and never mutates ``data``'s own masks. The attached exclusion
+    (``~selection``) composes (OR) with any existing dead/hot/per-image masks, so the same
+    mask-aware reductions used for rectangles yield sum/count over ``selected & unmasked`` pixels.
+    """
+    if "x" not in data.dims or "y" not in data.dims:
+        raise ValueError(f"{name} must have 'x' and 'y' dimensions for background_roi normalization")
+    ny, nx = region.shape
+    if ny != data.sizes["y"] or nx != data.sizes["x"]:
+        raise ValueError(
+            f"{name} MaskROI selection shape (ny={ny}, nx={nx}) does not match data size "
+            f"(y={data.sizes['y']}, x={data.sizes['x']})"
+        )
+    x0, y0, x1, y1 = region.bounding_box()
+    work = data["x", x0:x1]["y", y0:y1].copy(deep=False)
+    work.masks[_unique_mask_name(work.masks.keys())] = sc.array(dims=["y", "x"], values=~region.selection[y0:y1, x0:x1])
+    return work
+
+
 def _pooled_roi_coefficient(
     data: sc.DataArray,
-    rois_bounds: list[tuple[int, int, int, int]],
+    rois_bounds: list,
     name: str,
     strict: bool = True,
 ) -> sc.Variable:
-    """Per-image **pooled** background coefficient over one or more ROIs.
+    """Per-image **pooled** background coefficient over one or more regions (rectangles or masks).
 
-    ``coefficient = sum(counts over all ROIs) / sum(unmasked pixels over all ROIs)`` per spectral
-    bin — the pooled ratio-of-means (1.x / iBeatles form). For a single ROI this is the plain
-    mask-aware ROI mean. Reductions are mask-aware: masked dead/hot pixels are excluded from both
-    the summed counts and the pixel count (spatial ``(x, y)`` masks assumed). ``x1``/``y1`` are
-    exclusive stops. Returns a variance-bearing scipp Variable (the variance of the pooled mean).
+    ``coefficient = sum(counts over all regions) / sum(unmasked pixels over all regions)`` per
+    spectral bin — the pooled ratio-of-means (1.x / iBeatles form). For a single region this is the
+    plain mask-aware region mean. Reductions are mask-aware: masked dead/hot pixels are excluded
+    from both the summed counts and the pixel count (spatial ``(x, y)`` masks assumed). Rectangle
+    entries are exclusive-stop ``(x0, y0, x1, y1)`` bounds and keep the sliced fast path
+    bit-for-bit; ``MaskROI`` entries contribute their selected pixels through the same mask-aware
+    reductions (regions overlapping in a pooled list double-count, for masks exactly as for
+    rectangles). Returns a variance-bearing scipp Variable (the variance of the pooled mean).
 
-    Raises ``ValueError`` on an invalid/out-of-bounds ROI or missing ``x``/``y`` dims. With
-    ``strict`` (default) it also rejects a non-positive/non-finite pooled mean (which would
-    silently yield inf/nan output); ``strict=False`` skips only that guard and lets zeros
-    propagate through the division — the 1.x semantics, for downstreams reproducing legacy
-    outputs bit for bit.
+    Raises ``ValueError`` on an invalid/out-of-bounds rectangle, a selection shape not matching the
+    data, or missing ``x``/``y`` dims. With ``strict`` (default) it also rejects a
+    non-positive/non-finite pooled mean (which would silently yield inf/nan output);
+    ``strict=False`` skips only that guard and lets zeros propagate through the division — the 1.x
+    semantics, for downstreams reproducing legacy outputs bit for bit. (A selection whose pixels
+    are all dead/hot-masked behaves like an all-masked rectangle: strict raises, non-strict
+    propagates inf/nan.)
     """
     if "x" not in data.dims or "y" not in data.dims:
         raise ValueError(f"{name} must have 'x' and 'y' dimensions for background_roi normalization")
     total = None
     n_unmasked = None
-    for x0, y0, x1, y1 in rois_bounds:
+    for region_spec in rois_bounds:
+        if isinstance(region_spec, MaskROI):
+            region = _mask_region_view(data, region_spec, name)
+            roi_sum = sc.sum(region, dim=["x", "y"]).data  # selected & unmasked (mask-aware)
+            roi_n = _masked_ones_count(region)
+            total = roi_sum if total is None else total + roi_sum
+            n_unmasked = roi_n if n_unmasked is None else n_unmasked + roi_n
+            continue
+        x0, y0, x1, y1 = region_spec
         if x0 < 0 or y0 < 0 or x1 <= x0 or y1 <= y0:
             raise ValueError(f"Invalid background_roi ({x0}, {y0}, {x1}, {y1}): need 0 <= x0 < x1 and 0 <= y0 < y1")
         if x1 > data.sizes["x"] or y1 > data.sizes["y"]:
@@ -151,14 +216,27 @@ def _roi_dark_mean_covariance(
     n_s = None
     n_o = None
     intersection_var_sum = None  # sum over all ROIs of sum_{A∩B} Var(D)
-    for x0, y0, x1, y1 in rois_bounds:
-        d_roi = dark["x", x0:x1]["y", y0:y1].copy()
-        s_roi = sample_dc["x", x0:x1]["y", y0:y1]
-        o_roi = ob_dc["x", x0:x1]["y", y0:y1]
-        ms, mo = _excluded(s_roi), _excluded(o_roi)
-        # per-spectral unmasked counts (reduce masks over x,y only, mirroring _pooled_roi_coefficient
-        # so a per-image (spectral, x, y) mask does not collapse the denominator).
-        n_s_roi, n_o_roi = _unmasked_count(s_roi), _unmasked_count(o_roi)
+    for region_spec in rois_bounds:
+        if isinstance(region_spec, MaskROI):
+            # The bbox views carry ~selection as one more mask, so _excluded() and the counts below
+            # automatically restrict A/B to selected & unmasked pixels — the same generalization as
+            # the pooled coefficient (A/B = selection ∩ unmasked).
+            x0, y0, x1, y1 = region_spec.bounding_box()
+            d_roi = dark["x", x0:x1]["y", y0:y1].copy()
+            s_roi = _mask_region_view(sample_dc, region_spec, "sample")
+            o_roi = _mask_region_view(ob_dc, region_spec, "ob")
+            ms, mo = _excluded(s_roi), _excluded(o_roi)
+            n_s_roi, n_o_roi = _masked_ones_count(s_roi), _masked_ones_count(o_roi)
+        else:
+            x0, y0, x1, y1 = region_spec
+            d_roi = dark["x", x0:x1]["y", y0:y1].copy()
+            s_roi = sample_dc["x", x0:x1]["y", y0:y1]
+            o_roi = ob_dc["x", x0:x1]["y", y0:y1]
+            ms, mo = _excluded(s_roi), _excluded(o_roi)
+            # per-spectral unmasked counts (reduce masks over x,y only, mirroring
+            # _pooled_roi_coefficient so a per-image (spectral, x, y) mask does not collapse the
+            # denominator).
+            n_s_roi, n_o_roi = _unmasked_count(s_roi), _unmasked_count(o_roi)
         n_s = n_s_roi if n_s is None else n_s + n_s_roi
         n_o = n_o_roi if n_o is None else n_o + n_o_roi
         # sum Var(D) over A∩B (ROI pixels kept in BOTH sample and OB).
@@ -219,19 +297,21 @@ def normalize_transmission(  # noqa: C901
     pc_uncertainty : float, optional
         Relative proton charge uncertainty (default: 0.005 = 0.5%)
         From PLEIADES measurements
-    background_roi : ROI/tuple or a sequence of them, optional
+    background_roi : ROI/MaskROI/tuple or a sequence of them, optional
         Sample-free background region(s) — an :class:`~neunorm.data_models.roi.ROI` (or a bare
-        ``(x0, y0, x1, y1)`` tuple, exclusive stops), **or a sequence of those which are pooled**
-        (``sum(counts over all ROIs) / sum(pixels)``). When given, each image is normalized by its
-        pooled background mean — a proton-charge proxy for when proton charge is unavailable (e.g.
-        MARS): ``T = (S/mean(S[B])) / (O/mean(O[B]))``. For legacy inclusive extents (a width-``w`` ROI
-        spanning ``w+1`` pixels), use ``ROI(..., inclusive=True)``; see ``apply_background_roi`` for the
-        open-beam-less form. Mutually exclusive with ``proton_charge_sample`` / ``proton_charge_ob``.
-        Uncertainty is propagated first-order (the in-ROI sample/ROI-mean correlation is not
-        corrected). Unless ``background_roi_strict=False``, raises ``ValueError`` if the pooled mean
-        is not strictly positive and finite in every image. Indices are resolved against the passed
-        arrays; if a pipeline crops with ``roi`` first, give ``background_roi`` in the post-crop
-        frame.
+        ``(x0, y0, x1, y1)`` tuple, exclusive stops), an arbitrary-shape
+        :class:`~neunorm.data_models.roi.MaskROI` (selection mask: 1 = pixel in the region), **or a
+        sequence mixing those, which are pooled** (``sum(counts over all regions) / sum(pixels)``).
+        When given, each image is normalized by its pooled background mean — a proton-charge proxy
+        for when proton charge is unavailable (e.g. MARS): ``T = (S/mean(S[B])) / (O/mean(O[B]))``.
+        For legacy inclusive extents (a width-``w`` ROI spanning ``w+1`` pixels), use
+        ``ROI(..., inclusive=True)``; see ``apply_background_roi`` for the open-beam-less form.
+        Mutually exclusive with ``proton_charge_sample`` / ``proton_charge_ob``. Uncertainty is
+        propagated first-order (the in-ROI sample/ROI-mean correlation is not corrected). Unless
+        ``background_roi_strict=False``, raises ``ValueError`` if the pooled mean is not strictly
+        positive and finite in every image. Indices (and mask shapes) are resolved against the
+        passed arrays; if a pipeline crops with ``roi`` first, give ``background_roi`` in the
+        post-crop frame.
     background_roi_strict : bool, optional
         With the default ``True``, a non-positive/non-finite pooled background mean raises
         ``ValueError``. ``False`` skips only that guard and lets zeros propagate through the
@@ -265,7 +345,7 @@ def normalize_transmission(  # noqa: C901
     """
     logger.info("Normalizing transmission: T = Sample / OB")
 
-    roi_list = as_roi_bounds_list(background_roi) if background_roi is not None else None
+    roi_list = as_region_list(background_roi, arg_name="background_roi") if background_roi is not None else None
 
     # Background-ROI flux normalization: when no proton charge is available
     # (e.g. MARS), scale each image by its pooled mean counts in one or more sample-free ROIs so
@@ -429,7 +509,7 @@ def normalize_with_dark(
     sc.DataArray
         Transmission with correctly-propagated variance (no shared-dark double-counting).
     """
-    roi_list = as_roi_bounds_list(background_roi) if background_roi is not None else None
+    roi_list = as_region_list(background_roi, arg_name="background_roi") if background_roi is not None else None
 
     sample_dc = subtract_dark(sample, dark)
     ob_dc = subtract_dark(ob, dark)
@@ -548,7 +628,7 @@ def apply_background_roi(
     sc.DataArray
         ``data`` scaled so its pooled background-ROI mean is 1 per image.
     """
-    roi_list = as_roi_bounds_list(background_roi)
+    roi_list = as_region_list(background_roi, arg_name="background_roi")
     logger.info("Applying sample-only background-ROI flux flattening with ROI(s) {}", roi_list)
     coeff = _pooled_roi_coefficient(data, roi_list, "data", strict=strict)
     coeff_var = sc.variances(coeff) if coeff.variances is not None else None

--- a/src/neunorm/processing/normalizer.py
+++ b/src/neunorm/processing/normalizer.py
@@ -114,6 +114,34 @@ def _mask_region_view(
     return work
 
 
+def _pooled_union_selection(rois_bounds, ny: int, nx: int) -> np.ndarray:
+    """Boolean ``(ny, nx)`` union of every pooled region (rectangles and masks) — each pixel once.
+
+    Collapses an overlapping pooled list to one equivalent selection so shared pixels are counted
+    once. Bounds/shapes are assumed already validated (by ``_pooled_roi_coefficient``).
+    """
+    union = np.zeros((ny, nx), dtype=bool)
+    for region_spec in rois_bounds:
+        if isinstance(region_spec, MaskROI):
+            union |= region_spec.selection
+        else:
+            x0, y0, x1, y1 = region_spec
+            union[y0:y1, x0:x1] = True
+    return union
+
+
+def _pooled_regions_overlap(rois_bounds, ny: int, nx: int) -> bool:
+    """True if any pixel is selected by more than one region in a pooled list (validated bounds)."""
+    coverage = np.zeros((ny, nx), dtype=np.int32)
+    for region_spec in rois_bounds:
+        if isinstance(region_spec, MaskROI):
+            coverage += region_spec.selection
+        else:
+            x0, y0, x1, y1 = region_spec
+            coverage[y0:y1, x0:x1] += 1
+    return bool((coverage > 1).any())
+
+
 def _pooled_roi_coefficient(
     data: sc.DataArray,
     rois_bounds: list,
@@ -169,6 +197,19 @@ def _pooled_roi_coefficient(
         roi_n = _unmasked_count(region)
         n_unmasked = roi_n if n_unmasked is None else n_unmasked + roi_n
 
+    # Overlapping pooled regions double-count shared pixels in the accumulation above — inflating
+    # the pooled mean and, because each shared pixel's variance is then added more than once as if
+    # from independent samples, understating its variance. When the regions actually overlap,
+    # recompute over their UNION (each selected & unmasked pixel exactly once); a non-overlapping
+    # list keeps the per-region accumulation above bit-for-bit. Bounds/shapes are already validated.
+    if len(rois_bounds) > 1:
+        ny, nx = data.sizes["y"], data.sizes["x"]
+        if _pooled_regions_overlap(rois_bounds, ny, nx):
+            union_region = MaskROI(selection=_pooled_union_selection(rois_bounds, ny, nx))
+            region = _mask_region_view(data, union_region, name, region_arg=region_arg)
+            total = sc.sum(region, dim=["x", "y"]).data
+            n_unmasked = _masked_ones_count(region)
+
     coeff = total / n_unmasked
     if strict and (not bool(sc.all(sc.isfinite(coeff)).value) or sc.min(coeff).value <= 0):
         raise ValueError(
@@ -214,6 +255,15 @@ def _roi_dark_mean_covariance(
         for mask in da.masks.values():
             m = mask if m is None else (m | mask)
         return m
+
+    # Collapse an overlapping pooled list to its single union region so a dark pixel shared by
+    # several ROIs is counted once — otherwise the shared-dark covariance (and the n_s / n_o
+    # denominators) double-count it. A non-overlapping list is unchanged. Bounds are already
+    # validated by the _background_roi_means call that precedes this one.
+    if len(rois_bounds) > 1:
+        ny, nx = sample_dc.sizes["y"], sample_dc.sizes["x"]
+        if _pooled_regions_overlap(rois_bounds, ny, nx):
+            rois_bounds = [MaskROI(selection=_pooled_union_selection(rois_bounds, ny, nx))]
 
     n_s = None
     n_o = None

--- a/src/neunorm/processing/normalizer.py
+++ b/src/neunorm/processing/normalizer.py
@@ -559,10 +559,12 @@ def normalize_with_dark(
         Integrated proton charge for the SNS beam correction (see ``normalize_transmission``).
     pc_uncertainty : float, optional
         Relative proton-charge uncertainty (default 0.005).
-    background_roi : tuple[int, int, int, int], optional
+    background_roi : ROI/MaskROI/tuple or a sequence of them, optional
         Background-ROI flux normalization (see ``normalize_transmission``), used instead of proton
-        charge. The shared-dark correction then uses ``k = co/cs`` (ratio of dark-corrected ROI
-        means) in place of the proton-charge ratio, and additionally removes the ROI-mean shared-dark
+        charge. Accepts the same forms as ``normalize_transmission`` — a rectangle, an arbitrary-shape
+        ``MaskROI``, or a pooled sequence mixing them. The shared-dark correction then uses
+        ``k = co/cs`` (ratio of dark-corrected ROI means) in place of the proton-charge ratio, and
+        additionally removes the ROI-mean shared-dark
         covariance term ``2*T^2*Cov(cs,co)/(cs*co)`` (``Cov(cs,co) = Var(mean(D_roi))``) — the
         ROI-mean analog of the pixel-level correction. (The in-ROI pixel/ROI-mean correlation
         remains uncorrected, as documented on ``normalize_transmission``.)

--- a/src/neunorm/processing/roi_clipper.py
+++ b/src/neunorm/processing/roi_clipper.py
@@ -2,37 +2,51 @@
 Function for cropping spatial dimensions to a region of interest (ROI).
 """
 
+import numpy as np
 import scipp as sc
 from loguru import logger
 
-from neunorm.data_models.roi import ROILike, as_roi_bounds
+from neunorm.data_models.roi import MaskROI, RegionLike, as_roi_bounds
 
 
 def apply_roi(
     data: sc.DataArray,
-    roi: ROILike,  # (x0, y0, x1, y1) tuple or an ROI
+    roi: RegionLike,  # (x0, y0, x1, y1) tuple, an ROI, or a MaskROI
 ) -> sc.DataArray:
-    """Crop spatial dimensions to ROI.
+    """Crop spatial dimensions to a region of interest.
 
     Crop to specified ROI: (x0, y0, x1, y1)
     Work with 2D, 3D, and 4D arrays (preserve other dimensions)
     Update coordinate arrays if present
     Validate ROI is within bounds
 
+    Arrays are rectangular, so an arbitrary-shape :class:`~neunorm.data_models.roi.MaskROI` crops
+    to the selection's **bounding box** and attaches the outside-selection pixels as a scipp
+    exclusion mask named ``"outside_roi"``: every downstream mask-aware statistic (background-ROI
+    pooling, air-region correction, mean/sum reductions) then automatically ignores pixels outside
+    the region. Cropping an already-mask-cropped array ORs the exclusions (the selections
+    intersect). The mask is persisted by ``write_hdf5`` (``/masks/outside_roi``) and folded into
+    the merged TIFF ``scitiff-mask``. Rectangular ROIs crop exactly as before, with no mask
+    attached.
+
     Parameters
     ----------
     data : sc.DataArray
         Input data array to be cropped.
-    roi : ROI or tuple[int, int, int, int]
+    roi : ROI, MaskROI, or tuple[int, int, int, int]
         Region of interest as an :class:`~neunorm.data_models.roi.ROI` (e.g.
-        ``ROI(x0=10, y0=20, x1=30, y1=40)`` or ``ROI(x0=10, y0=20, width=20, height=20)``) or a bare
-        ``(x0, y0, x1, y1)`` tuple with exclusive stop indices.
+        ``ROI(x0=10, y0=20, x1=30, y1=40)`` or ``ROI(x0=10, y0=20, width=20, height=20)``), an
+        arbitrary-shape :class:`~neunorm.data_models.roi.MaskROI` (selection mask: 1 = pixel in the
+        region), or a bare ``(x0, y0, x1, y1)`` tuple with exclusive stop indices.
 
     Returns
     -------
     sc.DataArray
-        Cropped data array with updated coordinates.
+        Cropped data array with updated coordinates (and, for a ``MaskROI``, the ``outside_roi``
+        exclusion mask).
     """
+    if isinstance(roi, MaskROI):
+        return _apply_mask_roi(data, roi)
     roi = as_roi_bounds(roi)
 
     logger.info("Applying ROI: {}", roi)
@@ -63,3 +77,32 @@ def apply_roi(
 
     # Crop the DataArray
     return data["x", x_slice]["y", y_slice].copy()  # return a copy so it's not read-only
+
+
+def _apply_mask_roi(data: sc.DataArray, roi: MaskROI) -> sc.DataArray:
+    """Bounding-box crop + ``outside_roi`` exclusion mask for an arbitrary-shape region."""
+    if "x" not in data.dims or "y" not in data.dims:
+        raise ValueError("DataArray must have 'x' and 'y' dimensions for ROI cropping")
+    ny, nx = roi.shape
+    if ny != data.sizes["y"] or nx != data.sizes["x"]:
+        raise ValueError(
+            f"roi MaskROI selection shape (ny={ny}, nx={nx}) does not match data size "
+            f"(y={data.sizes['y']}, x={data.sizes['x']})"
+        )
+    x0, y0, x1, y1 = roi.bounding_box()
+    logger.info(
+        "Applying MaskROI: bbox ({}, {}, {}, {}), {} selected pixels; outside pixels masked as 'outside_roi'",
+        x0,
+        y0,
+        x1,
+        y1,
+        roi.n_selected,
+    )
+    cropped = data["x", x0:x1]["y", y0:y1].copy()
+    outside = sc.array(dims=["y", "x"], values=np.ascontiguousarray(~roi.selection[y0:y1, x0:x1]))
+    if "outside_roi" in cropped.masks:
+        # repeat mask-crop: exclusions OR together (the selections intersect)
+        cropped.masks["outside_roi"] = cropped.masks["outside_roi"] | outside
+    else:
+        cropped.masks["outside_roi"] = outside
+    return cropped

--- a/src/neunorm/processing/roi_clipper.py
+++ b/src/neunorm/processing/roi_clipper.py
@@ -2,51 +2,50 @@
 Function for cropping spatial dimensions to a region of interest (ROI).
 """
 
-import numpy as np
 import scipp as sc
 from loguru import logger
 
-from neunorm.data_models.roi import MaskROI, RegionLike, as_roi_bounds
+from neunorm.data_models.roi import MaskROI, ROILike, as_roi_bounds
 
 
 def apply_roi(
     data: sc.DataArray,
-    roi: RegionLike,  # (x0, y0, x1, y1) tuple, an ROI, or a MaskROI
+    roi: ROILike,  # (x0, y0, x1, y1) tuple or an ROI
 ) -> sc.DataArray:
-    """Crop spatial dimensions to a region of interest.
+    """Crop spatial dimensions to a rectangular region of interest.
 
     Crop to specified ROI: (x0, y0, x1, y1)
     Work with 2D, 3D, and 4D arrays (preserve other dimensions)
     Update coordinate arrays if present
     Validate ROI is within bounds
 
-    Arrays are rectangular, so an arbitrary-shape :class:`~neunorm.data_models.roi.MaskROI` crops
-    to the selection's **bounding box** and attaches the outside-selection pixels as a scipp
-    exclusion mask named ``"outside_roi"``: every downstream mask-aware statistic (background-ROI
-    pooling, air-region correction, mean/sum reductions) then automatically ignores pixels outside
-    the region. Cropping an already-mask-cropped array ORs the exclusions (the selections
-    intersect). The mask is persisted by ``write_hdf5`` (``/masks/outside_roi``) and folded into
-    the merged TIFF ``scitiff-mask``. Rectangular ROIs crop exactly as before, with no mask
-    attached.
+    Cropping always yields a rectangular array, so only a rectangular ROI is accepted here. An
+    arbitrary-shape :class:`~neunorm.data_models.roi.MaskROI` is not a crop region — pass it to the
+    region-statistics operations instead (``background_roi=`` / ``air_roi=`` /
+    :func:`~neunorm.processing.air_region_corrector.apply_air_region_correction` /
+    :func:`~neunorm.processing.normalizer.normalize_transmission`), which average over the selected
+    pixels without resizing the image.
 
     Parameters
     ----------
     data : sc.DataArray
         Input data array to be cropped.
-    roi : ROI, MaskROI, or tuple[int, int, int, int]
+    roi : ROI or tuple[int, int, int, int]
         Region of interest as an :class:`~neunorm.data_models.roi.ROI` (e.g.
-        ``ROI(x0=10, y0=20, x1=30, y1=40)`` or ``ROI(x0=10, y0=20, width=20, height=20)``), an
-        arbitrary-shape :class:`~neunorm.data_models.roi.MaskROI` (selection mask: 1 = pixel in the
-        region), or a bare ``(x0, y0, x1, y1)`` tuple with exclusive stop indices.
+        ``ROI(x0=10, y0=20, x1=30, y1=40)`` or ``ROI(x0=10, y0=20, width=20, height=20)``) or a bare
+        ``(x0, y0, x1, y1)`` tuple with exclusive stop indices.
 
     Returns
     -------
     sc.DataArray
-        Cropped data array with updated coordinates (and, for a ``MaskROI``, the ``outside_roi``
-        exclusion mask).
+        Cropped (rectangular) data array with updated coordinates.
     """
     if isinstance(roi, MaskROI):
-        return _apply_mask_roi(data, roi)
+        raise TypeError(
+            "apply_roi crops to a rectangle and does not accept a MaskROI. Use a MaskROI only with "
+            "the region-statistics APIs (background_roi= / air_roi= / apply_air_region_correction / "
+            "normalize_transmission), which average over the selected pixels without cropping."
+        )
     roi = as_roi_bounds(roi)
 
     logger.info("Applying ROI: {}", roi)
@@ -77,32 +76,3 @@ def apply_roi(
 
     # Crop the DataArray
     return data["x", x_slice]["y", y_slice].copy()  # return a copy so it's not read-only
-
-
-def _apply_mask_roi(data: sc.DataArray, roi: MaskROI) -> sc.DataArray:
-    """Bounding-box crop + ``outside_roi`` exclusion mask for an arbitrary-shape region."""
-    if "x" not in data.dims or "y" not in data.dims:
-        raise ValueError("DataArray must have 'x' and 'y' dimensions for ROI cropping")
-    ny, nx = roi.shape
-    if ny != data.sizes["y"] or nx != data.sizes["x"]:
-        raise ValueError(
-            f"roi MaskROI selection shape (ny={ny}, nx={nx}) does not match data size "
-            f"(y={data.sizes['y']}, x={data.sizes['x']})"
-        )
-    x0, y0, x1, y1 = roi.bounding_box()
-    logger.info(
-        "Applying MaskROI: bbox ({}, {}, {}, {}), {} selected pixels; outside pixels masked as 'outside_roi'",
-        x0,
-        y0,
-        x1,
-        y1,
-        roi.n_selected,
-    )
-    cropped = data["x", x0:x1]["y", y0:y1].copy()
-    outside = sc.array(dims=["y", "x"], values=np.ascontiguousarray(~roi.selection[y0:y1, x0:x1]))
-    if "outside_roi" in cropped.masks:
-        # repeat mask-crop: exclusions OR together (the selections intersect)
-        cropped.masks["outside_roi"] = cropped.masks["outside_roi"] | outside
-    else:
-        cropped.masks["outside_roi"] = outside
-    return cropped

--- a/tests/unit/test_air_region_corrector.py
+++ b/tests/unit/test_air_region_corrector.py
@@ -89,32 +89,32 @@ def test_apply_air_region_correction_invalid_roi():
 
     # Define invalid ROI: only x0 and y0 provided
     roi_invalid = (0, 0)
-    with pytest.raises(ValueError, match="ROI must be a tuple of 4 integers"):
+    with pytest.raises(ValueError, match="air_roi must be a tuple of 4 integers"):
         apply_air_region_correction(data, roi_invalid)
 
     # Define invalid ROI: non-integer values
     roi_invalid = (0.5, 0.5, 4.5, 4.5)
-    with pytest.raises(ValueError, match="ROI must be a tuple of 4 integers"):
+    with pytest.raises(ValueError, match="air_roi must be a tuple of 4 integers"):
         apply_air_region_correction(data, roi_invalid)
 
     # Define invalid ROI: (x0, y0, x1, y1) where x1 <= x0
     roi_invalid = (3, 0, 2, 4)
-    with pytest.raises(ValueError, match="Invalid ROI"):
+    with pytest.raises(ValueError, match="Invalid air_roi"):
         apply_air_region_correction(data, roi_invalid)
 
     # Define invalid ROI: (x0, y0, x1, y1) where y1 <= y0
     roi_invalid = (0, 3, 4, 2)
-    with pytest.raises(ValueError, match="Invalid ROI"):
+    with pytest.raises(ValueError, match="Invalid air_roi"):
         apply_air_region_correction(data, roi_invalid)
 
     # Define invalid ROI: negative coordinates
     roi_invalid = (-1, -1, 4, 4)
-    with pytest.raises(ValueError, match="Invalid ROI"):
+    with pytest.raises(ValueError, match="Invalid air_roi"):
         apply_air_region_correction(data, roi_invalid)
 
     # Define invalid ROI: exceeds data size
     roi_invalid = (0, 0, 6, 6)
-    with pytest.raises(ValueError, match="ROI .* exceeds data size"):
+    with pytest.raises(ValueError, match="air_roi .* exceeds transmission size"):
         apply_air_region_correction(data, roi_invalid)
 
 
@@ -134,5 +134,5 @@ def test_apply_air_region_correction_no_spatial_dims():
     )
 
     roi = (0, 0, 2, 2)  # ROI is irrelevant since there are no spatial dimensions
-    with pytest.raises(ValueError, match="DataArray must have 'x' and 'y' dimensions"):
+    with pytest.raises(ValueError, match="must have 'x' and 'y' dimensions"):
         apply_air_region_correction(data, roi)

--- a/tests/unit/test_mars_ccd.py
+++ b/tests/unit/test_mars_ccd.py
@@ -750,28 +750,18 @@ class TestMarsCCDPipelineFITS:
             stored = json.loads(raw.value if hasattr(raw, "value") else raw)
             assert stored == [{"mask": mask.provenance_summary()}]
 
-    def test_mars_ccd_pipeline_mask_roi_crop_end_to_end(self):
-        """roi=MaskROI crops to the bbox, persists outside_roi to HDF5, and records JSON provenance."""
+    def test_mars_ccd_pipeline_crop_roi_rejects_maskroi(self):
+        """Crop stays rectangle-only: a MaskROI for roi= is rejected (masks are for background_roi=)."""
         from neunorm.data_models.roi import MaskROI
 
         sel = np.zeros((32, 32), dtype=bool)
-        rr, cc = np.ogrid[:32, :32]
-        sel[(rr - 16) ** 2 + (cc - 16) ** 2 <= 64] = True  # disk of radius 8
-        mask = MaskROI(selection=sel)
-        x0, y0, x1, y1 = mask.bounding_box()
+        sel[2:6, 3:9] = True
         with tempfile.NamedTemporaryFile(suffix=".hdf5", delete=True) as f:
-            output_path = Path(f.name)
-            t = run_mars_ccd_pipeline(
-                sample_paths=[self.sample_paths],
-                ob_paths=[self.ob_paths],
-                output_path=output_path,
-                gamma_filter=False,
-                roi=mask,
-            )
-            assert t.shape == (5, y1 - y0, x1 - x0)
-            assert "outside_roi" in t.masks
-            with h5py.File(output_path, "r") as hf:
-                np.testing.assert_array_equal(hf["masks/outside_roi"][()], ~sel[y0:y1, x0:x1])
-                ds = hf["metadata/roi_applied"]
-                stored = json.loads(ds.asstr()[()])
-                assert stored == {"mask": mask.provenance_summary()}
+            with pytest.raises((TypeError, ValueError), match="[Mm]ask"):
+                run_mars_ccd_pipeline(
+                    sample_paths=[self.sample_paths],
+                    ob_paths=[self.ob_paths],
+                    output_path=Path(f.name),
+                    gamma_filter=False,
+                    roi=MaskROI(selection=sel),
+                )

--- a/tests/unit/test_mars_ccd.py
+++ b/tests/unit/test_mars_ccd.py
@@ -678,3 +678,100 @@ class TestMarsCCDPipelineFITS:
                 ds = hf["metadata/background_roi"]
                 assert ds.attrs.get("encoding") != "json"  # native int array, not the JSON backstop
                 np.testing.assert_array_equal(ds[()], [0, 0, 8, 8])
+
+    def test_mars_ccd_pipeline_mask_background_roi_hdf5_end_to_end(self):
+        """A MaskROI background region runs end-to-end; provenance stores the JSON mask summary (#180)."""
+        from neunorm.data_models.roi import MaskROI
+
+        sel = np.zeros((32, 32), dtype=bool)
+        sel[2:6, 3:9] = True
+        sel[20:25, 20:23] = True  # non-contiguous, non-rectangular union
+        mask = MaskROI(selection=sel)
+        with tempfile.NamedTemporaryFile(suffix=".hdf5", delete=True) as f:
+            output_path = Path(f.name)
+            t = run_mars_ccd_pipeline(
+                sample_paths=[self.sample_paths],
+                ob_paths=[self.ob_paths],
+                output_path=output_path,
+                gamma_filter=False,
+                background_roi=mask,
+            )
+            # uniform images -> the pooled flux proxy still cancels to T = 1
+            np.testing.assert_allclose(t.values, 1.0, rtol=1e-5)
+            with h5py.File(output_path, "r") as hf:
+                ds = hf["metadata/background_roi"]
+                assert ds.attrs.get("encoding") == "json"
+                stored = json.loads(ds.asstr()[()])
+                assert stored == [{"mask": mask.provenance_summary()}]
+
+    def test_mars_ccd_pipeline_mask_background_roi_pooled_with_rect(self):
+        """Rect + mask pooled in one background_roi list end-to-end; provenance mixes forms."""
+        from neunorm.data_models.roi import ROI, MaskROI
+
+        sel = np.zeros((32, 32), dtype=bool)
+        sel[20:25, 20:23] = True
+        mask = MaskROI(selection=sel)
+        with tempfile.NamedTemporaryFile(suffix=".hdf5", delete=True) as f:
+            output_path = Path(f.name)
+            t = run_mars_ccd_pipeline(
+                sample_paths=[self.sample_paths],
+                ob_paths=[self.ob_paths],
+                output_path=output_path,
+                gamma_filter=False,
+                background_roi=[ROI(x0=0, y0=0, width=8, height=8), mask],
+            )
+            np.testing.assert_allclose(t.values, 1.0, rtol=1e-5)
+            with h5py.File(output_path, "r") as hf:
+                ds = hf["metadata/background_roi"]
+                assert ds.attrs.get("encoding") == "json"
+                assert json.loads(ds.asstr()[()]) == [[0, 0, 8, 8], {"mask": mask.provenance_summary()}]
+
+    def test_mars_ccd_pipeline_mask_background_roi_tiff_output(self):
+        """The mask provenance survives the TIFF writer (dict-in-list, never a bare dict)."""
+        from scitiff.io import load_scitiff
+
+        from neunorm.data_models.roi import MaskROI
+
+        sel = np.zeros((32, 32), dtype=bool)
+        sel[2:6, 3:9] = True
+        mask = MaskROI(selection=sel)
+        with tempfile.NamedTemporaryFile(suffix=".tiff", delete=True) as f:
+            output_path = Path(f.name)
+            t = run_mars_ccd_pipeline(
+                sample_paths=[self.sample_paths],
+                ob_paths=[self.ob_paths],
+                output_path=output_path,
+                gamma_filter=False,
+                background_roi=mask,
+            )
+            np.testing.assert_allclose(t.values, 1.0, rtol=1e-5)
+            dg = load_scitiff(output_path)
+            raw = dg["extra"]["background_roi"]
+            stored = json.loads(raw.value if hasattr(raw, "value") else raw)
+            assert stored == [{"mask": mask.provenance_summary()}]
+
+    def test_mars_ccd_pipeline_mask_roi_crop_end_to_end(self):
+        """roi=MaskROI crops to the bbox, persists outside_roi to HDF5, and records JSON provenance."""
+        from neunorm.data_models.roi import MaskROI
+
+        sel = np.zeros((32, 32), dtype=bool)
+        rr, cc = np.ogrid[:32, :32]
+        sel[(rr - 16) ** 2 + (cc - 16) ** 2 <= 64] = True  # disk of radius 8
+        mask = MaskROI(selection=sel)
+        x0, y0, x1, y1 = mask.bounding_box()
+        with tempfile.NamedTemporaryFile(suffix=".hdf5", delete=True) as f:
+            output_path = Path(f.name)
+            t = run_mars_ccd_pipeline(
+                sample_paths=[self.sample_paths],
+                ob_paths=[self.ob_paths],
+                output_path=output_path,
+                gamma_filter=False,
+                roi=mask,
+            )
+            assert t.shape == (5, y1 - y0, x1 - x0)
+            assert "outside_roi" in t.masks
+            with h5py.File(output_path, "r") as hf:
+                np.testing.assert_array_equal(hf["masks/outside_roi"][()], ~sel[y0:y1, x0:x1])
+                ds = hf["metadata/roi_applied"]
+                stored = json.loads(ds.asstr()[()])
+                assert stored == {"mask": mask.provenance_summary()}

--- a/tests/unit/test_mask_roi.py
+++ b/tests/unit/test_mask_roi.py
@@ -496,7 +496,7 @@ class TestAirRegionUnified:
         np.testing.assert_allclose(out.values, t.values / coeff[:, None, None], rtol=1e-12)
 
 
-class TestApplyRoiMask:
+class TestApplyRoiCrop:
     def test_rect_crop_unchanged(self):
         from neunorm.processing.roi_clipper import apply_roi
 
@@ -505,72 +505,85 @@ class TestApplyRoiMask:
         assert out.sizes["x"] == 3 and out.sizes["y"] == 2
         assert len(out.masks) == 0
 
-    def test_mask_crop_bbox_plus_outside_roi(self):
+    def test_crop_rejects_maskroi(self):
+        """Crop is rectangle-only; a MaskROI must be routed to the region-statistics APIs (#180)."""
         from neunorm.processing.roi_clipper import apply_roi
 
-        s = _stack(28)
-        sel = _cross_selection()
-        m = MaskROI(selection=sel)
-        out = apply_roi(s, m)
-        x0, y0, x1, y1 = m.bounding_box()
-        assert out.sizes["x"] == x1 - x0 and out.sizes["y"] == y1 - y0
-        assert "outside_roi" in out.masks
-        np.testing.assert_array_equal(out.masks["outside_roi"].values, ~sel[y0:y1, x0:x1])
-        np.testing.assert_allclose(out.values, s.values[:, y0:y1, x0:x1], rtol=0)
-
-    def test_mask_crop_shape_mismatch_raises(self):
-        from neunorm.processing.roi_clipper import apply_roi
-
-        with pytest.raises(ValueError, match="does not match"):
-            apply_roi(_stack(29), MaskROI(selection=np.ones((3, 3), dtype=bool)))
-
-    def test_repeat_mask_crop_ors_exclusions(self):
-        from neunorm.processing.roi_clipper import apply_roi
-
-        s = _stack(30)
-        sel1 = _cross_selection()
-        out1 = apply_roi(s, MaskROI(selection=sel1))
-        # second mask in the CROPPED frame: keep only the center row of the bbox
-        sel2 = np.zeros((out1.sizes["y"], out1.sizes["x"]), dtype=bool)
-        sel2[1, :] = True
-        out2 = apply_roi(out1, MaskROI(selection=sel2))
-        # exclusion = outside(sel1 bbox slice, re-cropped) OR outside(sel2 within its bbox)
-        assert "outside_roi" in out2.masks
-        # every pixel kept by out2 must have been kept by BOTH selections
-        kept = ~out2.masks["outside_roi"].values
-        x0, y0, x1, y1 = MaskROI(selection=sel1).bounding_box()
-        sel1_crop = sel1[y0:y1, x0:x1]
-        bx0, by0, bx1, by1 = MaskROI(selection=sel2).bounding_box()
-        assert (kept <= (sel1_crop[by0:by1, bx0:bx1] & sel2[by0:by1, bx0:bx1])).all()
-
-    def test_downstream_stats_exclude_outside_pixels(self):
-        """After a mask crop, a rect background_roi is automatically mask-aware."""
-        from neunorm.processing.normalizer import apply_background_roi
-        from neunorm.processing.roi_clipper import apply_roi
-
-        s = _stack(31)
-        sel = _cross_selection()
-        cropped = apply_roi(s, MaskROI(selection=sel))
-        out = apply_background_roi(cropped, (0, 0, cropped.sizes["x"], cropped.sizes["y"]))
-        x0, y0, x1, y1 = MaskROI(selection=sel).bounding_box()
-        sel_crop = sel[y0:y1, x0:x1]
-        pooled = s.values[:, y0:y1, x0:x1][:, sel_crop].sum(axis=1) / sel_crop.sum()
-        np.testing.assert_allclose(out.values, s.values[:, y0:y1, x0:x1] / pooled[:, None, None], rtol=1e-12)
+        with pytest.raises(TypeError, match="does not accept a MaskROI"):
+            apply_roi(_stack(28), MaskROI(selection=_cross_selection()))
 
 
-class TestHdf5OutsideRoi:
-    def test_outside_roi_mask_persisted(self, tmp_path):
-        import h5py
+class TestPooledOverlapDedup:
+    """Overlapping pooled regions count each shared pixel once — correct mean AND variance (F3)."""
 
-        from neunorm.exporters.hdf5_writer import write_hdf5
-        from neunorm.processing.roi_clipper import apply_roi
+    def _frame(self):
+        vals = np.arange(1, 49, dtype="float64").reshape(6, 8)
+        return sc.DataArray(sc.array(dims=["y", "x"], values=vals.copy(), variances=vals.copy(), unit="counts"))
 
-        s = _stack(32)
-        sel = _cross_selection()
-        cropped = apply_roi(s, MaskROI(selection=sel))
-        path = tmp_path / "out.h5"
-        write_hdf5(path, cropped)
-        with h5py.File(path, "r") as f:
-            assert "masks/outside_roi" in f
-            x0, y0, x1, y1 = MaskROI(selection=sel).bounding_box()
-            np.testing.assert_array_equal(f["masks/outside_roi"][()], ~sel[y0:y1, x0:x1])
+    def _union_oracle(self, regions, ny=6, nx=8):
+        vals = np.arange(1, 49, dtype="float64").reshape(ny, nx)
+        union = np.zeros((ny, nx), dtype=bool)
+        for r in regions:
+            if isinstance(r, MaskROI):
+                union |= r.selection
+            else:
+                x0, y0, x1, y1 = r
+                union[y0:y1, x0:x1] = True
+        v = vals[union]
+        n = v.size
+        return v.sum() / n, v.sum() / n**2  # mean, Var(mean) with variances == values
+
+    def test_overlapping_rects_dedup_to_union(self):
+        from neunorm.processing.normalizer import _pooled_roi_coefficient
+
+        rois = [(0, 0, 5, 4), (3, 2, 8, 6)]  # overlap on x 3-4, y 2-3
+        coeff = _pooled_roi_coefficient(self._frame(), rois, "data", strict=True)
+        mean, var = self._union_oracle(rois)
+        np.testing.assert_allclose(coeff.value, mean, rtol=1e-12)
+        np.testing.assert_allclose(coeff.variance, var, rtol=1e-12)
+
+    def test_overlapping_rect_and_mask_dedup_to_union(self):
+        from neunorm.processing.normalizer import _pooled_roi_coefficient
+
+        sel = np.zeros((6, 8), dtype=bool)
+        sel[1:5, 2:6] = True
+        rois = [(0, 0, 4, 3), MaskROI(selection=sel)]  # rect and mask share pixels
+        coeff = _pooled_roi_coefficient(self._frame(), rois, "data", strict=True)
+        mean, var = self._union_oracle(rois)
+        np.testing.assert_allclose(coeff.value, mean, rtol=1e-12)
+        np.testing.assert_allclose(coeff.variance, var, rtol=1e-12)
+
+    def test_duplicate_region_equals_single_not_halved(self):
+        """Listing a region twice must equal listing it once — the old code halved the variance."""
+        from neunorm.processing.normalizer import _pooled_roi_coefficient
+
+        rect = (1, 1, 5, 4)
+        single = _pooled_roi_coefficient(self._frame(), [rect], "data", strict=True)
+        dup = _pooled_roi_coefficient(self._frame(), [rect, rect], "data", strict=True)
+        np.testing.assert_allclose(dup.value, single.value, rtol=1e-12)
+        np.testing.assert_allclose(dup.variance, single.variance, rtol=1e-12)
+
+    def test_disjoint_pooled_keeps_fast_path(self):
+        """Non-overlapping pooled regions are unchanged (values AND variances) — union oracle."""
+        from neunorm.processing.normalizer import _pooled_roi_coefficient
+
+        rois = [(0, 0, 2, 2), (5, 4, 8, 6)]
+        coeff = _pooled_roi_coefficient(self._frame(), rois, "data", strict=True)
+        mean, var = self._union_oracle(rois)
+        np.testing.assert_allclose(coeff.value, mean, rtol=1e-12)
+        np.testing.assert_allclose(coeff.variance, var, rtol=1e-12)
+
+    def test_covariance_duplicate_region_equals_single(self):
+        """Shared-dark covariance must also dedup: [R, R] == [R] (was double-counted)."""
+        from neunorm.processing.dark_corrector import subtract_dark
+        from neunorm.processing.normalizer import _roi_dark_mean_covariance
+
+        s, o = _stack(40), _stack(41, base=200)
+        d = _stack(42, base=5)["N_image", 0].copy()
+        s_dc, o_dc = subtract_dark(s, d), subtract_dark(o, d)
+        rect = (2, 1, 6, 4)
+        cov1 = _roi_dark_mean_covariance(s_dc, o_dc, d, [rect])
+        cov2 = _roi_dark_mean_covariance(s_dc, o_dc, d, [rect, rect])
+        v1 = np.atleast_1d(sc.values(cov1).values)
+        v2 = np.broadcast_to(np.atleast_1d(sc.values(cov2).values), v1.shape)
+        np.testing.assert_allclose(v2, v1, rtol=1e-12)

--- a/tests/unit/test_mask_roi.py
+++ b/tests/unit/test_mask_roi.py
@@ -123,6 +123,19 @@ class TestMaskROIPydantic:
         assert json.loads(json.dumps(s)) == s
         assert s["shape"] == [6, 8] and s["n_selected"] == 6 and s["source"] == "array"
 
+    def test_non_dict_mapping_input_is_canonicalized(self):
+        """Pydantic accepts any Mapping (e.g. UserDict), not just dict — it must canonicalize too."""
+        from collections import UserDict
+
+        sel = _block_selection().astype(np.int16) * 2  # non-bool; would miscount if not canonicalized
+        m = MaskROI.model_validate(UserDict(selection=sel))
+        assert m.selection.dtype == np.bool_  # coerced to bool
+        assert not m.selection.flags.writeable  # owned read-only buffer
+        assert m.n_selected == 6  # counts True pixels, not the summed int16 values
+        # an empty selection supplied via a Mapping must still be rejected at construction
+        with pytest.raises(Exception):
+            MaskROI.model_validate(UserDict(selection=np.zeros((6, 8), dtype=bool)))
+
 
 class TestMaskROIFromFile:
     @pytest.mark.parametrize("suffix", [".png", ".tiff"])
@@ -587,3 +600,40 @@ class TestPooledOverlapDedup:
         v1 = np.atleast_1d(sc.values(cov1).values)
         v2 = np.broadcast_to(np.atleast_1d(sc.values(cov2).values), v1.shape)
         np.testing.assert_allclose(v2, v1, rtol=1e-12)
+
+    def test_disjoint_and_single_do_not_take_union_path(self, monkeypatch):
+        """Pin the fast-path guard directly (a union-oracle match alone can't catch 'always union')."""
+        import neunorm.processing.normalizer as nz
+
+        def _boom(*_a, **_k):
+            raise AssertionError("union recompute taken for a non-overlapping pool")
+
+        monkeypatch.setattr(nz, "_pooled_union_selection", _boom)
+        nz._pooled_roi_coefficient(self._frame(), [(1, 1, 4, 4)], "data", strict=True)  # single
+        nz._pooled_roi_coefficient(self._frame(), [(0, 0, 2, 2), (5, 4, 8, 6)], "data", strict=True)  # disjoint
+        monkeypatch.undo()
+        # and the guard positively fires only on real overlap
+        assert nz._pooled_regions_overlap([(0, 0, 5, 4), (3, 2, 8, 6)], 6, 8) is True
+        assert nz._pooled_regions_overlap([(0, 0, 2, 2), (5, 4, 8, 6)], 6, 8) is False
+
+    def test_covariance_partial_overlap_matches_union_oracle(self):
+        """Partial (non-duplicate) overlap: covariance counts each shared dark pixel once (union)."""
+        from neunorm.processing.dark_corrector import subtract_dark
+        from neunorm.processing.normalizer import _roi_dark_mean_covariance
+
+        s, o = _stack(50), _stack(51, base=200)
+        d = _stack(52, base=5)["N_image", 0].copy()
+        dead = np.zeros((6, 8), dtype=bool)
+        dead[2, 3] = True  # a dead sample pixel inside the overlap
+        s.masks["dead_pixels"] = sc.array(dims=["y", "x"], values=dead)
+        s_dc, o_dc = subtract_dark(s, d), subtract_dark(o, d)
+        rois = [(0, 0, 5, 4), (3, 2, 8, 6)]  # partial overlap on x 3-4, y 2-3
+        cov = _roi_dark_mean_covariance(s_dc, o_dc, d, rois)
+        union = np.zeros((6, 8), dtype=bool)
+        for x0, y0, x1, y1 in rois:
+            union[y0:y1, x0:x1] = True
+        keep_s, keep_o = union & ~dead, union  # A (sample), B (ob)
+        n_s, n_o = keep_s.sum(), keep_o.sum()
+        expected = d.variances[keep_s & keep_o].sum() / (n_s * n_o)
+        got = np.atleast_1d(sc.values(cov).values)
+        np.testing.assert_allclose(got, expected, rtol=1e-12)

--- a/tests/unit/test_mask_roi.py
+++ b/tests/unit/test_mask_roi.py
@@ -1,0 +1,240 @@
+"""Unit tests for MaskROI (arbitrary-shape selection regions) and the unified region dispatch.
+
+Covers construction/canonicalization from every accepted input form, pydantic model safety
+(eq/hash/serialize on an array-bearing frozen model), the ``as_region_list`` grammar (including
+the collision cases pinned by design: a bare 4-int sequence is always a rectangle, raw arrays and
+paths are rejected), and the hardening of the legacy rect-only helpers.
+"""
+
+from collections import deque
+from pathlib import Path
+
+import numpy as np
+import pytest
+import scipp as sc
+
+from neunorm.data_models import MaskROI, as_region_list
+from neunorm.data_models.roi import ROI, as_roi_bounds
+from neunorm.processing.normalizer import as_roi_bounds_list
+
+
+def _block_selection(ny=6, nx=8, y=slice(1, 3), x=slice(2, 5), dtype=bool):
+    sel = np.zeros((ny, nx), dtype=dtype)
+    sel[y, x] = 1
+    return sel
+
+
+class TestMaskROIConstruction:
+    def test_bool_array(self):
+        m = MaskROI(selection=_block_selection())
+        assert m.n_selected == 6
+        assert m.shape == (6, 8)
+        assert m.selection.dtype == np.bool_
+
+    def test_nonzero_thresholding_int_and_float(self):
+        for dtype, value in [(np.int32, 7), (np.float64, 0.5)]:
+            sel = np.zeros((6, 8), dtype=dtype)
+            sel[1:3, 2:5] = value
+            m = MaskROI(selection=sel)
+            assert m.n_selected == 6, dtype
+
+    def test_canonical_buffer_is_readonly_and_isolated(self):
+        sel = _block_selection()
+        m = MaskROI(selection=sel)
+        assert not m.selection.flags.writeable
+        with pytest.raises(ValueError):
+            m.selection[0, 0] = True
+        # mutating the caller's array must not change the region
+        n_before = m.n_selected
+        sel[:, :] = True
+        assert m.n_selected == n_before
+
+    def test_scipp_variable_yx_and_xy_are_equal(self):
+        sel = _block_selection()
+        m_np = MaskROI(selection=sel)
+        m_yx = MaskROI(selection=sc.array(dims=["y", "x"], values=sel))
+        m_xy = MaskROI(selection=sc.array(dims=["x", "y"], values=sel.T))
+        assert m_np == m_yx == m_xy
+        assert m_np.sha256() == m_xy.sha256()
+
+    def test_scipp_variable_wrong_dims_raises(self):
+        with pytest.raises(ValueError, match="dims"):
+            MaskROI(selection=sc.array(dims=["row", "col"], values=_block_selection()))
+
+    def test_numpy_dims_xy_transposes(self):
+        sel = _block_selection()
+        assert MaskROI(selection=sel.T, dims=("x", "y")) == MaskROI(selection=sel)
+
+    def test_invalid_dims_kwarg_raises(self):
+        with pytest.raises(ValueError, match="dims"):
+            MaskROI(selection=_block_selection(), dims=("t", "x"))
+
+    def test_non_2d_raises(self):
+        with pytest.raises(ValueError, match="2D"):
+            MaskROI(selection=np.ones(8, dtype=bool))
+        with pytest.raises(ValueError, match="2D"):
+            MaskROI(selection=np.ones((2, 3, 4), dtype=bool))
+
+    def test_empty_selection_raises_structurally(self):
+        with pytest.raises(ValueError, match="at least one pixel"):
+            MaskROI(selection=np.zeros((6, 8), dtype=bool))
+
+    def test_bounding_box_exclusive_stops(self):
+        m = MaskROI(selection=_block_selection(y=slice(1, 3), x=slice(2, 5)))
+        assert m.bounding_box() == (2, 1, 5, 3)
+
+    def test_non_rectangular_selection(self):
+        sel = np.zeros((8, 8), dtype=bool)
+        rr, cc = np.ogrid[:8, :8]
+        disk = (rr - 4) ** 2 + (cc - 4) ** 2 <= 4
+        sel[disk] = True
+        m = MaskROI(selection=sel)
+        assert m.n_selected == int(disk.sum())
+
+
+class TestMaskROIPydantic:
+    def test_eq_and_hash(self):
+        a = MaskROI(selection=_block_selection())
+        b = MaskROI(selection=_block_selection().astype(np.int8) * 3)  # same region, different input form
+        c = MaskROI(selection=_block_selection(x=slice(0, 2)))
+        assert a == b and hash(a) == hash(b)
+        assert a != c
+        assert a != "not a region"
+
+    def test_frozen(self):
+        m = MaskROI(selection=_block_selection())
+        with pytest.raises(Exception):  # pydantic frozen -> ValidationError
+            m.source = "changed"
+
+    def test_model_dump_json_is_summary(self):
+        m = MaskROI(selection=_block_selection())
+        dumped = m.model_dump_json()
+        assert '"n_selected":6' in dumped.replace(" ", "")
+        assert '"sha256"' in dumped
+
+    def test_repr(self):
+        r = repr(MaskROI(selection=_block_selection()))
+        assert "ny=6" in r and "nx=8" in r and "n_selected=6" in r
+
+    def test_provenance_summary_json_safe(self):
+        import json
+
+        s = MaskROI(selection=_block_selection()).provenance_summary()
+        assert json.loads(json.dumps(s)) == s
+        assert s["shape"] == [6, 8] and s["n_selected"] == 6 and s["source"] == "array"
+
+
+class TestMaskROIFromFile:
+    @pytest.mark.parametrize("suffix", [".png", ".tiff"])
+    def test_grayscale_roundtrip(self, tmp_path, suffix):
+        from PIL import Image
+
+        sel = _block_selection(dtype=np.uint8) * 255
+        path = tmp_path / f"mask{suffix}"
+        Image.fromarray(sel).save(path)
+        m = MaskROI.from_file(path)
+        assert m == MaskROI(selection=sel)
+        assert m.source == str(path)
+
+    def test_rgb_any_channel_selects(self, tmp_path):
+        from PIL import Image
+
+        rgb = np.zeros((6, 8, 3), dtype=np.uint8)
+        rgb[1:3, 2:5, 0] = 255  # red channel only
+        path = tmp_path / "mask_rgb.png"
+        Image.fromarray(rgb).save(path)
+        assert MaskROI.from_file(path) == MaskROI(selection=_block_selection())
+
+
+class TestMaskROIFromDataArrayMask:
+    def _da(self):
+        da = sc.DataArray(sc.ones(sizes={"y": 6, "x": 8}))
+        da.masks["dead"] = sc.array(dims=["y", "x"], values=_block_selection())
+        return da
+
+    def test_invert_false_selects_flagged(self):
+        m = MaskROI.from_dataarray_mask(self._da(), "dead", invert=False)
+        assert m == MaskROI(selection=_block_selection())
+        assert m.source == "dataarray_mask:dead"
+
+    def test_invert_true_selects_kept(self):
+        m = MaskROI.from_dataarray_mask(self._da(), "dead", invert=True)
+        assert m == MaskROI(selection=~_block_selection())
+
+    def test_invert_is_required_keyword(self):
+        with pytest.raises(TypeError):
+            MaskROI.from_dataarray_mask(self._da(), "dead", True)  # noqa: too many positional
+
+    def test_missing_mask_raises(self):
+        with pytest.raises(ValueError, match="no mask named"):
+            MaskROI.from_dataarray_mask(self._da(), "hot", invert=False)
+
+    def test_non_spatial_mask_raises(self):
+        da = self._da()
+        da.masks["frame"] = sc.array(dims=["y"], values=np.zeros(6, dtype=bool))
+        with pytest.raises(ValueError, match="spatial"):
+            MaskROI.from_dataarray_mask(da, "frame", invert=False)
+
+
+class TestAsRegionList:
+    def test_single_forms(self):
+        m = MaskROI(selection=_block_selection())
+        assert as_region_list(m) == [m]
+        assert as_region_list(ROI(x0=1, y0=2, x1=3, y1=4)) == [(1, 2, 3, 4)]
+        assert as_region_list((1, 2, 3, 4)) == [(1, 2, 3, 4)]
+        assert as_region_list([0, 0, 1, 1]) == [(0, 0, 1, 1)]  # bare 4-int is ALWAYS a rectangle
+
+    def test_mixed_pooled_list(self):
+        m = MaskROI(selection=_block_selection())
+        out = as_region_list([ROI(x0=0, y0=0, width=2, height=2), m, (5, 5, 7, 7)])
+        assert out == [(0, 0, 2, 2), m, (5, 5, 7, 7)]
+
+    def test_idempotent_on_own_output(self):
+        m = MaskROI(selection=_block_selection())
+        once = as_region_list([m, (0, 0, 2, 2)])
+        assert as_region_list(once) == once
+
+    def test_numpy_integer_bounds_coerced(self):
+        out = as_region_list(np.array([1, 2, 3, 4]).tolist())
+        assert all(type(v) is int for v in out[0])
+        out2 = as_region_list([np.int64(1), np.int64(2), np.int64(3), np.int64(4)])
+        assert all(type(v) is int for v in out2[0])
+
+    def test_any_sequence_type_accepted(self):
+        assert as_region_list(deque([1, 2, 3, 4])) == [(1, 2, 3, 4)]
+
+    def test_bare_array_and_path_rejected(self):
+        for bad in [np.zeros((6, 8), dtype=bool), "mask.tif", b"mask", Path("mask.tif"), 7]:
+            with pytest.raises(ValueError, match="must be an ROI"):
+                as_region_list(bad)
+
+    def test_empty_list_raises(self):
+        with pytest.raises(ValueError, match="at least one"):
+            as_region_list([])
+
+    def test_malformed_int_sequence_raises(self):
+        with pytest.raises(ValueError, match="4 integers"):
+            as_region_list([1, 2, 3])
+        with pytest.raises(ValueError, match="4 integers"):
+            as_region_list([1, 2, 3, 4, 5])
+
+    def test_arg_name_in_errors(self):
+        with pytest.raises(ValueError, match="air_roi"):
+            as_region_list("nope", arg_name="air_roi")
+
+
+class TestLegacyHelpersHardened:
+    def test_as_roi_bounds_rejects_mask_roi(self):
+        with pytest.raises(ValueError, match="MaskROI"):
+            as_roi_bounds(MaskROI(selection=_block_selection()))
+
+    def test_as_roi_bounds_still_accepts_rects(self):
+        assert as_roi_bounds(ROI(x0=1, y0=2, x1=3, y1=4)) == (1, 2, 3, 4)
+        assert as_roi_bounds((1, 2, 3, 4)) == (1, 2, 3, 4)
+
+    def test_as_roi_bounds_list_rejects_masks_bare_and_in_list(self):
+        m = MaskROI(selection=_block_selection())
+        with pytest.raises(ValueError, match="must be an ROI"):
+            as_roi_bounds_list(m)  # not a Sequence -> legacy rejection path
+        with pytest.raises(ValueError, match="MaskROI"):
+            as_roi_bounds_list([m])  # element path -> hardened as_roi_bounds

--- a/tests/unit/test_mask_roi.py
+++ b/tests/unit/test_mask_roi.py
@@ -238,3 +238,179 @@ class TestLegacyHelpersHardened:
             as_roi_bounds_list(m)  # not a Sequence -> legacy rejection path
         with pytest.raises(ValueError, match="MaskROI"):
             as_roi_bounds_list([m])  # element path -> hardened as_roi_bounds
+
+
+def _stack(seed=42, base=100, n=3, ny=6, nx=8, unit="counts"):
+    rng = np.random.default_rng(seed)
+    v = rng.poisson(base, size=(n, ny, nx)).astype("float64")
+    return sc.DataArray(sc.array(dims=["N_image", "y", "x"], values=v, variances=v.copy(), unit=unit))
+
+
+def _cross_selection(ny=6, nx=8):
+    """Plus-shaped selection that provably differs from its bounding box (corners excluded)."""
+    sel = np.zeros((ny, nx), dtype=bool)
+    sel[2, 3:6] = True
+    sel[1:4, 4] = True
+    return sel
+
+
+class TestPooledCoefficientMask:
+    """The core #180 contract: a rectangle expressed as a MaskROI matches the sliced rect path."""
+
+    def _rect_and_mask(self, ny=6, nx=8):
+        sel = np.zeros((ny, nx), dtype=bool)
+        sel[1:3, 2:5] = True
+        return (2, 1, 5, 3), MaskROI(selection=sel)
+
+    def test_normalize_transmission_rect_as_mask_matches(self):
+        from neunorm.processing.normalizer import normalize_transmission
+
+        s, o = _stack(1), _stack(2, base=200)
+        rect, mask = self._rect_and_mask()
+        t_rect = normalize_transmission(s, o, background_roi=rect)
+        t_mask = normalize_transmission(s, o, background_roi=mask)
+        np.testing.assert_allclose(t_mask.values, t_rect.values, rtol=1e-12)
+        np.testing.assert_allclose(t_mask.variances, t_rect.variances, rtol=1e-12)
+
+    def test_rect_as_mask_matches_with_dead_pixel_masks(self):
+        from neunorm.processing.normalizer import normalize_transmission
+
+        s, o = _stack(3), _stack(4, base=200)
+        dead = np.zeros((6, 8), dtype=bool)
+        dead[1, 2] = dead[2, 4] = True
+        for da in (s, o):
+            da.masks["dead_pixels"] = sc.array(dims=["y", "x"], values=dead)
+        rect, mask = self._rect_and_mask()
+        t_rect = normalize_transmission(s, o, background_roi=rect)
+        t_mask = normalize_transmission(s, o, background_roi=mask)
+        np.testing.assert_allclose(t_mask.values, t_rect.values, rtol=1e-12)
+        np.testing.assert_allclose(t_mask.variances, t_rect.variances, rtol=1e-12)
+
+    def test_normalize_with_dark_rect_as_mask_matches(self):
+        from neunorm.processing.normalizer import normalize_with_dark
+
+        s, o = _stack(5), _stack(6, base=200)
+        d = _stack(7, base=5)["N_image", 0].copy()
+        rect, mask = self._rect_and_mask()
+        t_rect = normalize_with_dark(s, o, d, background_roi=rect)
+        t_mask = normalize_with_dark(s, o, d, background_roi=mask)
+        np.testing.assert_allclose(t_mask.values, t_rect.values, rtol=1e-12)
+        np.testing.assert_allclose(t_mask.variances, t_rect.variances, rtol=1e-12)
+
+    def test_apply_background_roi_mixed_pooling_matches_two_rects(self):
+        from neunorm.processing.normalizer import apply_background_roi
+
+        s = _stack(8)
+        rect2 = (0, 4, 2, 6)
+        sel2 = np.zeros((6, 8), dtype=bool)
+        sel2[4:6, 0:2] = True
+        a_rects = apply_background_roi(s, [(2, 1, 5, 3), rect2])
+        a_mixed = apply_background_roi(s, [(2, 1, 5, 3), MaskROI(selection=sel2)])
+        np.testing.assert_allclose(a_mixed.values, a_rects.values, rtol=1e-12)
+        np.testing.assert_allclose(a_mixed.variances, a_rects.variances, rtol=1e-12)
+
+    def test_non_rectangular_selection_differs_from_bbox_and_matches_manual(self):
+        from neunorm.processing.normalizer import apply_background_roi
+
+        s = _stack(9)
+        sel = _cross_selection()
+        m = MaskROI(selection=sel)
+        out = apply_background_roi(s, m)
+        bbox_out = apply_background_roi(s, m.bounding_box())
+        assert not np.allclose(out.values, bbox_out.values)  # corners excluded -> different mean
+        # manual pooled mean over the selected pixels, per image
+        coeff = s.values[:, sel].sum(axis=1) / sel.sum()
+        expected = s.values / coeff[:, None, None]
+        np.testing.assert_allclose(out.values, expected, rtol=1e-12)
+
+    def test_mask_selection_pixels_all_dead_strict_raises_nonstrict_propagates(self):
+        from neunorm.processing.normalizer import apply_background_roi
+
+        s = _stack(10)
+        sel = _cross_selection()
+        s.masks["dead_pixels"] = sc.array(dims=["y", "x"], values=sel.copy())  # kill exactly the selection
+        with pytest.raises(ValueError, match="strictly positive"):
+            apply_background_roi(s, MaskROI(selection=sel))
+        out = apply_background_roi(s, MaskROI(selection=sel), strict=False)
+        assert not np.isfinite(out.values).any()  # 0/0 propagates, legacy rect parity
+
+    def test_nan_outside_selection_does_not_leak(self):
+        """Pixels outside the selection may hold NaN/inf without affecting the coefficient."""
+        from neunorm.processing.normalizer import apply_background_roi
+
+        s = _stack(11)
+        sel = _cross_selection()
+        ref = apply_background_roi(s, MaskROI(selection=sel)).copy()
+        vals = s.values.copy()
+        vals[:, 0, 0] = np.nan  # outside the selection AND outside its bbox
+        vals[:, 1, 5] = np.inf  # inside the bbox, outside the selection
+        s2 = sc.DataArray(
+            sc.array(dims=["N_image", "y", "x"], values=vals, variances=s.variances.copy(), unit="counts")
+        )
+        out = apply_background_roi(s2, MaskROI(selection=sel))
+        finite = np.isfinite(out.values)
+        np.testing.assert_allclose(out.values[finite], ref.values[finite], rtol=1e-12)
+        # the coefficient itself was unaffected: all selected pixels stay finite
+        assert np.isfinite(out.values[:, sel]).all()
+
+    def test_shape_mismatch_raises_valueerror(self):
+        from neunorm.processing.normalizer import normalize_transmission
+
+        s, o = _stack(12), _stack(13, base=200)
+        with pytest.raises(ValueError, match="does not match"):
+            normalize_transmission(s, o, background_roi=MaskROI(selection=np.ones((4, 4), dtype=bool)))
+
+    def test_user_mask_named_region_sel_not_clobbered(self):
+        from neunorm.processing.normalizer import apply_background_roi
+
+        s = _stack(14)
+        # a user mask that would collide with the internal name: masks one selected pixel
+        user = np.zeros((6, 8), dtype=bool)
+        user[2, 4] = True
+        s.masks["_region_sel"] = sc.array(dims=["y", "x"], values=user)
+        sel = _cross_selection()
+        out = apply_background_roi(s, MaskROI(selection=sel))
+        # expected: pooled mean over selected & ~user (the user mask must stay in force)
+        keep = sel & ~user
+        coeff = s.values[:, keep].sum(axis=1) / keep.sum()
+        np.testing.assert_allclose(out.values, s.values / coeff[:, None, None], rtol=1e-12)
+
+
+class TestSharedDarkCovarianceMask:
+    def test_covariance_matches_hand_computed_oracle(self):
+        """Cov = sum Var(D) over (sel & unmasked_s & unmasked_o) / (n_s * n_o), per design."""
+        from neunorm.processing.dark_corrector import subtract_dark
+        from neunorm.processing.normalizer import _roi_dark_mean_covariance
+
+        s, o = _stack(15), _stack(16, base=200)
+        d = _stack(17, base=5)["N_image", 0].copy()
+        dead_s = np.zeros((6, 8), dtype=bool)
+        dead_s[2, 4] = True
+        s.masks["dead_pixels"] = sc.array(dims=["y", "x"], values=dead_s)
+        sel = _cross_selection()
+        s_dc, o_dc = subtract_dark(s, d), subtract_dark(o, d)
+        cov = _roi_dark_mean_covariance(s_dc, o_dc, d, [MaskROI(selection=sel)])
+        keep_s = sel & ~dead_s
+        keep_o = sel
+        n_s, n_o = keep_s.sum(), keep_o.sum()
+        expected = d.variances[keep_s & keep_o].sum() / (n_s * n_o)
+        np.testing.assert_allclose(float(sc.values(cov).min().value), expected, rtol=1e-12)
+        np.testing.assert_allclose(float(sc.values(cov).max().value), expected, rtol=1e-12)
+
+    def test_covariance_rect_as_mask_matches_rect(self):
+        from neunorm.processing.dark_corrector import subtract_dark
+        from neunorm.processing.normalizer import _roi_dark_mean_covariance
+
+        s, o = _stack(18), _stack(19, base=200)
+        d = _stack(20, base=5)["N_image", 0].copy()
+        s_dc, o_dc = subtract_dark(s, d), subtract_dark(o, d)
+        sel = np.zeros((6, 8), dtype=bool)
+        sel[1:3, 2:5] = True
+        cov_rect = _roi_dark_mean_covariance(s_dc, o_dc, d, [(2, 1, 5, 3)])
+        cov_mask = _roi_dark_mean_covariance(s_dc, o_dc, d, [MaskROI(selection=sel)])
+        # The rect path returns a constant per-spectral vector, the mask fast path a scalar — both
+        # broadcast identically downstream (normalize_with_dark equivalence pins that end to end);
+        # compare the broadcast values.
+        rect_vals = np.atleast_1d(sc.values(cov_rect).values)
+        mask_vals = np.broadcast_to(np.atleast_1d(sc.values(cov_mask).values), rect_vals.shape)
+        np.testing.assert_allclose(mask_vals, rect_vals, rtol=1e-12)

--- a/tests/unit/test_mask_roi.py
+++ b/tests/unit/test_mask_roi.py
@@ -38,6 +38,39 @@ class TestMaskROIConstruction:
             m = MaskROI(selection=sel)
             assert m.n_selected == 6, dtype
 
+    def test_non_finite_float_selection_treated_as_unselected(self):
+        """A NaN/inf in a float mask is dropped from the selection — not silently selected
+        (``NaN != 0`` is True), and without halting the run over one bad pixel.
+
+        Guards a real defect: a no-data sentinel (NaN/inf) in a float TIFF/array must not join the
+        region (it would corrupt the region mean and propagated variance). The run continues over
+        the valid pixels; only the non-finite pixels are excluded.
+        """
+        for bad in (np.nan, np.inf, -np.inf):
+            sel = np.zeros((6, 8), dtype=np.float64)
+            sel[1:3, 2:5] = 1.0  # 6 genuine finite-nonzero pixels
+            sel[0, 0] = bad
+            m = MaskROI(selection=sel)
+            assert m.n_selected == 6, bad  # the non-finite pixel is NOT selected
+            assert not bool(m.selection[0, 0]), bad
+            assert m.selection[1:3, 2:5].all(), bad
+        # the scipp-Variable input path is handled identically
+        sel = np.zeros((6, 8), dtype=np.float64)
+        sel[1:3, 2:5] = 1.0
+        sel[0, 0] = np.nan
+        m = MaskROI(selection=sc.array(dims=["y", "x"], values=sel))
+        assert m.n_selected == 6
+        assert not bool(m.selection[0, 0])
+
+    def test_all_nonfinite_selection_raises_as_empty(self):
+        """A float mask whose only nonzero entries are non-finite selects nothing after they are
+        dropped -> the structural empty-mask error (never a spurious all-NaN region)."""
+        sel = np.zeros((4, 4), dtype=np.float64)
+        sel[0, 0] = np.nan
+        sel[1, 1] = np.inf
+        with pytest.raises(ValueError, match="at least one pixel"):
+            MaskROI(selection=sel)
+
     def test_canonical_buffer_is_readonly_and_isolated(self):
         sel = _block_selection()
         m = MaskROI(selection=sel)

--- a/tests/unit/test_mask_roi.py
+++ b/tests/unit/test_mask_roi.py
@@ -566,6 +566,20 @@ class TestPooledOverlapDedup:
         np.testing.assert_allclose(coeff.value, mean, rtol=1e-12)
         np.testing.assert_allclose(coeff.variance, var, rtol=1e-12)
 
+    def test_overlapping_two_masks_dedup_to_union(self):
+        """Two overlapping MaskROIs (the per-pixel coverage branch) also dedup to their union."""
+        from neunorm.processing.normalizer import _pooled_roi_coefficient
+
+        sel_a = np.zeros((6, 8), dtype=bool)
+        sel_a[1:4, 1:5] = True
+        sel_b = np.zeros((6, 8), dtype=bool)
+        sel_b[2:5, 3:7] = True  # overlaps sel_a on rows 2-3, cols 3-4
+        rois = [MaskROI(selection=sel_a), MaskROI(selection=sel_b)]
+        coeff = _pooled_roi_coefficient(self._frame(), rois, "data", strict=True)
+        mean, var = self._union_oracle(rois)
+        np.testing.assert_allclose(coeff.value, mean, rtol=1e-12)
+        np.testing.assert_allclose(coeff.variance, var, rtol=1e-12)
+
     def test_duplicate_region_equals_single_not_halved(self):
         """Listing a region twice must equal listing it once — the old code halved the variance."""
         from neunorm.processing.normalizer import _pooled_roi_coefficient

--- a/tests/unit/test_mask_roi.py
+++ b/tests/unit/test_mask_roi.py
@@ -414,3 +414,163 @@ class TestSharedDarkCovarianceMask:
         rect_vals = np.atleast_1d(sc.values(cov_rect).values)
         mask_vals = np.broadcast_to(np.atleast_1d(sc.values(cov_mask).values), rect_vals.shape)
         np.testing.assert_allclose(mask_vals, rect_vals, rtol=1e-12)
+
+
+class TestAirRegionUnified:
+    def test_rect_parity_with_old_sequential_math_unmasked(self):
+        """On unmasked data the pooled mean equals the old sc.mean-based path to allclose."""
+        from neunorm.processing.air_region_corrector import apply_air_region_correction
+
+        t = _stack(21, base=50, unit="dimensionless")
+        rect = (2, 1, 5, 3)
+        out = apply_air_region_correction(t, rect)
+        # old math, computed manually: T / mean(T[air]); var = corrected^2*(Var(T)/T^2 + Var(m)/m^2)
+        x0, y0, x1, y1 = rect
+        air = t.values[:, y0:y1, x0:x1]
+        mean_air = air.mean(axis=(1, 2))
+        var_mean = t.variances[:, y0:y1, x0:x1].sum(axis=(1, 2)) / air[0].size ** 2
+        expected = t.values / mean_air[:, None, None]
+        exp_var = expected**2 * (t.variances / t.values**2 + (var_mean / mean_air**2)[:, None, None])
+        np.testing.assert_allclose(out.values, expected, rtol=1e-12)
+        np.testing.assert_allclose(out.variances, exp_var, rtol=1e-12)
+
+    def test_t_zero_pixel_variance_now_finite(self):
+        """Old formula gave 0*inf = NaN variance at T==0 pixels; pooled path stays finite."""
+        from neunorm.processing.air_region_corrector import apply_air_region_correction
+
+        t = _stack(22, base=50, unit="dimensionless")
+        vals = t.values.copy()
+        vals[:, 0, 0] = 0.0  # outside the air region
+        t2 = sc.DataArray(
+            sc.array(dims=["N_image", "y", "x"], values=vals, variances=t.variances.copy(), unit="dimensionless")
+        )
+        out = apply_air_region_correction(t2, (2, 1, 5, 3))
+        assert np.isfinite(out.variances[:, 0, 0]).all()
+
+    def test_mask_region_true_region_mean_under_dead_pixels(self):
+        """With a dead pixel in the air region the pooled mean is the true region mean."""
+        from neunorm.processing.air_region_corrector import apply_air_region_correction
+
+        t = _stack(23, base=50, unit="dimensionless")
+        dead = np.zeros((6, 8), dtype=bool)
+        dead[2, 4] = True
+        t.masks["dead_pixels"] = sc.array(dims=["y", "x"], values=dead)
+        sel = _cross_selection()
+        out = apply_air_region_correction(t, MaskROI(selection=sel))
+        keep = sel & ~dead
+        coeff = t.values[:, keep].sum(axis=1) / keep.sum()
+        np.testing.assert_allclose(out.values, t.values / coeff[:, None, None], rtol=1e-12)
+
+    def test_fully_masked_row_no_longer_nans_the_region(self):
+        """A fully-dead row inside the air rect used to NaN the sequential mean-of-row-means."""
+        from neunorm.processing.air_region_corrector import apply_air_region_correction
+
+        t = _stack(24, base=50, unit="dimensionless")
+        dead = np.zeros((6, 8), dtype=bool)
+        dead[1, 2:5] = True  # kills the entire first row of the (2,1,5,3) rect
+        t.masks["dead_pixels"] = sc.array(dims=["y", "x"], values=dead)
+        out = apply_air_region_correction(t, (2, 1, 5, 3))
+        assert np.isfinite(out.values).all()
+
+    def test_nonpositive_air_mean_raises_with_air_roi_message(self):
+        from neunorm.processing.air_region_corrector import apply_air_region_correction
+
+        t = _stack(25, base=50, unit="dimensionless")
+        vals = t.values.copy()
+        vals[:, 1:3, 2:5] = 0.0
+        t2 = sc.DataArray(
+            sc.array(dims=["N_image", "y", "x"], values=vals, variances=t.variances.copy(), unit="dimensionless")
+        )
+        with pytest.raises(ValueError, match="air_roi.*strictly positive"):
+            apply_air_region_correction(t2, (2, 1, 5, 3))
+
+    def test_pooled_multiple_air_regions(self):
+        from neunorm.processing.air_region_corrector import apply_air_region_correction
+
+        t = _stack(26, base=50, unit="dimensionless")
+        out = apply_air_region_correction(t, [(2, 1, 5, 3), (0, 4, 2, 6)])
+        sel = np.zeros((6, 8), dtype=bool)
+        sel[1:3, 2:5] = True
+        sel[4:6, 0:2] = True
+        coeff = t.values[:, sel].sum(axis=1) / sel.sum()
+        np.testing.assert_allclose(out.values, t.values / coeff[:, None, None], rtol=1e-12)
+
+
+class TestApplyRoiMask:
+    def test_rect_crop_unchanged(self):
+        from neunorm.processing.roi_clipper import apply_roi
+
+        s = _stack(27)
+        out = apply_roi(s, (2, 1, 5, 3))
+        assert out.sizes["x"] == 3 and out.sizes["y"] == 2
+        assert len(out.masks) == 0
+
+    def test_mask_crop_bbox_plus_outside_roi(self):
+        from neunorm.processing.roi_clipper import apply_roi
+
+        s = _stack(28)
+        sel = _cross_selection()
+        m = MaskROI(selection=sel)
+        out = apply_roi(s, m)
+        x0, y0, x1, y1 = m.bounding_box()
+        assert out.sizes["x"] == x1 - x0 and out.sizes["y"] == y1 - y0
+        assert "outside_roi" in out.masks
+        np.testing.assert_array_equal(out.masks["outside_roi"].values, ~sel[y0:y1, x0:x1])
+        np.testing.assert_allclose(out.values, s.values[:, y0:y1, x0:x1], rtol=0)
+
+    def test_mask_crop_shape_mismatch_raises(self):
+        from neunorm.processing.roi_clipper import apply_roi
+
+        with pytest.raises(ValueError, match="does not match"):
+            apply_roi(_stack(29), MaskROI(selection=np.ones((3, 3), dtype=bool)))
+
+    def test_repeat_mask_crop_ors_exclusions(self):
+        from neunorm.processing.roi_clipper import apply_roi
+
+        s = _stack(30)
+        sel1 = _cross_selection()
+        out1 = apply_roi(s, MaskROI(selection=sel1))
+        # second mask in the CROPPED frame: keep only the center row of the bbox
+        sel2 = np.zeros((out1.sizes["y"], out1.sizes["x"]), dtype=bool)
+        sel2[1, :] = True
+        out2 = apply_roi(out1, MaskROI(selection=sel2))
+        # exclusion = outside(sel1 bbox slice, re-cropped) OR outside(sel2 within its bbox)
+        assert "outside_roi" in out2.masks
+        # every pixel kept by out2 must have been kept by BOTH selections
+        kept = ~out2.masks["outside_roi"].values
+        x0, y0, x1, y1 = MaskROI(selection=sel1).bounding_box()
+        sel1_crop = sel1[y0:y1, x0:x1]
+        bx0, by0, bx1, by1 = MaskROI(selection=sel2).bounding_box()
+        assert (kept <= (sel1_crop[by0:by1, bx0:bx1] & sel2[by0:by1, bx0:bx1])).all()
+
+    def test_downstream_stats_exclude_outside_pixels(self):
+        """After a mask crop, a rect background_roi is automatically mask-aware."""
+        from neunorm.processing.normalizer import apply_background_roi
+        from neunorm.processing.roi_clipper import apply_roi
+
+        s = _stack(31)
+        sel = _cross_selection()
+        cropped = apply_roi(s, MaskROI(selection=sel))
+        out = apply_background_roi(cropped, (0, 0, cropped.sizes["x"], cropped.sizes["y"]))
+        x0, y0, x1, y1 = MaskROI(selection=sel).bounding_box()
+        sel_crop = sel[y0:y1, x0:x1]
+        pooled = s.values[:, y0:y1, x0:x1][:, sel_crop].sum(axis=1) / sel_crop.sum()
+        np.testing.assert_allclose(out.values, s.values[:, y0:y1, x0:x1] / pooled[:, None, None], rtol=1e-12)
+
+
+class TestHdf5OutsideRoi:
+    def test_outside_roi_mask_persisted(self, tmp_path):
+        import h5py
+
+        from neunorm.exporters.hdf5_writer import write_hdf5
+        from neunorm.processing.roi_clipper import apply_roi
+
+        s = _stack(32)
+        sel = _cross_selection()
+        cropped = apply_roi(s, MaskROI(selection=sel))
+        path = tmp_path / "out.h5"
+        write_hdf5(path, cropped)
+        with h5py.File(path, "r") as f:
+            assert "masks/outside_roi" in f
+            x0, y0, x1, y1 = MaskROI(selection=sel).bounding_box()
+            np.testing.assert_array_equal(f["masks/outside_roi"][()], ~sel[y0:y1, x0:x1])

--- a/tests/unit/test_venus_ccd.py
+++ b/tests/unit/test_venus_ccd.py
@@ -307,6 +307,45 @@ class TestVenusCCDPipeline:
             transmission.coords["ManufacturerStr"].values, "ANDOR"
         )  # should be unchanged since it's the same for both runs
 
+    def test_venus_ccd_pipeline_air_roi_provenance_recorded(self):
+        """air_roi is recorded in output-file provenance — rect as native ints, mask as JSON (#180 F7)."""
+        from neunorm.data_models.roi import MaskROI
+
+        # rectangular air_roi -> flat native int array (same convention as roi_applied)
+        with tempfile.NamedTemporaryFile(suffix=".h5", delete=True) as f:
+            output_path = Path(f.name)
+            run_venus_ccd_pipeline(
+                sample_paths=[self.sample_paths_air],
+                ob_paths=[self.ob_paths[1:2]],
+                dark_paths=[self.dark_paths],
+                output_path=output_path,
+                gamma_filter=False,
+                air_roi=(6, 6, 11, 11),
+            )
+            with h5py.File(output_path, "r") as hf:
+                assert "metadata/air_roi" in hf
+                ds = hf["metadata/air_roi"]
+                assert ds.attrs.get("encoding") != "json"  # native int array, not the JSON backstop
+                np.testing.assert_array_equal(ds[()], [6, 6, 11, 11])
+
+        # MaskROI air_roi -> JSON mask summary (never a bare dict the TIFF writer would reject)
+        sel = np.zeros((32, 32), dtype=bool)
+        sel[6:11, 6:11] = True
+        mask = MaskROI(selection=sel)
+        with tempfile.NamedTemporaryFile(suffix=".h5", delete=True) as f:
+            output_path = Path(f.name)
+            run_venus_ccd_pipeline(
+                sample_paths=[self.sample_paths_air],
+                ob_paths=[self.ob_paths[1:2]],
+                dark_paths=[self.dark_paths],
+                output_path=output_path,
+                gamma_filter=False,
+                air_roi=mask,
+            )
+            with h5py.File(output_path, "r") as hf:
+                assert "metadata/air_roi" in hf
+                assert json.loads(hf["metadata/air_roi"].asstr()[()]) == {"mask": mask.provenance_summary()}
+
     def test_venus_ccd_pipeline_air_roi(self):
         """Test that air_roi is handled correctly."""
 

--- a/tests/unit/test_venus_ccd.py
+++ b/tests/unit/test_venus_ccd.py
@@ -346,6 +346,24 @@ class TestVenusCCDPipeline:
                 assert "metadata/air_roi" in hf
                 assert json.loads(hf["metadata/air_roi"].asstr()[()]) == {"mask": mask.provenance_summary()}
 
+        # TIFF output: the MaskROI air_roi provenance must survive the scitiff metadata writer as a
+        # JSON-safe scalar (a bare top-level dict would crash it).
+        from scitiff.io import load_scitiff
+
+        with tempfile.NamedTemporaryFile(suffix=".tiff", delete=True) as f:
+            output_path = Path(f.name)
+            run_venus_ccd_pipeline(
+                sample_paths=[self.sample_paths_air],
+                ob_paths=[self.ob_paths[1:2]],
+                dark_paths=[self.dark_paths],
+                output_path=output_path,
+                gamma_filter=False,
+                air_roi=mask,
+            )
+            dg = load_scitiff(output_path)
+            raw = dg["extra"]["air_roi"]
+            assert json.loads(raw.value if hasattr(raw, "value") else raw) == {"mask": mask.provenance_summary()}
+
     def test_venus_ccd_pipeline_air_roi(self):
         """Test that air_roi is handled correctly."""
 

--- a/tests/unit/test_venus_tpx1.py
+++ b/tests/unit/test_venus_tpx1.py
@@ -371,6 +371,53 @@ class TestVenusTPX1Pipeline:
                 assert ds.attrs.get("encoding") != "json"  # native int array, not the JSON backstop
                 np.testing.assert_array_equal(ds[()], [0, 0, 10, 10])
 
+    def test_venus_tpx1_pipeline_mask_air_roi_over_bin_edge_tof(self):
+        """A non-rectangular MaskROI air_roi flows through the TPX1 pipeline on top of #187's N+1
+        bin-edge tof coord (the #187 x MaskROI seam).
+
+        Regression guard for the exact interaction introduced when this feature was rebased onto the
+        #187 fix: a MaskROI air region reduces over (y, x) only, so the bin-edge tof coord (length
+        N+1 on a length-N tof dim) must survive air correction untouched, the air-region mean must be
+        driven to 1.0 per tof bin, the propagated variance must stay finite, and the mask must be
+        recorded in provenance as its JSON summary (not a native-int rectangle).
+        """
+        from neunorm.data_models.roi import MaskROI
+
+        # L-shaped (non-rectangular) selection over the (y, x) frame -> exercises the mask reduction
+        # path (as_region_list), not the rectangle as_roi_bounds path.
+        sel = np.zeros((32, 32), dtype=bool)
+        sel[0:10, 0:5] = True
+        sel[0:5, 0:10] = True
+        mask = MaskROI(selection=sel)
+
+        with tempfile.NamedTemporaryFile(suffix=".hdf5", delete=True) as f:
+            output_path = Path(f.name)
+            transmission = run_venus_tpx1_pipeline(
+                sample_tiff_paths=[self.sample_tiff_paths],
+                ob_tiff_paths=[self.ob_tiff_paths],
+                sample_hdf5_paths=[self.sample_nexus_path],
+                ob_hdf5_paths=[self.ob_nexus_path],
+                output_path=output_path,
+                air_roi=mask,
+            )
+            assert output_path.exists()
+
+            # #187: tof is a proper bin-edge axis (N+1 edges) and survives MaskROI air correction.
+            assert transmission.shape == (5, 32, 32)
+            assert transmission.coords["tof"].sizes["tof"] == transmission.sizes["tof"] + 1
+            np.testing.assert_allclose(transmission.coords["tof"].values, [0.1, 0.2, 0.3, 0.4, 0.5, 0.6])
+
+            # Spatially-uniform input -> air correction drives the frame to 1.0 per tof bin; the
+            # mask-aware pooled mean keeps the propagated variance finite (no 0*inf = NaN).
+            np.testing.assert_allclose(transmission.values, 1.0, rtol=1e-5)
+            assert np.all(np.isfinite(transmission.variances))
+            assert np.all(transmission.variances >= 0.0)
+
+            # MaskROI air_roi provenance is the JSON mask summary, not a native-int rect array.
+            with h5py.File(output_path, "r") as hf:
+                assert "metadata/air_roi" in hf
+                assert json.loads(hf["metadata/air_roi"].asstr()[()]) == {"mask": mask.provenance_summary()}
+
     def test_venus_tpx1_pipeline_invalid_paths(self):
         """Check error when the length of tiff and hdf5 paths do not match."""
         with tempfile.NamedTemporaryFile(suffix=".hdf5", delete=True) as f:

--- a/tests/unit/test_venus_tpx1.py
+++ b/tests/unit/test_venus_tpx1.py
@@ -353,6 +353,24 @@ class TestVenusTPX1Pipeline:
         np.testing.assert_allclose(transmission.values, 1)
         np.testing.assert_allclose(transmission.variances, 0.0227, rtol=0.1)
 
+    def test_venus_tpx1_pipeline_air_roi_provenance_recorded(self):
+        """A TPX pipeline records air_roi in HDF5 output-file provenance (#180 F7)."""
+        with tempfile.NamedTemporaryFile(suffix=".hdf5", delete=True) as f:
+            output_path = Path(f.name)
+            run_venus_tpx1_pipeline(
+                sample_tiff_paths=[self.sample_tiff_paths],
+                ob_tiff_paths=[self.ob_tiff_paths],
+                sample_hdf5_paths=[self.sample_nexus_path],
+                ob_hdf5_paths=[self.ob_nexus_path],
+                output_path=output_path,
+                air_roi=(0, 0, 10, 10),
+            )
+            with h5py.File(output_path, "r") as hf:
+                assert "metadata/air_roi" in hf
+                ds = hf["metadata/air_roi"]
+                assert ds.attrs.get("encoding") != "json"  # native int array, not the JSON backstop
+                np.testing.assert_array_equal(ds[()], [0, 0, 10, 10])
+
     def test_venus_tpx1_pipeline_invalid_paths(self):
         """Check error when the length of tiff and hdf5 paths do not match."""
         with tempfile.NamedTemporaryFile(suffix=".hdf5", delete=True) as f:

--- a/tests/unit/test_venus_tpx3_event.py
+++ b/tests/unit/test_venus_tpx3_event.py
@@ -415,3 +415,39 @@ class TestVenusTPX3EventPipeline:
         # Since all the data are the same for a single tof the air correction should just normalize 1.
         np.testing.assert_allclose(transmission.values, 1)
         np.testing.assert_allclose(transmission.variances, 0.244, rtol=0.25)
+
+    def test_venus_tpx3_event_pipeline_mask_air_roi(self):
+        """A non-rectangular MaskROI air_roi flows through the TPX3 event pipeline over a bin-edge
+        tof coord: air-region mean -> 1.0 per tof bin, the N+1 bin-edge tof axis survives, variance
+        stays finite, and the mask is recorded as its JSON provenance summary.
+        """
+        from neunorm.data_models.roi import MaskROI
+
+        # L-shaped (non-rectangular) selection -> exercises the mask reduction path, not as_roi_bounds.
+        sel = np.zeros((32, 32), dtype=bool)
+        sel[0:10, 0:5] = True
+        sel[0:5, 0:10] = True
+        mask = MaskROI(selection=sel)
+
+        with tempfile.NamedTemporaryFile(suffix=".hdf5", delete=True) as f:
+            output_path = Path(f.name)
+            transmission = run_venus_tpx3_event_pipeline(
+                sample_paths=[self.sample],
+                ob_paths=[self.ob],
+                binning=self.binning,
+                output_path=output_path,
+                detector_shape=(32, 32),
+                air_roi=mask,
+            )
+            assert output_path.exists()
+
+            assert transmission.shape == (5, 32, 32)
+            # Bin-edge tof axis (N+1 edges) survives the MaskROI air correction untouched.
+            assert transmission.coords["tof"].sizes["tof"] == transmission.sizes["tof"] + 1
+            np.testing.assert_allclose(transmission.values, 1.0, rtol=1e-5)
+            assert np.all(np.isfinite(transmission.variances))
+            assert np.all(transmission.variances >= 0.0)
+
+            with h5py.File(output_path, "r") as hf:
+                assert "metadata/air_roi" in hf
+                assert json.loads(hf["metadata/air_roi"].asstr()[()]) == {"mask": mask.provenance_summary()}

--- a/tests/unit/test_venus_tpx3_histogram.py
+++ b/tests/unit/test_venus_tpx3_histogram.py
@@ -325,6 +325,42 @@ class TestVenusTPX3HistogramPipeline:
         np.testing.assert_allclose(transmission.values, 1)
         np.testing.assert_allclose(transmission.variances, 0.0227, rtol=0.1)
 
+    def test_venus_tpx3_histogram_pipeline_mask_air_roi(self):
+        """A non-rectangular MaskROI air_roi flows through the TPX3 histogram pipeline over a
+        bin-edge tof coord: air-region mean -> 1.0 per tof bin, the N+1 bin-edge tof axis survives,
+        variance stays finite, and the mask is recorded as its JSON provenance summary.
+        """
+        from neunorm.data_models.roi import MaskROI
+
+        # L-shaped (non-rectangular) selection -> exercises the mask reduction path, not as_roi_bounds.
+        sel = np.zeros((32, 32), dtype=bool)
+        sel[0:10, 0:5] = True
+        sel[0:5, 0:10] = True
+        mask = MaskROI(selection=sel)
+
+        with tempfile.NamedTemporaryFile(suffix=".hdf5", delete=True) as f:
+            output_path = Path(f.name)
+            transmission = run_venus_tpx3_histogram_pipeline(
+                sample_tiff_paths=[self.sample_tiff_paths],
+                ob_tiff_paths=[self.ob_tiff_paths],
+                sample_hdf5_paths=[self.sample_nexus_path],
+                ob_hdf5_paths=[self.ob_nexus_path],
+                output_path=output_path,
+                air_roi=mask,
+            )
+            assert output_path.exists()
+
+            assert transmission.shape == (5, 32, 32)
+            # Bin-edge tof axis (N+1 edges) survives the MaskROI air correction untouched.
+            assert transmission.coords["tof"].sizes["tof"] == transmission.sizes["tof"] + 1
+            np.testing.assert_allclose(transmission.values, 1.0, rtol=1e-5)
+            assert np.all(np.isfinite(transmission.variances))
+            assert np.all(transmission.variances >= 0.0)
+
+            with h5py.File(output_path, "r") as hf:
+                assert "metadata/air_roi" in hf
+                assert json.loads(hf["metadata/air_roi"].asstr()[()]) == {"mask": mask.provenance_summary()}
+
     def test_venus_tpx3_histogram_pipeline_invalid_paths(self):
         """Check error when the length of tiff and hdf5 paths do not match."""
         with tempfile.NamedTemporaryFile(suffix=".hdf5", delete=True) as f:


### PR DESCRIPTION
> ✅ **#187 is fixed and merged to `next`** ([#190](https://github.com/ornlneutronimaging/NeuNorm/pull/190)).
> This branch has been **rebased onto that fix** and re-reviewed clean — the spurious
> *"number of TIFFs does not match the spectra file"* failure that blocked the flagship
> real-data merge gate no longer applies. The only remaining gate is Jean Bilheux's test on
> **real** MARS/VENUS data (see below).

## Summary

Adds **arbitrary-shape (mask-based) ROIs** — a `MaskROI` selection mask — for the
region-statistics operations, and fixes two uncertainty defects in the pooled/air
region math. Closes #180.

A `MaskROI` (a 2D selection mask, `1 = pixel in the region`, the opposite polarity of
scipp exclusion masks) is accepted anywhere the region-statistics APIs take a rectangle:
`normalize_transmission(background_roi=)`, `normalize_with_dark`, `apply_background_roi`,
`apply_air_region_correction`, and the pipelines' `background_roi=`/`air_roi=`. Construct
from a numpy/scipp array, an image drawn in e.g. ImageJ (`MaskROI.from_file`), or an
existing DataArray mask. Rectangles and masks pool together in one list.

**Cropping stays rectangle-only.** `apply_roi` / the pipeline `roi=` reject a `MaskROI`
(an arbitrary shape has no rectangular crop) and point the user to `background_roi=` /
`air_roi=`. Rectangle inputs are bit-identical to 2.2.x.

## What's in it

- **`MaskROI` type + unified `as_region_list` dispatch** (`data_models/roi.py`): canonical
  read-only `(y, x)` bool, array/file/DataArray-mask constructors, JSON-safe provenance.
- **Mask branch in the pooled background coefficient + shared-dark covariance**
  (`normalizer.py`), poolable with rectangles.
- **Air-region estimator fix**: the old `sc.mean(air, dim=["x","y"])` reduced sequentially
  (a mean of row-means) — wrong under dead/hot-masked pixels — and produced `0*inf = NaN`
  at `T == 0`. Now the mask-aware pooled mean, finite variance, and a `ValueError` on a
  non-positive mean. Values change only for masked air regions (unmasked agree to round-off).
- **Overlapping pooled ROIs no longer understate their uncertainty**: shared pixels were
  counted more than once, understating the variance/shared-dark covariance. Pooled stats now
  reduce over the **union** (each unmasked pixel once); non-overlapping/single lists keep the
  per-region fast path bit-for-bit.
- `air_roi` recorded in output-file provenance (HDF5 + TIFF, JSON-safe).

## Testing

- `pixi run test` → **525 passed**; `pre-commit run --all-files` clean; `pixi run build-docs`
  clean.
- **Rebased onto the #187 fix and re-reviewed** with a two-LLM-family review (Claude + Codex,
  cross-family verification) focused on the #187 × MaskROI seam: **0 P0 / 0 P1 correctness
  regressions**. Both families confirmed the MaskROI region reductions are spatial-only (over
  `x, y`) and orthogonal to #187's N+1 bin-edge `tof` coord; Claude ran the real `venus_tpx1`
  pipeline end-to-end with a non-rectangular MaskROI air region (air mean → 1.0 per frame,
  bin-edge `tof` preserved, provenance serialized, variance finite).
- The re-review's one actionable item — no end-to-end MaskROI `air_roi` test through the TPX
  pipelines — is now closed: added guard tests to `venus_tpx1`, `venus_tpx3_event`, and
  `venus_tpx3_histogram` (the CCD pipelines already had this coverage).
- Union dedup (mean + variance + covariance), crop rejection, and provenance were confirmed
  correct against independent hand oracles. Copilot's one earlier review comment (a perf note on
  the overlap check, not a bug) was addressed.

## ⚠️ Merge gate (flagship rule)

This change touches normalization, so it must pass **Jean Bilheux's real-data test before
merge**. With #187 now fixed and merged, real-data normalization on VENUS TPX1 runs cleanly, so
this gate is ready to be exercised. CI + the automated review verify code correctness on
synthetic data only; the feature has not yet been exercised on real MARS/VENUS detector data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
