### PR TITLE
Fix #187: read VENUS TPX1 spectra/shutter sidecars from the image dir, not the DAS-log raw path

### DIFF
--- a/src/neunorm/loaders/metadata_loader.py
+++ b/src/neunorm/loaders/metadata_loader.py
@@ -6,7 +6,7 @@ VENUS NeXus files, plus optional shutter-count and spectra-TOF sidecar text file
 
 import glob
 from pathlib import Path
-from typing import Union
+from typing import Optional, Union
 
 import h5py
 import numpy as np
@@ -15,7 +15,10 @@ from loguru import logger
 
 
 def load_metadata(  # noqa: C901
-    file_path: Union[str, Path], read_shutter_counts: bool = False, read_spectra_tof: bool = False
+    file_path: Union[str, Path],
+    read_shutter_counts: bool = False,
+    read_spectra_tof: bool = False,
+    image_dir: Optional[Union[str, Path]] = None,
 ) -> dict[str, sc.Variable]:
     """Load metadata from NeXus file.
 
@@ -24,9 +27,15 @@ def load_metadata(  # noqa: C901
     file_path : str or Path
         Path to NeXus HDF5 file containing metadata
     read_shutter_counts : bool
-        Whether to read shutter counts from the image directory specified in the metadata (default: False)
+        Whether to read shutter counts from the image directory (default: False)
     read_spectra_tof : bool
-        Whether to read spectra TOF from the image directory specified in the metadata (default: False)
+        Whether to read spectra TOF from the image directory (default: False)
+    image_dir : str or Path, optional
+        Directory the image stack was actually loaded from. When given, the ``*_Spectra.txt`` and
+        ``*_ShutterCount.txt`` sidecar files are read from here instead of the raw-acquisition
+        directory recorded in the NeXus DAS log ``BL10:Exp:IM:ImageFilePath``. This is required for
+        VENUS TPX1, whose images come from the auto-reduction tree (different frame count than raw);
+        reading the sidecars from the raw tree mismatches the image stack (GitHub #187).
     Returns
     -------
     dict
@@ -61,6 +70,12 @@ def load_metadata(  # noqa: C901
             metadata["image_file_path"] = sc.scalar(image_file_path)
             # The image path is relative to the parent directory of the HDF5 file, so we need to resolve it
             image_path = file_path.parent.parent.joinpath(image_file_path).resolve()
+
+        # The DAS log records the RAW acquisition directory, which is not necessarily where the
+        # caller's images came from. When the caller supplies the actual image directory, read the
+        # sidecar files (spectra TOF, shutter counts) from there so they match the image stack (#187).
+        if image_dir is not None:
+            image_path = Path(image_dir)
 
         if read_shutter_counts:
             metadata["shutter_counts"] = load_shutter_counts(image_path)

--- a/src/neunorm/loaders/metadata_loader.py
+++ b/src/neunorm/loaders/metadata_loader.py
@@ -79,7 +79,10 @@ def load_metadata(  # noqa: C901
         # and record that directory as image_file_path so the stored provenance points at the real
         # data source instead of the known-mismatched raw DAS-log path.
         if image_dir is not None:
-            image_path = Path(image_dir)
+            # Resolve to an absolute path (like the DAS-log branch above) so a relative image_dir
+            # does not depend on the current working directory. Missing directories still fail fast
+            # in load_spectra_tof / load_shutter_counts with a clear FileNotFoundError.
+            image_path = Path(image_dir).resolve()
             metadata["image_file_path"] = sc.scalar(str(image_path))
 
         if read_shutter_counts:

--- a/src/neunorm/loaders/metadata_loader.py
+++ b/src/neunorm/loaders/metadata_loader.py
@@ -35,7 +35,9 @@ def load_metadata(  # noqa: C901
         ``*_ShutterCount.txt`` sidecar files are read from here instead of the raw-acquisition
         directory recorded in the NeXus DAS log ``BL10:Exp:IM:ImageFilePath``. This is required for
         VENUS TPX1, whose images come from the auto-reduction tree (different frame count than raw);
-        reading the sidecars from the raw tree mismatches the image stack (GitHub #187).
+        reading the sidecars from the raw tree mismatches the image stack (GitHub #187). When given,
+        the returned ``image_file_path`` reflects this directory rather than the DAS-log value, so the
+        recorded provenance matches where the data was actually read.
     Returns
     -------
     dict
@@ -73,9 +75,12 @@ def load_metadata(  # noqa: C901
 
         # The DAS log records the RAW acquisition directory, which is not necessarily where the
         # caller's images came from. When the caller supplies the actual image directory, read the
-        # sidecar files (spectra TOF, shutter counts) from there so they match the image stack (#187).
+        # sidecar files (spectra TOF, shutter counts) from there so they match the image stack (#187),
+        # and record that directory as image_file_path so the stored provenance points at the real
+        # data source instead of the known-mismatched raw DAS-log path.
         if image_dir is not None:
             image_path = Path(image_dir)
+            metadata["image_file_path"] = sc.scalar(str(image_path))
 
         if read_shutter_counts:
             metadata["shutter_counts"] = load_shutter_counts(image_path)

--- a/src/neunorm/pipelines/venus_tpx1.py
+++ b/src/neunorm/pipelines/venus_tpx1.py
@@ -122,7 +122,9 @@ def run_venus_tpx1_pipeline(  # noqa: C901
 
     # Load data from TIFF files and metadata from HDF5 files
     for hdf5_path, tiff_paths in zip(sample_hdf5_paths, sample_tiff_paths):
-        metadata = load_metadata(hdf5_path, read_spectra_tof=True)
+        # Read the spectra TOF sidecar from the directory the images actually came from (the
+        # auto-reduction tree), not the raw-acquisition path in the DAS log — see GitHub #187.
+        metadata = load_metadata(hdf5_path, read_spectra_tof=True, image_dir=Path(tiff_paths[0]).parent)
         sample = load_tiff_stack(tiff_paths)
         # Attach metadata as coordinates to the sample DataArray for later use in normalization and rebinning
         for key, value in metadata.items():
@@ -138,7 +140,9 @@ def run_venus_tpx1_pipeline(  # noqa: C901
 
     # Load data from TIFF files and metadata from HDF5 files
     for hdf5_path, tiff_paths in zip(ob_hdf5_paths, ob_tiff_paths):
-        metadata = load_metadata(hdf5_path, read_spectra_tof=True)
+        # Read the spectra TOF sidecar from the directory the images actually came from (the
+        # auto-reduction tree), not the raw-acquisition path in the DAS log — see GitHub #187.
+        metadata = load_metadata(hdf5_path, read_spectra_tof=True, image_dir=Path(tiff_paths[0]).parent)
         ob_run = load_tiff_stack(tiff_paths)
         # Attach metadata as coordinates to the OB DataArray for later use in normalization and rebinning
         for key, value in metadata.items():

--- a/src/neunorm/pipelines/venus_tpx1.py
+++ b/src/neunorm/pipelines/venus_tpx1.py
@@ -28,6 +28,22 @@ from neunorm.tof.statistics_analyzer import analyze_statistics
 from neunorm.utils.constants import VENUS_FLIGHT_PATH_M
 
 
+def _tof_bin_edges_from_left_edges(spectra_tof: sc.Variable) -> sc.Variable:
+    """Build N+1 TOF bin edges from the per-frame LEFT edges.
+
+    The VENUS TPX1 ``*_Spectra.txt`` ``shutter_time`` column gives the LEFT (opening) edge of each
+    frame's TOF bin — one value per image, i.e. N left edges for N frames. scipp histograms need
+    N+1 bin edges, so the closing edge (right edge of the last bin) is appended using the last bin's
+    width. This makes ``tof`` a proper bin-edge axis so ``rebin_by_tof`` works (GitHub #187). A
+    single-frame stack (N < 2) has no inferable width and is returned unchanged.
+    """
+    values = spectra_tof.values
+    if values.size < 2:
+        return spectra_tof.rename_dims({"N_image": "tof"})
+    closing = values[-1] + (values[-1] - values[-2])
+    return sc.array(dims=["tof"], values=np.append(values, closing), unit=spectra_tof.unit)
+
+
 def run_venus_tpx1_pipeline(  # noqa: C901
     sample_hdf5_paths: Sequence[str | Path],
     ob_hdf5_paths: Sequence[str | Path],
@@ -131,9 +147,10 @@ def run_venus_tpx1_pipeline(  # noqa: C901
         # Attach metadata as coordinates to the sample DataArray for later use in normalization and rebinning
         for key, value in metadata.items():
             if key == "spectra_tof":
-                # replace N_image dim with TOF from spectra_tof
+                # spectra_tof holds per-frame LEFT bin edges; build N+1 bin edges so tof is a
+                # proper bin-edge axis and rebin_by_tof works (#187).
                 sample = sample.rename_dims({"N_image": "tof"})
-                sample.coords["tof"] = metadata["spectra_tof"].rename_dims({"N_image": "tof"})
+                sample.coords["tof"] = _tof_bin_edges_from_left_edges(value)
             else:
                 sample.coords[key] = value
                 sample.coords.set_aligned(key, False)
@@ -151,9 +168,10 @@ def run_venus_tpx1_pipeline(  # noqa: C901
         # Attach metadata as coordinates to the OB DataArray for later use in normalization and rebinning
         for key, value in metadata.items():
             if key == "spectra_tof":
-                # replace N_image dim with TOF from spectra_tof
+                # spectra_tof holds per-frame LEFT bin edges; build N+1 bin edges so tof is a
+                # proper bin-edge axis and rebin_by_tof works (#187).
                 ob_run = ob_run.rename_dims({"N_image": "tof"})
-                ob_run.coords["tof"] = metadata["spectra_tof"].rename_dims({"N_image": "tof"})
+                ob_run.coords["tof"] = _tof_bin_edges_from_left_edges(value)
             else:
                 ob_run.coords[key] = value
                 ob_run.coords.set_aligned(key, False)

--- a/src/neunorm/pipelines/venus_tpx1.py
+++ b/src/neunorm/pipelines/venus_tpx1.py
@@ -29,17 +29,18 @@ from neunorm.utils.constants import VENUS_FLIGHT_PATH_M
 
 
 def _tof_bin_edges_from_left_edges(spectra_tof: sc.Variable) -> sc.Variable:
-    """Build N+1 TOF bin edges from the per-frame LEFT edges.
+    """Build N+1 TOF bin edges from the N per-frame LEFT edges.
 
     The VENUS TPX1 ``*_Spectra.txt`` ``shutter_time`` column gives the LEFT (opening) edge of each
     frame's TOF bin — one value per image, i.e. N left edges for N frames. scipp histograms need
-    N+1 bin edges, so the closing edge (right edge of the last bin) is appended using the last bin's
-    width. This makes ``tof`` a proper bin-edge axis so ``rebin_by_tof`` works (GitHub #187). A
-    single-frame stack (N < 2) has no inferable width and is returned unchanged.
+    N+1 bin edges, so the closing edge (right edge of the last bin) is appended. Its width is
+    extrapolated from the last observed step, which is exact for VENUS's fixed-width TOF grid.
+    This makes ``tof`` a proper bin-edge axis so ``rebin_by_tof`` works (GitHub #187).
+
+    ``spectra_tof`` always has >= 2 rows here: ``load_spectra_tof`` rejects a single-row sidecar
+    before this is reached, and real TPX1 acquisitions have thousands of frames.
     """
     values = spectra_tof.values
-    if values.size < 2:
-        return spectra_tof.rename_dims({"N_image": "tof"})
     closing = values[-1] + (values[-1] - values[-2])
     return sc.array(dims=["tof"], values=np.append(values, closing), unit=spectra_tof.unit)
 

--- a/src/neunorm/pipelines/venus_tpx1.py
+++ b/src/neunorm/pipelines/venus_tpx1.py
@@ -122,6 +122,8 @@ def run_venus_tpx1_pipeline(  # noqa: C901
 
     # Load data from TIFF files and metadata from HDF5 files
     for hdf5_path, tiff_paths in zip(sample_hdf5_paths, sample_tiff_paths):
+        if not tiff_paths:
+            raise ValueError("Each sample TIFF path group must contain at least one TIFF file.")
         # Read the spectra TOF sidecar from the directory the images actually came from (the
         # auto-reduction tree), not the raw-acquisition path in the DAS log — see GitHub #187.
         metadata = load_metadata(hdf5_path, read_spectra_tof=True, image_dir=Path(tiff_paths[0]).parent)
@@ -140,6 +142,8 @@ def run_venus_tpx1_pipeline(  # noqa: C901
 
     # Load data from TIFF files and metadata from HDF5 files
     for hdf5_path, tiff_paths in zip(ob_hdf5_paths, ob_tiff_paths):
+        if not tiff_paths:
+            raise ValueError("Each OB TIFF path group must contain at least one TIFF file.")
         # Read the spectra TOF sidecar from the directory the images actually came from (the
         # auto-reduction tree), not the raw-acquisition path in the DAS log — see GitHub #187.
         metadata = load_metadata(hdf5_path, read_spectra_tof=True, image_dir=Path(tiff_paths[0]).parent)

--- a/tests/unit/test_metadata_loader.py
+++ b/tests/unit/test_metadata_loader.py
@@ -98,8 +98,8 @@ class TestMetadataLoader:
 
         assert "spectra_tof" in metadata
         assert sc.identical(metadata["spectra_tof"], sc.array(dims=["N_image"], values=[0.1, 0.2, 0.3, 0.4], unit="s"))
-        # image_file_path now reflects the real read directory, not the DAS-log value (#187)
-        assert sc.identical(metadata["image_file_path"], sc.scalar(str(real_dir)))
+        # image_file_path now reflects the real read directory (resolved), not the DAS-log value (#187)
+        assert sc.identical(metadata["image_file_path"], sc.scalar(str(real_dir.resolve())))
 
     def test_load_metadata_image_dir_overrides_daslog_for_shutter_counts(self):
         """#187: shutter counts are read from image_dir too (same resolution path as spectra)."""

--- a/tests/unit/test_metadata_loader.py
+++ b/tests/unit/test_metadata_loader.py
@@ -98,6 +98,8 @@ class TestMetadataLoader:
 
         assert "spectra_tof" in metadata
         assert sc.identical(metadata["spectra_tof"], sc.array(dims=["N_image"], values=[0.1, 0.2, 0.3, 0.4], unit="s"))
+        # image_file_path now reflects the real read directory, not the DAS-log value (#187)
+        assert sc.identical(metadata["image_file_path"], sc.scalar(str(real_dir)))
 
     def test_load_metadata_image_dir_overrides_daslog_for_shutter_counts(self):
         """#187: shutter counts are read from image_dir too (same resolution path as spectra)."""

--- a/tests/unit/test_metadata_loader.py
+++ b/tests/unit/test_metadata_loader.py
@@ -75,3 +75,39 @@ class TestMetadataLoader:
         assert sc.identical(
             metadata["shutter_counts"], sc.array(dims=["N_image"], values=[1000.0, 2000.0, 3000.0, 4000.0, 5000.0])
         )
+
+    def test_load_metadata_image_dir_overrides_daslog_for_spectra(self):
+        """#187: when image_dir is given, spectra TOF is read from THERE, not the DAS-log raw path.
+
+        A decoy ``*_Spectra.txt`` with different values sits at the DAS-log-resolved directory; the
+        loader must ignore it and read the file co-located with the caller's images instead.
+        """
+        tmp = Path(self._tmpdir.name)
+        # decoy spectra at the DAS-log-resolved dir (tmp/images) — must NOT be read
+        with open(tmp / "images" / "decoy_Spectra.txt", "w") as f:
+            for i in range(3):
+                f.write(f"{9.0 + i} 0\n")
+        # the real image directory the caller passes, with the correct spectra
+        real_dir = tmp / "autoreduce_spectra"
+        real_dir.mkdir(exist_ok=True)
+        with open(real_dir / "real_Spectra.txt", "w") as f:
+            for v in (0.1, 0.2, 0.3, 0.4):
+                f.write(f"{v} 0\n")
+
+        metadata = load_metadata(self.nexus_path, read_spectra_tof=True, image_dir=real_dir)
+
+        assert "spectra_tof" in metadata
+        assert sc.identical(metadata["spectra_tof"], sc.array(dims=["N_image"], values=[0.1, 0.2, 0.3, 0.4], unit="s"))
+
+    def test_load_metadata_image_dir_overrides_daslog_for_shutter_counts(self):
+        """#187: shutter counts are read from image_dir too (same resolution path as spectra)."""
+        tmp = Path(self._tmpdir.name)
+        real_dir = tmp / "autoreduce_shutter"
+        real_dir.mkdir(exist_ok=True)
+        with open(real_dir / "real_ShutterCount.txt", "w") as f:
+            f.write("0\t111\n1\t222\n2\t0\n")  # loader stops at the first 0 count
+
+        metadata = load_metadata(self.nexus_path, read_shutter_counts=True, image_dir=real_dir)
+
+        # values come from real_dir, not the tmp/images shutter file used by the other tests
+        assert sc.identical(metadata["shutter_counts"], sc.array(dims=["N_image"], values=[111.0, 222.0]))

--- a/tests/unit/test_venus_tpx1.py
+++ b/tests/unit/test_venus_tpx1.py
@@ -367,6 +367,29 @@ class TestVenusTPX1Pipeline:
                     output_path=output_path,
                 )
 
+    def test_venus_tpx1_pipeline_empty_tiff_group(self):
+        """An empty inner TIFF path group is rejected with a descriptive error, not a bare IndexError."""
+        with tempfile.NamedTemporaryFile(suffix=".hdf5", delete=True) as f:
+            output_path = Path(f.name)
+
+            with pytest.raises(ValueError, match=r"sample TIFF path group must contain at least one"):
+                run_venus_tpx1_pipeline(
+                    sample_tiff_paths=[[]],  # empty run group
+                    ob_tiff_paths=[self.ob_tiff_paths],
+                    sample_hdf5_paths=[self.sample_nexus_path],
+                    ob_hdf5_paths=[self.ob_nexus_path],
+                    output_path=output_path,
+                )
+
+            with pytest.raises(ValueError, match=r"OB TIFF path group must contain at least one"):
+                run_venus_tpx1_pipeline(
+                    sample_tiff_paths=[self.sample_tiff_paths],
+                    ob_tiff_paths=[[]],  # empty run group
+                    sample_hdf5_paths=[self.sample_nexus_path],
+                    ob_hdf5_paths=[self.ob_nexus_path],
+                    output_path=output_path,
+                )
+
     def test_venus_tpx1_pipeline_invalid_rebin_by_tof(self):
         """Check error for invalid rebin_by_tof values."""
         with tempfile.NamedTemporaryFile(suffix=".hdf5", delete=True) as f:

--- a/tests/unit/test_venus_tpx1.py
+++ b/tests/unit/test_venus_tpx1.py
@@ -72,11 +72,11 @@ class TestVenusTPX1Pipeline:
             Image.fromarray(data).save(filename)
             cls.ob_tiff_paths.append(filename)
 
-        # Co-located spectra: 6 rows (N+1) so the tof coord is treated as bin edges (0.1..0.6),
-        # matching the wavelength/energy/rebin assertions below. (Real autoreduce data has one row
-        # per image; the centers case is covered by test_venus_tpx1_real_data_topology_default_path.)
-        _write_spectra(sample_image_dir / "sample_Spectra.txt", [round(0.1 * (i + 1), 1) for i in range(6)])
-        _write_spectra(ob_image_dir / "ob_Spectra.txt", [round(0.1 * (i + 1), 1) for i in range(6)])
+        # Co-located spectra: 5 rows = one LEFT bin edge per image (real autoreduce topology). The
+        # pipeline appends the closing edge -> N+1 bin edges [0.1..0.6], matching the
+        # wavelength/energy/rebin assertions below.
+        _write_spectra(sample_image_dir / "sample_Spectra.txt", [round(0.1 * (i + 1), 1) for i in range(5)])
+        _write_spectra(ob_image_dir / "ob_Spectra.txt", [round(0.1 * (i + 1), 1) for i in range(5)])
 
         # DECOY raw dir recorded in the DAS log, with a DIFFERENT frame count (8). If the fix
         # regresses to DAS-log resolution, assigning a length-8 coord onto the length-5 image stack
@@ -467,9 +467,10 @@ class TestVenusTPX1Pipeline:
         np.testing.assert_allclose(transmission.coords["tof"].values, [0.1, 0.2, 0.3, 0.4, 0.5, 0.6])
 
     def test_venus_tpx1_real_data_topology_default_path(self):
-        """Real autoreduce topology: the co-located spectra has exactly one row per image (N TOF
-        centers, not N+1 edges) — the shape of actual VENUS TPX1 data that #187 crashed on. The
-        default (non-rebin) pipeline must run and produce a length-N tof coord from that sidecar.
+        """Real autoreduce topology: the co-located spectra has exactly one row per image (N LEFT
+        bin edges) — the shape of actual VENUS TPX1 data that #187 crashed on. The pipeline appends
+        the closing edge, so the default (non-rebin) pipeline runs and produces an N+1 bin-edge tof
+        coord from that sidecar.
         """
         with tempfile.TemporaryDirectory() as d:
             tmp = Path(d)
@@ -487,7 +488,7 @@ class TestVenusTPX1Pipeline:
                 Image.fromarray(np.full((8, 8), 99 + i, dtype=np.float32)).save(op)
                 ob_tiffs.append(op)
 
-            # N (=5) co-located spectra rows — the real-data centers shape
+            # N (=5) co-located spectra rows — one LEFT bin edge per image (real-data shape)
             _write_spectra(sample_dir / "s_Spectra.txt", [round(0.1 * (i + 1), 1) for i in range(5)])
             _write_spectra(ob_dir / "o_Spectra.txt", [round(0.1 * (i + 1), 1) for i in range(5)])
             # decoy raw dir with a different frame count, recorded in the DAS log
@@ -511,9 +512,9 @@ class TestVenusTPX1Pipeline:
 
                 assert output_path.exists()
 
-        # length-N (5) tof coord, one value per image, taken from the co-located sidecar
+        # 5 images = 5 bins; the 5 left edges + appended closing edge => 6 bin edges [0.1..0.6]
         assert transmission.shape == (5, 8, 8)
-        assert transmission.coords["tof"].sizes["tof"] == 5
-        np.testing.assert_allclose(transmission.coords["tof"].values, [0.1, 0.2, 0.3, 0.4, 0.5])
+        assert transmission.coords["tof"].sizes["tof"] == 6
+        np.testing.assert_allclose(transmission.coords["tof"].values, [0.1, 0.2, 0.3, 0.4, 0.5, 0.6])
         for i in range(5):
             np.testing.assert_allclose(transmission.values[i], (81 + i) / (99 + i) * 2)

--- a/tests/unit/test_venus_tpx1.py
+++ b/tests/unit/test_venus_tpx1.py
@@ -10,7 +10,7 @@ from PIL import Image
 from scitiff.io import load_scitiff
 
 from neunorm import __version__
-from neunorm.pipelines.venus_tpx1 import run_venus_tpx1_pipeline
+from neunorm.pipelines.venus_tpx1 import _tof_bin_edges_from_left_edges, run_venus_tpx1_pipeline
 
 
 def _write_spectra(path, tof_values):
@@ -32,6 +32,20 @@ def _write_nexus(path, proton_charge, das_image_path, include_time_offset=True):
         if include_time_offset:
             daslogs.create_group("BL10:Det:TH:DSPT1:TIDelay").create_dataset("average_value", data=[5000])
         daslogs.create_group("BL10:Exp:Det").create_dataset("value_strings", data=[[b"MCP TPX1"]])
+
+
+def test_tof_bin_edges_from_left_edges_non_uniform():
+    """The appended closing edge extrapolates the LAST bin's width, verified on non-uniform edges.
+
+    Left edges [0.1, 0.2, 0.4, 0.7] have widths [0.1, 0.2, 0.3], so the closing edge is
+    0.7 + 0.3 = 1.0 — which distinguishes the ``last + (last - prev)`` rule from a first-width
+    or average-width formula (uniform fixtures could not).
+    """
+    left = sc.array(dims=["N_image"], values=[0.1, 0.2, 0.4, 0.7], unit="s")
+    edges = _tof_bin_edges_from_left_edges(left)
+    assert edges.dims == ("tof",)
+    assert edges.unit == sc.Unit("s")
+    np.testing.assert_allclose(edges.values, [0.1, 0.2, 0.4, 0.7, 1.0])
 
 
 class TestVenusTPX1Pipeline:
@@ -448,9 +462,10 @@ class TestVenusTPX1Pipeline:
         not the raw dir recorded in the DAS log.
 
         The shared fixture's DAS log points at a decoy raw dir whose spectra has 8 rows; the
-        co-located sidecar has 6 (0.1..0.6). Reading the decoy would raise scipp DimensionError
-        (length-8 coord onto a length-5 stack). A successful run whose tof equals the co-located
-        values proves the fix.
+        co-located sidecar has 5 rows (left edges 0.1..0.5), which the pipeline turns into 6 bin
+        edges (0.1..0.6). Reading the decoy would raise scipp DimensionError (a mismatched-length
+        coord onto the length-5 stack). A successful run whose tof equals the co-located edges
+        proves the fix.
         """
         with tempfile.NamedTemporaryFile(suffix=".hdf5", delete=True) as f:
             output_path = Path(f.name)
@@ -463,7 +478,7 @@ class TestVenusTPX1Pipeline:
                 output_path=output_path,
             )
 
-        # tof came from the co-located sidecar (6 rows), NOT the decoy raw dir (8 rows: 0.05..0.4)
+        # tof from the co-located sidecar (5 left edges -> 6 bin edges), NOT the decoy raw dir (8 rows)
         np.testing.assert_allclose(transmission.coords["tof"].values, [0.1, 0.2, 0.3, 0.4, 0.5, 0.6])
 
     def test_venus_tpx1_real_data_topology_default_path(self):

--- a/tests/unit/test_venus_tpx1.py
+++ b/tests/unit/test_venus_tpx1.py
@@ -13,78 +13,86 @@ from neunorm import __version__
 from neunorm.pipelines.venus_tpx1 import run_venus_tpx1_pipeline
 
 
+def _write_spectra(path, tof_values):
+    """Write a whitespace-delimited ``*_Spectra.txt`` sidecar (one TOF value per row)."""
+    with open(path, "w") as f:
+        for v in tof_values:
+            f.write(f"{v} 0\n")
+
+
+def _write_nexus(path, proton_charge, das_image_path, include_time_offset=True):
+    """Write a minimal VENUS NeXus file. ``das_image_path`` is the RAW dir recorded in the DAS log."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with h5py.File(path, "w") as f:
+        entry = f.create_group("entry")
+        entry.create_dataset("proton_charge", data=[proton_charge])
+        entry.create_dataset("duration", data=[60.0])
+        daslogs = entry.create_group("DASlogs")
+        daslogs.create_group("BL10:Exp:IM:ImageFilePath").create_dataset("value", data=[[das_image_path]])
+        if include_time_offset:
+            daslogs.create_group("BL10:Det:TH:DSPT1:TIDelay").create_dataset("average_value", data=[5000])
+        daslogs.create_group("BL10:Exp:Det").create_dataset("value_strings", data=[[b"MCP TPX1"]])
+
+
 class TestVenusTPX1Pipeline:
     """Tests for the VENUS TPX1 pipeline."""
 
     @classmethod
     def setup_class(cls):
-        """Create tiff files for testing once for all tests in this class."""
+        """Create tiff files (with co-located spectra) for testing once for all tests in this class.
+
+        Mirrors real VENUS TPX1 topology: the images live in the auto-reduction tree with their
+        ``*_Spectra.txt`` sidecar CO-LOCATED next to them, while the NeXus DAS log records a
+        DIFFERENT raw-acquisition directory (a decoy here) whose spectra has a different frame
+        count. The pipeline must read the co-located sidecar, not the DAS-log one (GitHub #187).
+        """
         cls.sample_tiff_paths = []
         cls.ob_tiff_paths = []
 
         cls._tmpdir = tempfile.TemporaryDirectory(delete=False)
         tmp_dir = Path(cls._tmpdir.name)
 
-        # create 5 sample tiffs with values 81-85 and metadata.
+        # Images + co-located spectra live in the auto-reduction tree (where the pipeline reads).
+        sample_image_dir = tmp_dir / "autoreduce" / "sample"
+        ob_image_dir = tmp_dir / "autoreduce" / "ob"
+        sample_image_dir.mkdir(parents=True, exist_ok=True)
+        ob_image_dir.mkdir(parents=True, exist_ok=True)
+
+        # create 5 sample tiffs with values 81-85
         for i in range(5):
             data = np.full((32, 32), 81 + i, dtype=np.float32)
-            img = Image.fromarray(data)
-            filename = tmp_dir / f"sample_{i:03}.tiff"
-            img.save(filename)
+            filename = sample_image_dir / f"sample_{i:03}.tiff"
+            Image.fromarray(data).save(filename)
             cls.sample_tiff_paths.append(filename)
 
-        # create 5 OB tiffs with values 99, 100, 101, 102, 103 and metadata
+        # create 5 OB tiffs with values 99, 100, 101, 102, 103
         for i in range(5):
             data = np.full((32, 32), 99 + i, dtype=np.float32)
-            img = Image.fromarray(data)
-            filename = tmp_dir / f"ob_{i:03}.tiff"
-            img.save(filename)
+            filename = ob_image_dir / f"ob_{i:03}.tiff"
+            Image.fromarray(data).save(filename)
             cls.ob_tiff_paths.append(filename)
 
-        # Create temporary HDF5 file with minimal metadata
+        # Co-located spectra: 6 rows (N+1) so the tof coord is treated as bin edges (0.1..0.6),
+        # matching the wavelength/energy/rebin assertions below. (Real autoreduce data has one row
+        # per image; the centers case is covered by test_venus_tpx1_real_data_topology_default_path.)
+        _write_spectra(sample_image_dir / "sample_Spectra.txt", [round(0.1 * (i + 1), 1) for i in range(6)])
+        _write_spectra(ob_image_dir / "ob_Spectra.txt", [round(0.1 * (i + 1), 1) for i in range(6)])
+
+        # DECOY raw dir recorded in the DAS log, with a DIFFERENT frame count (8). If the fix
+        # regresses to DAS-log resolution, assigning a length-8 coord onto the length-5 image stack
+        # raises scipp DimensionError and every pipeline test fails — the #187 regression guard.
+        sample_raw_dir = tmp_dir / "raw" / "sample"
+        ob_raw_dir = tmp_dir / "raw" / "ob"
+        sample_raw_dir.mkdir(parents=True, exist_ok=True)
+        ob_raw_dir.mkdir(parents=True, exist_ok=True)
+        _write_spectra(sample_raw_dir / "raw_Spectra.txt", [round(0.05 * (i + 1), 2) for i in range(8)])
+        _write_spectra(ob_raw_dir / "raw_Spectra.txt", [round(0.05 * (i + 1), 2) for i in range(8)])
+
+        # NeXus files; DAS log points at the raw decoy (relative to the NeXus grandparent = tmp_dir).
         cls.sample_nexus_path = tmp_dir / "nexus" / "test_sample_metadata.nxs.h5"
-        cls.sample_nexus_path.parent.mkdir(parents=True, exist_ok=True)
-        with h5py.File(cls.sample_nexus_path, "w") as f:
-            entry = f.create_group("entry")
-            entry.create_dataset("proton_charge", data=[12345])
-            entry.create_dataset("duration", data=[60.0])
-            daslogs = entry.create_group("DASlogs")
-            image_file_path = daslogs.create_group("BL10:Exp:IM:ImageFilePath")
-            image_file_path.create_dataset("value", data=[[b"images/sample"]])
-            time_offset_path = daslogs.create_group("BL10:Det:TH:DSPT1:TIDelay")
-            time_offset_path.create_dataset("average_value", data=[5000])
-            detector_path = daslogs.create_group("BL10:Exp:Det")
-            detector_path.create_dataset("value_strings", data=[[b"MCP TPX1"]])
-
-        # Also create a directory for the image file and a spectra TOF file
-        image_dir = tmp_dir / "images" / "sample"
-        image_dir.mkdir(exist_ok=True, parents=True)
-        spectra_tof_file = image_dir / "test_Spectra.txt"
-        with open(spectra_tof_file, "w") as f:
-            for i in range(6):
-                f.write(f"{i * 0.1 + 0.1} 0\n")
-
+        _write_nexus(cls.sample_nexus_path, 12345, b"raw/sample")
         cls.ob_nexus_path = tmp_dir / "nexus" / "test_ob_metadata.nxs.h5"
-        cls.ob_nexus_path.parent.mkdir(parents=True, exist_ok=True)
-        with h5py.File(cls.ob_nexus_path, "w") as f:
-            entry = f.create_group("entry")
-            entry.create_dataset("proton_charge", data=[12345 * 2])
-            entry.create_dataset("duration", data=[60.0])
-            daslogs = entry.create_group("DASlogs")
-            image_file_path = daslogs.create_group("BL10:Exp:IM:ImageFilePath")
-            image_file_path.create_dataset("value", data=[[b"images/ob"]])
-            time_offset_path = daslogs.create_group("BL10:Det:TH:DSPT1:TIDelay")
-            time_offset_path.create_dataset("average_value", data=[5000])
-            detector_path = daslogs.create_group("BL10:Exp:Det")
-            detector_path.create_dataset("value_strings", data=[[b"MCP TPX1"]])
-
-        # Also create a directory for the image file and a spectra TOF file
-        image_dir = tmp_dir / "images" / "ob"
-        image_dir.mkdir(exist_ok=True, parents=True)
-        spectra_tof_file = image_dir / "test_Spectra.txt"
-        with open(spectra_tof_file, "w") as f:
-            for i in range(6):
-                f.write(f"{i * 0.1 + 0.1} 0\n")
+        _write_nexus(cls.ob_nexus_path, 12345 * 2, b"raw/ob")
 
     @classmethod
     def teardown_class(cls):
@@ -392,15 +400,7 @@ class TestVenusTPX1Pipeline:
         """Check warning when detector_time_offset is missing."""
 
         path = Path(self._tmpdir.name) / "nexus" / "test_missing_detector_time_offset.nxs.h5"
-        with h5py.File(path, "w") as f:
-            entry = f.create_group("entry")
-            entry.create_dataset("proton_charge", data=[12345])
-            entry.create_dataset("duration", data=[60.0])
-            daslogs = entry.create_group("DASlogs")
-            image_file_path = daslogs.create_group("BL10:Exp:IM:ImageFilePath")
-            image_file_path.create_dataset("value", data=[[b"images/sample"]])
-            detector_path = daslogs.create_group("BL10:Exp:Det")
-            detector_path.create_dataset("value_strings", data=[[b"MCP TPX1"]])
+        _write_nexus(path, 12345, b"raw/sample", include_time_offset=False)
 
         with tempfile.NamedTemporaryFile(suffix=".hdf5", delete=True) as f:
             output_path = Path(f.name)
@@ -419,3 +419,78 @@ class TestVenusTPX1Pipeline:
         assert "tof" in transmission.coords
         assert "wavelength" not in transmission.coords
         assert "energy" not in transmission.coords
+
+    def test_venus_tpx1_reads_spectra_from_image_dir_not_daslog(self):
+        """#187 regression: the TOF axis must come from the spectra co-located with the images,
+        not the raw dir recorded in the DAS log.
+
+        The shared fixture's DAS log points at a decoy raw dir whose spectra has 8 rows; the
+        co-located sidecar has 6 (0.1..0.6). Reading the decoy would raise scipp DimensionError
+        (length-8 coord onto a length-5 stack). A successful run whose tof equals the co-located
+        values proves the fix.
+        """
+        with tempfile.NamedTemporaryFile(suffix=".hdf5", delete=True) as f:
+            output_path = Path(f.name)
+
+            transmission = run_venus_tpx1_pipeline(
+                sample_tiff_paths=[self.sample_tiff_paths],
+                ob_tiff_paths=[self.ob_tiff_paths],
+                sample_hdf5_paths=[self.sample_nexus_path],
+                ob_hdf5_paths=[self.ob_nexus_path],
+                output_path=output_path,
+            )
+
+        # tof came from the co-located sidecar (6 rows), NOT the decoy raw dir (8 rows: 0.05..0.4)
+        np.testing.assert_allclose(transmission.coords["tof"].values, [0.1, 0.2, 0.3, 0.4, 0.5, 0.6])
+
+    def test_venus_tpx1_real_data_topology_default_path(self):
+        """Real autoreduce topology: the co-located spectra has exactly one row per image (N TOF
+        centers, not N+1 edges) — the shape of actual VENUS TPX1 data that #187 crashed on. The
+        default (non-rebin) pipeline must run and produce a length-N tof coord from that sidecar.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            sample_dir = tmp / "autoreduce" / "sample"
+            ob_dir = tmp / "autoreduce" / "ob"
+            sample_dir.mkdir(parents=True)
+            ob_dir.mkdir(parents=True)
+
+            sample_tiffs, ob_tiffs = [], []
+            for i in range(5):
+                sp = sample_dir / f"s_{i:03}.tiff"
+                Image.fromarray(np.full((8, 8), 81 + i, dtype=np.float32)).save(sp)
+                sample_tiffs.append(sp)
+                op = ob_dir / f"o_{i:03}.tiff"
+                Image.fromarray(np.full((8, 8), 99 + i, dtype=np.float32)).save(op)
+                ob_tiffs.append(op)
+
+            # N (=5) co-located spectra rows — the real-data centers shape
+            _write_spectra(sample_dir / "s_Spectra.txt", [round(0.1 * (i + 1), 1) for i in range(5)])
+            _write_spectra(ob_dir / "o_Spectra.txt", [round(0.1 * (i + 1), 1) for i in range(5)])
+            # decoy raw dir with a different frame count, recorded in the DAS log
+            (tmp / "raw" / "sample").mkdir(parents=True)
+            (tmp / "raw" / "ob").mkdir(parents=True)
+            _write_spectra(tmp / "raw" / "sample" / "r_Spectra.txt", [round(0.05 * (i + 1), 2) for i in range(7)])
+            _write_spectra(tmp / "raw" / "ob" / "r_Spectra.txt", [round(0.05 * (i + 1), 2) for i in range(7)])
+            _write_nexus(tmp / "nexus" / "s.nxs.h5", 12345, b"raw/sample")
+            _write_nexus(tmp / "nexus" / "o.nxs.h5", 12345 * 2, b"raw/ob")
+
+            with tempfile.NamedTemporaryFile(suffix=".hdf5", delete=True) as f:
+                output_path = Path(f.name)
+
+                transmission = run_venus_tpx1_pipeline(
+                    sample_tiff_paths=[sample_tiffs],
+                    ob_tiff_paths=[ob_tiffs],
+                    sample_hdf5_paths=[tmp / "nexus" / "s.nxs.h5"],
+                    ob_hdf5_paths=[tmp / "nexus" / "o.nxs.h5"],
+                    output_path=output_path,
+                )
+
+                assert output_path.exists()
+
+        # length-N (5) tof coord, one value per image, taken from the co-located sidecar
+        assert transmission.shape == (5, 8, 8)
+        assert transmission.coords["tof"].sizes["tof"] == 5
+        np.testing.assert_allclose(transmission.coords["tof"].values, [0.1, 0.2, 0.3, 0.4, 0.5])
+        for i in range(5):
+            np.testing.assert_allclose(transmission.values[i], (81 + i) / (99 + i) * 2)


### PR DESCRIPTION
## Summary

Fixes #187 — `run_venus_tpx1_pipeline` crashed with a scipp `DimensionError` when attaching the TOF axis on real VENUS TPX1 data, and makes the `rebin_by_tof` path work on that data.

**Root cause — a spectra-source mismatch** (not an off-by-one, not duplicated frames): `load_metadata` resolved the `*_Spectra.txt` sidecar directory from the NeXus DAS log `BL10:Exp:IM:ImageFilePath`, which records the **raw acquisition** tree. But the caller's image stack comes from the **auto-reduction** tree, whose frame count differs (e.g. run 23296 / IPTS-36967: raw 5000 vs autoreduce 4998). So the `spectra_tof` coord length never matched the image stack.

## Changes

- **`load_metadata`** — new optional `image_dir` parameter. When supplied, the `*_Spectra.txt` and `*_ShutterCount.txt` sidecars are read from there (resolved to an absolute path) instead of the DAS-log-resolved raw path, and `image_file_path` reflects that directory so provenance matches where the data was actually read.
- **`venus_tpx1`** — passes `image_dir=Path(tiff_paths[0]).parent` at both the sample and OB call sites; guards empty TIFF-path groups with a descriptive `ValueError`.
- **`rebin_by_tof` support** — the `shutter_time` column is the **left edge** of each frame's TOF bin (determined from the data: values lie on the pulse-T0 grid at `k·width`, 0% on the half-integer center grid; and the design doc specs `tof_edges: (N_bins+1,)`, "bin boundaries"). `_tof_bin_edges_from_left_edges` appends the closing edge (`last + width`) so the `tof` coordinate is a proper N+1 bin-edge axis and `rebin_by_tof` works.
- **Tests** — fixture co-locates the spectra with the TIFFs (N left-edge rows per N images) and adds a DAS-log **decoy** dir with a different frame count as a #187 regression guard; direct `image_dir` coverage for spectra and shutter counts.

## Verification

- Full `tests/unit` suite: **448 passed**.
- #187 crash: reproduced on Jean's exact data (spectra 5000 vs stack 4998) and fixed (spectra 4998 == stack). Jean's full reproduction now completes end-to-end (4998, 512, 512) instead of failing at 23.6 s.
- `rebin_by_tof=2` end-to-end on the same real data: completes (`4998 → 2499` bins), previously `BinEdgeError`.
- Revert-check reproduces the exact #187 `DimensionError`; ruff + pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
