### PR TITLE
Resonance mode (#197): ROI-level normalization producing a transmission spectrum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,71 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Resonance mode: ROI-level normalization producing a transmission spectrum**
+  ([#197](https://github.com/ornlneutronimaging/NeuNorm/issues/197)). A new keyword-only
+  `spectrum_roi` on `run_venus_tpx1_pipeline`, `run_venus_tpx3_histogram_pipeline` and
+  `run_venus_tpx3_event_pipeline` switches the output from a stack of normalized images to a **1-D
+  transmission spectrum**: for each spectral bin the sample's mean counts over the region are divided
+  by the open beam's mean counts over the same region, giving one point per bin. Written as a
+  three-column ASCII file — `bin_index,transmission,uncertainty`, comma-delimited with exactly one
+  plain header line — which is the `*_Spectra.txt` shape the ORNL imaging tools exchange and which
+  NeuNorm's own reader parses with `np.loadtxt(path, skiprows=1, delimiter=",")`. An HDF5 file is
+  written alongside it carrying the time axis, the masks and the provenance that three columns cannot
+  hold. See `docs/resonance_mode.md`.
+
+  The requirement is an order of operations: the region is collapsed to one number per bin **before**
+  the division, because the ratio of means is not the mean of ratios — about 1.2% apart on synthetic
+  Poisson counts over a 64-pixel region, and the per-pixel form additionally yields NaN wherever an
+  open-beam pixel recorded zero counts in a bin. The region mean is the same mask-aware pooled mean
+  `background_roi` and `air_roi` already use, so rectangles, arbitrary-shape `MaskROI` selections and
+  pooled lists all behave identically, and a dead pixel inside the region is excluded from the summed
+  counts and the pixel count alike.
+
+  Both sides are given the **union of both sides' masks** before the collapse. A region mean divides by
+  its own count of unmasked pixels, so a pixel masked on the sample alone leaves numerator and
+  denominator averaging over different pixels while the dead pixel goes on inflating the open beam:
+  measured on four pixels with one dead under non-uniform flux, 0.400 from a ratio of sums and 0.533
+  from a ratio of means against a true 0.800, which only mask symmetry recovers. Switching from sums to
+  means is not by itself the fix.
+
+  Frame-index binning works as in image mode — `rebin_by_tof` takes the same integer factor, `True`, or
+  explicit `[[start, stop], ...]` list, and the stacks are binned before the region is collapsed, so a
+  spectrum run and an image run of the same data see the same counts. `bin_index` is each point's first
+  input frame, which is the file index when no rebinning ran: a gapped list `[[0, 2], [4, 6]]` gives
+  rows indexed 0 and 4, and the dropped span has no row. `spectrum_roi_strict` (default `True`) guards
+  a non-positive or non-finite **open-beam** region mean; a zero *sample* mean is a real measurement — a
+  fully absorbing bin — and gives transmission 0.0. TIFF output is refused for a spectrum, because the
+  TIFF writer would otherwise quietly produce a multi-page file of 1x1-pixel images.
+
+  `spectrum_roi` indices are resolved against the arrays as normalization sees them, so after a `roi`
+  crop or a `rebin_by_spatial` they are **not** detector pixels — the same caveat `background_roi`
+  carries. A run that combines them warns, because the numbers look plausible either way.
+
+  Scope is the three VENUS TOF pipelines. The CCD pipelines and MARS TPX3 collapse or lack a spectral
+  axis at normalization time, so they have no per-bin open beam to divide by.
+
+- **`detect_resonances` takes a `spectrum_roi`**, so peaks are looked for where the sample is rather
+  than across the whole detector. Its integrated spectrum is now the mask-aware pooled region mean with
+  the masks symmetrized, instead of two independent bare sums — dividing two sums with no pixel count
+  is biased whenever the two sides carry different masks (measured 0.400 against a true 0.800). The SNR
+  is computed from the propagated transmission variance instead of a Poisson formula hard-coded over
+  raw counts, which is what allows the spectrum to be a mean at all: feeding means to the old formula
+  would have shrunk every SNR by `1/sqrt(N_pixels)`. For counting data the two agree to floating-point
+  round-off — measured maximum relative SNR difference 1.9e-16 on synthetic Poisson data, with
+  identical peaks — so detection on existing data is unchanged.
+
+- **`neunorm.processing.spectrum_reducer`** — `roi_mean_spectrum` promotes the pooled region mean to a
+  documented public function (no numerical change; the existing private helper stays the single
+  implementation), and `normalize_roi_spectrum` reduces a sample and open-beam pair to a transmission
+  spectrum carrying the `N+1` `tof` bin edges, so the result can be rebinned again or converted to
+  wavelength or energy. It reuses `normalize_transmission`, so the proton-charge correction and its
+  0.5% systematic come with it. Sample and open-beam inputs whose aligned time axes disagree raise a
+  message naming the axis, the deviation and both inputs, rather than a raw scipp `DatasetError`.
+
+- **`neunorm.exporters.ascii_writer`** — the package's first text exporter. `write_ascii_spectrum`
+  writes the three-column spectrum; a spectrum that is not 1-D, or that carries no variances, is
+  rejected rather than written with a fabricated uncertainty column.
+
 - **Progress-reporting contract** — new `neunorm.utils.progress` module
   ([#195](https://github.com/ornlneutronimaging/NeuNorm/issues/195)), the foundation for reporting
   where a long normalization run has got to. Defines the immutable `ProgressEvent(stage, completed,
@@ -216,6 +281,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bit-identical to 2.2.x.
 
 ### Changed
+
+- **The three VENUS TOF pipelines share one implementation.** `venus_tpx1`, `venus_tpx3_histogram` and
+  `venus_tpx3_event` each carried the same ~150 lines — crop, dead/hot detection, spatial rebin, TOF
+  rebin, normalize, air correction, coordinate labelling, export — so that middle now lives once in
+  `neunorm.pipelines._tof_spine.reduce_tof_stacks` and each entry point keeps only its own loading and
+  metadata. 409/405/418 lines become 271/263/287, and all three `# noqa: C901` complexity suppressions
+  are gone. Public signatures are unchanged apart from the two new keyword-only parameters.
+
+  The differences that genuinely exist between the three are now named in a `TofPipelineProfile` rather
+  than implied by which copy of the code you are reading, **including two that look like oversights and
+  are preserved exactly**: `venus_tpx3_histogram` re-detects its dead/hot masks from the *sample* after
+  a spatial rebin where its own pre-rebin detection and both other pipelines read the open beam, and
+  `venus_tpx1` passes no `hot_pixel_mask` to the HDF5 writer. Changing either would change published
+  output, so neither was changed here.
+
+  Behaviour-preserving, and verified rather than asserted: every pipeline's written `transmission`,
+  `uncertainty`, `tof`/`spectra_tof`/`wavelength`/`energy` coordinates and every mask are bit-identical
+  before and after, across 31 runs covering all three pipelines against ten argument combinations plus
+  three untouched pipelines as controls.
 
 - **Parameters added since v2.2.3 are now keyword-only, and the released positional order is guarded
   by tests.** `rebin_reduction` and `tiff_one_file_per_image` on the three VENUS TOF pipelines,

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -57,6 +57,9 @@ Processing
 .. automodule:: neunorm.processing.spatial_rebinner
    :members:
 
+.. automodule:: neunorm.processing.spectrum_reducer
+   :members:
+
 .. automodule:: neunorm.processing.uncertainty_calculator
    :members:
 
@@ -115,6 +118,9 @@ Exporters
    :members:
 
 .. automodule:: neunorm.exporters.tiff_writer
+   :members:
+
+.. automodule:: neunorm.exporters.ascii_writer
    :members:
 
 Filters

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,7 @@ migration
 :caption: Using
 
 progress
+resonance_mode
 ```
 
 ```{toctree}

--- a/docs/resonance_mode.md
+++ b/docs/resonance_mode.md
@@ -1,0 +1,275 @@
+# Resonance mode: a spectrum instead of images
+
+The normal reduction divides sample by open beam pixel by pixel and gives you a stack of normalized
+images. Resonance mode gives you a **1-D transmission spectrum**: you name a region of interest, and
+each spectral bin becomes one data point — the sample's mean counts in that region divided by the open
+beam's mean counts in the same region. The result is written as a three-column ASCII file, which is
+what the resonance and Bragg-edge fitting tools read.
+
+Pass `spectrum_roi` to any of the three VENUS TOF pipelines:
+
+```python
+from pathlib import Path
+
+from neunorm.pipelines.venus_tpx1 import run_venus_tpx1_pipeline
+
+spectrum = run_venus_tpx1_pipeline(
+    sample_hdf5_paths=sample_hdf5_paths,
+    ob_hdf5_paths=ob_hdf5_paths,
+    sample_tiff_paths=sample_tiff_paths,
+    ob_tiff_paths=ob_tiff_paths,
+    output_path=Path("spectrum.txt"),
+    spectrum_roi=(10, 10, 26, 26),
+)
+print(spectrum.dims, spectrum.sizes)
+```
+
+`spectrum_roi` is a fourth ROI role, distinct from the three that already exist:
+
+| argument | what it does to the region |
+|---|---|
+| `roi` | **crops** to it; everything downstream sees only that region |
+| `background_roi` | takes its mean as a **flux proxy**, standing in for proton charge |
+| `air_roi` | takes its mean as a **scale correction**, so open beam reads 1.0 there |
+| `spectrum_roi` | takes its mean as **the measurement itself** |
+
+## The file it writes
+
+Comma-delimited, exactly one plain header line, one row per bin:
+
+```text
+bin_index,transmission,uncertainty
+0,0.448760,0.010663
+1,0.451203,0.010701
+2,0.449881,0.010684
+```
+
+This is the `*_Spectra.txt` shape the ORNL imaging tools already exchange, so NeuNorm's own reader
+parses it with no special casing:
+
+```python
+import numpy as np
+
+data = np.loadtxt("spectrum.txt", skiprows=1, delimiter=",")
+bin_index, transmission, uncertainty = data.T
+```
+
+- **`bin_index`** is each point's **first input frame index**. With no rebinning that is simply the
+  file index, which is what the column is usually read as. Under a rebinning it stays traceable — see
+  "Binning by frame index" below.
+- **`transmission`** is dimensionless, at six decimal places.
+- **`uncertainty`** is **1 sigma**, `sqrt(variance)` — the same quantity the HDF5 writer stores as
+  `/uncertainty`.
+
+An HDF5 file is written **alongside** it, at the same path with a `.hdf5` suffix. Three columns cannot
+hold a time axis, the masks, or the provenance, and those are worth keeping: the HDF5 carries
+`/transmission`, `/uncertainty`, the `N+1` `/tof` bin edges, the per-bin `/spectra_tof` mean time,
+`/wavelength`, `/energy`, and `/metadata/spectrum_roi`. Ask for `output_path="spectrum.hdf5"` instead
+and you get only the HDF5.
+
+TIFF output is refused. A 1-D spectrum is not an image stack, and the TIFF writer would not object —
+it would quietly produce a multi-page file of 1×1-pixel images that even reads back cleanly.
+
+## Why the region is collapsed before the division
+
+This is the whole point of the mode, and it is an order of operations rather than a new algorithm. The
+region is reduced to one number per bin **first**, and the division happens **once**:
+
+$$T_i = \frac{\langle S_i \rangle_{\text{ROI}}}{\langle O_i \rangle_{\text{ROI}}}
+\qquad \text{not} \qquad
+T_i = \Big\langle \frac{S_i}{O_i} \Big\rangle_{\text{ROI}}$$
+
+The two are different quantities — the ratio of means is not the mean of ratios. On synthetic Poisson
+counts over a 64-pixel region they sit about 1.2% apart. The per-pixel form has a second problem at
+fine TOF binning: wherever an open-beam pixel recorded zero counts in a bin its ratio is undefined, so
+averaging ratios spreads NaN through the spectrum, while summing counts first does not notice.
+
+The mean is **mask-aware and pooled** — `sum(counts over the region) / count(unmasked pixels)` — so a
+dead or hot pixel inside the region is excluded from the numerator and the denominator alike, and the
+remaining pixels still give the region's true mean. Several regions can be pooled by passing a list;
+where they overlap, each pixel is counted once.
+
+Both sides are given the **union of both sides' masks** before the collapse. This matters more than it
+looks: a region mean divides by its own count of unmasked pixels, so a pixel masked on the sample alone
+leaves the numerator and the denominator averaging over different pixels — and the dead pixel goes on
+inflating the open beam's mean. Measured on four pixels with one dead, under non-uniform flux: 0.400
+from a ratio of sums, 0.533 from a ratio of means, 0.800 once the masks match, against a true 0.800.
+Switching from sums to means is not by itself the fix.
+
+## Binning by frame index
+
+Frame-index binning works exactly as it does in image mode, and for the same reason — the stacks are
+binned **before** the region is collapsed, so a spectrum run and an image run of the same data see the
+same counts:
+
+```python
+from pathlib import Path
+
+from neunorm.pipelines.venus_tpx1 import run_venus_tpx1_pipeline
+
+# every 2 frames into one point
+spectrum = run_venus_tpx1_pipeline(
+    sample_hdf5_paths=sample_hdf5_paths,
+    ob_hdf5_paths=ob_hdf5_paths,
+    sample_tiff_paths=sample_tiff_paths,
+    ob_tiff_paths=ob_tiff_paths,
+    output_path=Path("binned.txt"),
+    spectrum_roi=(10, 10, 26, 26),
+    rebin_by_tof=2,
+)
+print(spectrum.sizes)
+```
+
+`rebin_by_tof` takes the same arguments as in image mode: an integer factor, `True` for the
+statistics-based recommendation, or an explicit `[[start, stop], ...]` list of half-open frame ranges.
+`rebin_reduction` chooses how frames combine and keeps its usual defaults — a factor **sums**, a bin
+list takes the **mean**.
+
+The `bin_index` column follows the input, not the row number. With `rebin_by_tof=2` over six frames you
+get rows indexed `0, 2, 4`. With a gapped list the gap shows:
+
+```text
+rebin_by_tof=[[0, 2], [4, 6]]   ->   bin_index 0 and 4; frames 2-3 have no row at all
+```
+
+Frames no range covers are dropped silently, as in image mode. A gapped axis is no longer a continuous
+spectrum, and resonance fitting over it is not valid — prefer contiguous ranges when the output will be
+fitted. The full bin-to-frame mapping is recorded in the HDF5 under
+`/metadata/spectrum_bin_first_frame`.
+
+Sum and mean binning **commute** with the region collapse, so binning first costs nothing. A median
+reduction does not commute, and neither does any reduction when a per-frame `(tof, y, x)` mask is
+present — binning consumes that mask and changes each bin's unmasked pixel count. Where the two orders
+differ, the documented order above is what runs.
+
+### Binning a stack that has no timing coordinate
+
+The three TOF pipelines always attach a `tof` axis, so this does not arise in a pipeline run. It does
+arise if you load a stack yourself and bin it directly: the rebinner rebuilds its output axis from the
+input's bin edges, so a stack with no coordinate on the binned dimension is refused with
+`ValueError: data must carry a 'N_image' coordinate to rebuild the rebinned axis`. It does not invent an
+index axis for you.
+
+Attach one and binning by pure file index works, with the frame index becoming the axis:
+
+```python
+import numpy as np
+import scipp as sc
+
+from neunorm.tof.histogram_rebinner import reduce_tof_bins
+
+n_frames = 6
+values = np.arange(1, n_frames * 4 + 1, dtype=float).reshape(n_frames, 2, 2)
+stack = sc.DataArray(
+    sc.array(dims=["N_image", "y", "x"], values=values, variances=values.copy(), unit="counts"),
+    coords={"N_image": sc.arange("N_image", 0, n_frames + 1, unit=None)},
+)
+
+binned = reduce_tof_bins(stack, [(0, 2), (2, 4), (4, 6)], reduction="sum", tof_dim="N_image")
+print(binned.coords["N_image"].values)  # [0 2 4 6] -- bin boundaries as file indices
+print(binned.coords["spectra_tof"].values)  # [0.5 2.5 4.5] -- each bin's mean member index
+```
+
+## Which pixel frame `spectrum_roi` is resolved in
+
+The crop and the spatial rebin both run **before** the region is collapsed, so `spectrum_roi` indices
+are resolved against the array as it is at that point — not against detector pixels. With
+`roi=(4, 4, 60, 60)` the region's origin is that crop's corner; with `rebin_by_spatial=2` one index
+step is two detector pixels. `background_roi` carries the same caveat.
+
+A run that combines them says so in the log, because the numbers look entirely plausible either way:
+
+```text
+WARNING  spectrum_roi indices are resolved AFTER the roi=(4, 4, 60, 60) crop, so they are offsets
+         into the cropped image, not detector pixels.
+```
+
+## Zero open beam
+
+An open-beam region mean of zero would make the transmission infinite. By default that raises. Pass
+`spectrum_roi_strict=False` to let `inf`/`nan` through instead, which is the 1.x behaviour and is there
+for reproducing legacy output:
+
+```python
+from pathlib import Path
+
+from neunorm.pipelines.venus_tpx1 import run_venus_tpx1_pipeline
+
+spectrum = run_venus_tpx1_pipeline(
+    sample_hdf5_paths=sample_hdf5_paths,
+    ob_hdf5_paths=ob_hdf5_paths,
+    sample_tiff_paths=sample_tiff_paths,
+    ob_tiff_paths=ob_tiff_paths,
+    output_path=Path("legacy.txt"),
+    spectrum_roi=(10, 10, 26, 26),
+    spectrum_roi_strict=False,
+)
+```
+
+The guard applies to the **open beam only**. A zero *sample* mean is a real measurement — a fully
+absorbing bin, a black resonance — and gives transmission 0.0, never an error.
+
+## Using it without a pipeline
+
+The reduction is a public function, if you already have two stacks in memory:
+
+```python
+import numpy as np
+import scipp as sc
+
+from neunorm.processing.spectrum_reducer import normalize_roi_spectrum, roi_mean_spectrum
+
+edges = sc.array(dims=["tof"], values=np.arange(4, dtype=float) * 10.0, unit="us")
+
+
+def stack(scale):
+    values = np.full((3, 8, 8), scale)
+    return sc.DataArray(
+        sc.array(dims=["tof", "y", "x"], values=values, variances=values.copy(), unit="counts"),
+        coords={"tof": edges},
+    )
+
+
+spectrum = normalize_roi_spectrum(stack(50.0), stack(100.0), (2, 2, 6, 6))
+print(spectrum.values)  # one point per TOF bin
+
+# or just the region mean of one stack
+mean_counts = roi_mean_spectrum(stack(50.0), (2, 2, 6, 6))
+print(mean_counts.values)
+```
+
+`normalize_roi_spectrum` reuses the same normalization the image mode uses, so the proton-charge
+correction and its 0.5% systematic come with it.
+
+## Feeding the resonance detector
+
+`detect_resonances` takes the same `spectrum_roi`, so peaks are looked for where the sample actually is
+rather than across the whole detector:
+
+```python
+from neunorm.tof.resonance import detect_resonances
+
+result = detect_resonances(hist_sample, hist_ob, spectrum_roi=(10, 10, 26, 26))
+print(result["resonance_energies"])
+```
+
+Its integrated spectrum is now the same mask-aware pooled region mean, with the masks symmetrized, and
+its SNR is computed from the propagated transmission variance rather than from a Poisson formula over
+raw counts. For counting data the two agree to floating-point round-off, so detection on existing data
+is unchanged; what changes is that a region mean and an asymmetric mask no longer bias it.
+
+## What resonance mode does not do
+
+- It does not fit anything. It produces the spectrum; `detect_resonances` finds peaks in one, and
+  fitting lives downstream.
+- It does not give you images as well. One run produces one output — ask for image mode if you want
+  the stack.
+- It is not available on the CCD pipelines or MARS TPX3. Those collapse or lack a spectral axis at
+  normalization time, so there is no per-bin open beam to divide by; a "spectrum" over their image
+  index would not be a TOF spectrum.
+- It does not represent masks in the ASCII file. Three columns cannot, and inventing a fourth would
+  break the format every downstream reader expects. The HDF5 written alongside carries them.
+- It does not correct the shared-dark correlation. When a dark frame is subtracted from both sides
+  before the collapse, the two region means are correlated through it, and the uncertainty reported
+  here treats them as independent — so it is slightly **conservative**. `normalize_with_dark` has the
+  analytic correction for the image mode.

--- a/docs/workflows/venus_tpx1.md
+++ b/docs/workflows/venus_tpx1.md
@@ -344,6 +344,24 @@ flowchart TD
 - Software version
 - ROI applied (if any)
 
+### Resonance mode: a spectrum instead of images
+
+Passing `spectrum_roi` replaces the output above with a **1-D transmission spectrum** — one point per
+TOF bin, the sample's mean counts over the region divided by the open beam's mean counts over the same
+region — written as a three-column ASCII file plus an HDF5 sibling:
+
+| Output | Dimensions | Description |
+|--------|------------|-------------|
+| `bin_index,transmission,uncertainty` ASCII | (N_bins,) | comma-delimited, one plain header line |
+| Transmission | (TOF,) | dimensionless, in the HDF5 sibling |
+| Uncertainty | (TOF,) | propagated 1σ |
+| tof coordinate | (N_bins + 1,) | bin edges, so the spectrum can be rebinned again |
+| spectra_tof | (N_bins,) | each bin's representative time |
+
+Everything before the normalization is unchanged, so a spectrum run and an image run of the same data
+see the same counts. Frame-index binning applies as it does here. TIFF output is refused for a spectrum.
+See {doc}`../resonance_mode` for the format, the coordinate-frame caveat and worked examples.
+
 ---
 
 ## 4. Coordinate Conversions

--- a/docs/workflows/venus_tpx3.md
+++ b/docs/workflows/venus_tpx3.md
@@ -464,6 +464,16 @@ TPX3 records individual neutron events with:
 - ROI applied (if any)
 - Software version
 
+#### Resonance mode: a spectrum instead of images
+
+Both TPX3 modes accept `spectrum_roi`, which replaces the output above with a **1-D transmission
+spectrum** — one point per TOF bin, the sample's mean counts over the region divided by the open beam's
+mean counts over the same region — written as a three-column
+`bin_index,transmission,uncertainty` ASCII file plus an HDF5 sibling carrying the `N+1` `tof` bin edges,
+the per-bin `spectra_tof` time and the provenance. Everything before the normalization is unchanged, so
+a spectrum run and an image run of the same data see the same counts; frame-index binning applies as it
+does here, and TIFF output is refused for a spectrum. See {doc}`../resonance_mode`.
+
 ---
 
 ### A.6 Pulse ID Reconstruction Detail

--- a/src/neunorm/exporters/ascii_writer.py
+++ b/src/neunorm/exporters/ascii_writer.py
@@ -1,0 +1,162 @@
+"""
+ASCII writer for 1-D transmission spectra, in the comma-delimited ``*_Spectra.txt`` shape.
+"""
+
+import os
+from pathlib import Path
+from typing import Optional, Sequence, Union
+
+import numpy as np
+import scipp as sc
+from loguru import logger
+
+from neunorm.utils.progress import STAGE_EXPORT, ProgressLike, resolve_progress
+
+#: The one header line the file carries, naming its three columns. No ``#`` prefix: the ecosystem's
+#: readers skip exactly one line and then parse the rest as data
+#: (``np.loadtxt(path, skiprows=1, delimiter=",")`` in :mod:`neunorm.loaders.metadata_loader`), so a
+#: commented header would be counted as the skipped line and the first data row lost.
+ASCII_SPECTRUM_HEADER = "bin_index,transmission,uncertainty"
+
+#: Per-column formats. ``bin_index`` is an integer frame index; the two value columns are fixed-point
+#: with six decimals, the precision the agreed format shows (``0,0.448760,0.010663``). The default
+#: ``%.18e`` would render ``bin_index`` as ``0.000000000000000000e+00``.
+_ASCII_SPECTRUM_FMT = ("%d", "%.6f", "%.6f")
+
+
+def ascii_spectrum_export_step_count(spectrum: sc.DataArray) -> int:  # noqa: ARG001 - fixed cost, by design
+    """How many progress steps :func:`write_ascii_spectrum` reports.
+
+    One: the file is a single small write, and splitting it would report progress that does not exist.
+    Public and taking the spectrum anyway, so a pipeline sizes this stage the same way it sizes the
+    HDF5 and TIFF exports — ``hdf5_export_step_count``'s counterpart — and a later change to the
+    writer cannot leave a caller's total stale.
+    """
+    return 1
+
+
+def _resolved_bin_indices(spectrum: sc.DataArray, bin_indices: Optional[Sequence[int]], n: int) -> np.ndarray:
+    """The first column's values: the given input-frame indices, or the row index when none are given."""
+    if bin_indices is None:
+        return np.arange(n, dtype=np.int64)
+    indices = np.asarray(list(bin_indices))
+    if indices.ndim != 1 or indices.size != n:
+        raise ValueError(
+            f"bin_indices must give one index per spectrum bin; got {indices.size} for a spectrum of "
+            f"{n} bin(s) (dims {spectrum.dims})"
+        )
+    if not np.issubdtype(indices.dtype, np.integer):
+        raise ValueError(f"bin_indices must be integers; got dtype {indices.dtype}")
+    return indices.astype(np.int64, copy=False)
+
+
+def write_ascii_spectrum(
+    output_path: Union[Path, str],
+    spectrum: sc.DataArray,
+    bin_indices: Optional[Sequence[int]] = None,
+    *,
+    progress: ProgressLike = False,
+    stage: str = STAGE_EXPORT,
+) -> Path:
+    """Write a 1-D transmission spectrum as a three-column comma-delimited ASCII file.
+
+    Output structure
+    ----------------
+
+    Exactly one plain header line, then one row per spectrum bin::
+
+        bin_index,transmission,uncertainty
+        0,0.448760,0.010663
+        1,0.451203,0.010701
+
+    This mirrors the ``*_Spectra.txt`` convention the ORNL imaging tools already exchange, so the
+    file is readable by NeuNorm's own spectra reader with no special casing:
+    ``np.loadtxt(path, skiprows=1, delimiter=",")``.
+
+    ``uncertainty`` is **1 sigma** — ``sqrt(variance)`` — the same quantity the HDF5 writer stores as
+    ``/uncertainty``. A spectrum carrying no variances is rejected rather than written with a
+    fabricated third column.
+
+    ``bin_index`` identifies each point by its **first input frame index**, which is what makes the
+    column mean "file index" when no rebinning was requested, as the format's users expect. Under a
+    rebinning it stays traceable: frames 0-1 and 4-5 binned as ``[[0, 2], [4, 6]]`` give rows indexed
+    ``0`` and ``4``, and the dropped 2-3 span simply has no row. The column therefore has gaps rather
+    than renumbered rows, and the full bin-to-frame mapping belongs in the run's provenance.
+
+    Values are written from the DataArray at six decimal places. Masks are not representable in a
+    three-column format and are not written here; the HDF5 file written alongside carries them, along
+    with the run's provenance and the spectrum's time axis.
+
+    Parameters
+    ----------
+    output_path : Path or str
+        File to write. Parent directories are created; an existing file is overwritten.
+    spectrum : sc.DataArray
+        The 1-D transmission spectrum, carrying variances.
+    bin_indices : sequence of int, optional
+        One input-frame index per bin, in order — normally each bin's first frame. Defaults to the
+        row index ``0..N-1``, which is the same thing when no rebinning was applied.
+    progress : bool or callable, optional
+        Progress reporting, off by default. Reports the single write step. Accepts an existing
+        ``ProgressReporter``, which is how a pipeline keeps one export count across the HDF5 and
+        ASCII writes; size it with :func:`ascii_spectrum_export_step_count`. See
+        :mod:`neunorm.utils.progress`.
+    stage : str, optional
+        Stage label the events carry. Defaults to ``STAGE_EXPORT``.
+
+    Returns
+    -------
+    Path
+        The file written.
+
+    Raises
+    ------
+    ValueError
+        If ``spectrum`` is not 1-D, carries no variances, or ``bin_indices`` does not match it.
+    PermissionError
+        If the parent directory is not writeable.
+    """
+    if len(spectrum.dims) != 1:
+        raise ValueError(
+            f"write_ascii_spectrum needs a 1-D spectrum; got dims {spectrum.dims} with sizes "
+            f"{dict(spectrum.sizes)}. Reduce the spatial dimensions first (see "
+            "neunorm.processing.spectrum_reducer.normalize_roi_spectrum)."
+        )
+    if spectrum.variances is None:
+        raise ValueError(
+            "write_ascii_spectrum needs a spectrum carrying variances: the file's third column is a "
+            "1-sigma uncertainty, and there is nothing truthful to write in it otherwise."
+        )
+
+    # Ensure output directory exists
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    # Check if path is writeable
+    if not os.access(output_path.parent, os.W_OK):
+        raise PermissionError(f"No write permission for directory: {output_path.parent}")
+
+    dim = spectrum.dims[0]
+    n = spectrum.sizes[dim]
+    indices = _resolved_bin_indices(spectrum, bin_indices, n)
+
+    with resolve_progress(progress, stage, total=ascii_spectrum_export_step_count(spectrum)) as report:
+        report.note("writing ASCII spectrum")
+        table = np.column_stack(
+            [
+                indices.astype(float),
+                np.asarray(spectrum.values, dtype=float),
+                np.sqrt(np.asarray(spectrum.variances, dtype=float)),
+            ]
+        )
+        np.savetxt(
+            output_path,
+            table,
+            delimiter=",",
+            header=ASCII_SPECTRUM_HEADER,
+            comments="",
+            fmt=_ASCII_SPECTRUM_FMT,
+        )
+        report()
+
+    logger.info("ASCII spectrum ({} bins) written to {}", n, output_path)
+    return output_path

--- a/src/neunorm/pipelines/_tof_spine.py
+++ b/src/neunorm/pipelines/_tof_spine.py
@@ -1,0 +1,658 @@
+"""
+The shared middle of the three VENUS TOF pipelines.
+
+``venus_tpx1``, ``venus_tpx3_histogram`` and ``venus_tpx3_event`` differ only in how they get their
+two stacks — a TIFF stack plus a spectra sidecar, a TIFF stack plus NeXus TOF binning, or events
+histogrammed on the fly — and in a handful of per-detector details. Everything from the ROI crop to
+the written file was the same 150 lines copied three times.
+
+That middle lives here, once. Each entry point keeps its own loading and metadata and calls
+:func:`reduce_tof_stacks`; the per-detector differences are named in a :class:`TofPipelineProfile`
+rather than encoded by which copy of the code you are reading.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, Optional
+
+import numpy as np
+import scipp as sc
+from loguru import logger
+
+from neunorm.data_models.roi import (
+    MaskROI,
+    RegionLike,
+    RegionsLike,
+    ROILike,
+    as_region_list,
+    as_roi_bounds,
+    region_provenance,
+)
+from neunorm.exporters.ascii_writer import ascii_spectrum_export_step_count, write_ascii_spectrum
+from neunorm.exporters.hdf5_writer import hdf5_export_step_count, write_hdf5
+from neunorm.exporters.tiff_writer import tiff_export_step_count, write_tiff_stack
+from neunorm.processing.air_region_corrector import apply_air_region_correction
+from neunorm.processing.normalizer import normalize_step_count, normalize_transmission
+from neunorm.processing.roi_clipper import apply_roi
+from neunorm.processing.spatial_rebinner import rebin_spatial
+from neunorm.processing.spectrum_reducer import (
+    normalize_roi_spectrum,
+    normalize_roi_spectrum_step_count,
+    spectrum_reduction_provenance,
+)
+from neunorm.tof.coordinate_converter import convert_tof_to_energy, convert_tof_to_wavelength
+from neunorm.tof.histogram_rebinner import _parse_bin_list, linear_bin_list, rebin_tof
+from neunorm.tof.pixel_detector import detect_dead_pixels, detect_hot_pixels
+from neunorm.tof.statistics_analyzer import analyze_statistics
+from neunorm.utils.progress import (
+    STAGE_EXPORT,
+    STAGE_NORMALIZE,
+    STAGE_REBIN_TOF,
+    STAGE_REDUCE_SPECTRUM,
+    ProgressReporter,
+)
+
+
+@dataclass(frozen=True)
+class TofPipelineProfile:
+    """What genuinely differs between the three VENUS TOF pipelines.
+
+    Every field records a difference that exists in the code today and is preserved verbatim, including
+    the two that look like oversights. They are named here rather than silently unified, because
+    unifying them would change published output.
+
+    Parameters
+    ----------
+    label : str
+        How the pipeline names itself in its completion log line.
+    detect_hot : bool
+        Whether a hot-pixel mask is detected alongside the dead-pixel one. TPX1 does not.
+    remask_after_spatial_rebin_from : {"ob", "sample"}
+        Which stack the masks are re-detected from after a spatial rebin. Two pipelines use the open
+        beam; ``venus_tpx3_histogram`` uses the sample, which disagrees with its own pre-rebin
+        detection (that one reads the open beam). Preserved as-is: changing it changes that
+        pipeline's masks.
+    hdf5_hot_pixel_mask : str, optional
+        The mask name handed to :func:`~neunorm.exporters.hdf5_writer.write_hdf5` as
+        ``hot_pixel_mask``, or ``None`` to leave the writer's default. TPX1 passes nothing, so a mask
+        literally named ``hot_pixels`` would land at ``/masks/hot_pixels`` there and at ``/masks/hot``
+        in the other two. Preserved: it is the on-disk layout.
+    tiff_detector_model : str, optional
+        The ``detector_type`` written into the TIFF DAQ metadata. ``None`` reads it from the sample's
+        ``detector`` coordinate, falling back to ``"Unknown"``; the event pipeline hard-codes
+        ``"TPX3"``.
+    """
+
+    label: str
+    detect_hot: bool
+    remask_after_spatial_rebin_from: Literal["ob", "sample"]
+    hdf5_hot_pixel_mask: Optional[str]
+    tiff_detector_model: Optional[str]
+
+
+def coerce_roi_arguments(
+    roi: Optional[ROILike], air_roi: Optional[RegionLike]
+) -> tuple[Optional[tuple], Optional[RegionLike]]:
+    """Coerce the ROI arguments every TOF entry point accepts to the forms downstream code expects.
+
+    A crop is always a bounds tuple; an air region may also be an arbitrary-shape ``MaskROI``, which
+    passes through untouched.
+    """
+    if roi is not None:
+        roi = as_roi_bounds(roi)
+    if air_roi is not None:
+        air_roi = air_roi if isinstance(air_roi, MaskROI) else as_roi_bounds(air_roi)
+    return roi, air_roi
+
+
+def require_matching_group_counts(sample_hdf5_paths, sample_tiff_paths, ob_hdf5_paths, ob_tiff_paths) -> None:
+    """One metadata file per TIFF group, for the two pipelines that take both."""
+    if len(sample_hdf5_paths) != len(sample_tiff_paths):
+        raise ValueError(
+            f"Number of sample HDF5 paths ({len(sample_hdf5_paths)}) does not match number of sample TIFF path groups "
+            f"({len(sample_tiff_paths)})."
+        )
+    if len(ob_hdf5_paths) != len(ob_tiff_paths):
+        raise ValueError(
+            f"Number of OB HDF5 paths ({len(ob_hdf5_paths)}) does not match number of OB TIFF path groups "
+            f"({len(ob_tiff_paths)})."
+        )
+
+
+def _attach_pixel_masks(sample: sc.DataArray, source: sc.DataArray, profile: TofPipelineProfile) -> None:
+    """Attach the dead (and, per profile, hot) pixel masks to ``sample``, detected from ``source``."""
+    sample.masks["dead_pixels"] = detect_dead_pixels(source)
+    if profile.detect_hot:
+        sample.masks["hot_pixels"] = detect_hot_pixels(source)
+
+
+def _resolve_tof_rebin_spec(spec, ob: sc.DataArray):
+    """Resolve ``rebin_by_tof`` to a concrete factor or bin list, rejecting anything else.
+
+    ``True`` means "ask the statistics analysis", which is why the open beam is needed here.
+    """
+    if spec is True:
+        spec = analyze_statistics(ob).recommended_rebinning
+        logger.info(f"Recommended TOF rebinning factor based on statistics analysis: {spec}")
+    if isinstance(spec, bool) or not isinstance(spec, (int, np.integer, list, tuple)):
+        raise ValueError(
+            f"rebin_by_tof must be a bool, an int factor, or a list/tuple of [start, stop] pairs; got {spec!r}"
+        )
+    return spec
+
+
+def _apply_rebinning(
+    sample: sc.DataArray,
+    ob: sc.DataArray,
+    *,
+    profile: TofPipelineProfile,
+    rebin_by_spatial,
+    rebin_by_tof,
+    rebin_reduction,
+    run_progress: ProgressReporter,
+) -> tuple[sc.DataArray, sc.DataArray, object]:
+    """Spatial then TOF rebinning, each optional, with the masks re-detected after a spatial rebin.
+
+    Also returns the TOF rebin spec as actually resolved — the concrete factor or bin list, with
+    ``rebin_by_tof=True`` already turned into the statistics-recommended factor — or ``None`` when no
+    TOF rebin ran. A spectrum run needs it to label each output point with the input frame index it
+    came from, and re-deriving it at the call site would mean resolving ``True`` twice.
+    """
+    if rebin_by_spatial is not None:
+        sample = rebin_spatial(sample, rebin_by_spatial)
+        ob = rebin_spatial(ob, rebin_by_spatial)
+        # redo mask after rebinning
+        source = ob if profile.remask_after_spatial_rebin_from == "ob" else sample
+        _attach_pixel_masks(sample, source, profile)
+
+    # TOF rebinning (optional): an integer factor, ``True`` for the statistics-based recommended
+    # factor, or an explicit ``[[start, stop], ...]`` bin list. ``rebin_reduction`` selects how
+    # frames combine (default: sum for a factor, mean for a bin list); see ``rebin_tof``.
+    # A bin list/tuple (even empty) is an explicit rebin request; an empty one must surface as an error
+    # from ``rebin_tof`` rather than be silently skipped by the plain falsy check.
+    resolved_spec = None
+    if rebin_by_tof or isinstance(rebin_by_tof, (list, tuple)):
+        spec = _resolve_tof_rebin_spec(rebin_by_tof, ob)
+        resolved_spec = spec
+        # rebin_tof takes no progress argument of its own, so the pipeline names the two calls
+        # around it: with a median reduction this is one of the slowest stages in the run.
+        rebin = run_progress.for_stage(STAGE_REBIN_TOF, total=2)
+        rebin.note("rebinning sample TOF")
+        sample = rebin_tof(sample, spec, reduction=rebin_reduction)
+        rebin()
+        rebin.note("rebinning open beam TOF")
+        ob = rebin_tof(ob, spec, reduction=rebin_reduction)
+        rebin()
+
+    return sample, ob, resolved_spec
+
+
+def spectrum_bin_indices(n_frames: Optional[int], spec) -> Optional[list[int]]:
+    """The input frame index each output spectrum point came from.
+
+    The ASCII spectrum's first column is documented as "the same as the file index if no binning", so
+    it is each bin's FIRST input frame — which degenerates to the row index exactly when no rebinning
+    ran, and stays traceable when one did. A gapped bin list therefore produces a column with gaps
+    (``[[0, 2], [4, 6]]`` -> ``0, 4``) rather than renumbered rows, and the dropped 2-3 span has no
+    row at all.
+
+    Returns ``None`` when no TOF rebin ran, which the writer renders as the plain row index.
+    """
+    if spec is None:
+        return None
+    if isinstance(spec, (list, tuple)):
+        ranges = _parse_bin_list(spec)
+    else:
+        if n_frames is None:
+            return None
+        ranges = linear_bin_list(n_frames, int(spec))
+    return [int(start) for start, _ in ranges]
+
+
+def _warn_on_a_gapped_spectrum(spec, n_frames: Optional[int]) -> None:
+    """Warn when a spectrum's frames are not contiguous, because the axis stops being a spectrum.
+
+    `docs/workflows/venus_tpx1.md` and the rebinner's own module warning already tell users that once
+    frames are dropped the axis is no longer a continuous spectrum and that Bragg-edge fitting,
+    resonance analysis and integrating over a wavelength range are not valid on it. That warning
+    matters more here than in image mode, because a spectrum is precisely the thing those tools fit.
+
+    Warned rather than refused: dropping frames between bins is a deliberate, requested behaviour and a
+    user may well want a gapped spectrum for something other than fitting. Silence is the option not
+    taken — the file looks entirely well-formed either way.
+    """
+    if not isinstance(spec, (list, tuple)):
+        return
+    ranges = _parse_bin_list(spec)
+    gaps = [(prev[1], nxt[0]) for prev, nxt in zip(ranges, ranges[1:]) if nxt[0] > prev[1]]
+    leading = ranges[0][0] if ranges and ranges[0][0] > 0 else None
+    trailing = ranges[-1][1] if ranges and n_frames is not None and ranges[-1][1] < n_frames else None
+    if not gaps and leading is None and trailing is None:
+        return
+    dropped = [f"{start}-{stop - 1}" for start, stop in gaps]
+    if leading is not None:
+        dropped.insert(0, f"0-{leading - 1}")
+    if trailing is not None:
+        dropped.append(f"{trailing}-{n_frames - 1}")
+    logger.warning(
+        "spectrum_roi with a gapped bin list: frames {} are covered by no range and are dropped, so the "
+        "output axis is NOT a continuous spectrum. Resonance and Bragg-edge fitting, and integrating "
+        "over a wavelength range, are not valid on it. Use contiguous ranges if the spectrum will be "
+        "fitted.",
+        ", ".join(dropped),
+    )
+
+
+def _add_derived_coords(transmission: sc.DataArray, sample: sc.DataArray, flight_path: sc.Variable) -> None:
+    """Label the result with wavelength and energy converted from TOF, when the offset is known."""
+    # Add wavelength and energy coordinates converted from TOF using the configurable flight
+    # path and the time offset from the metadata.
+    if "detector_time_offset" in sample.coords:
+        time_offset = sample.coords["detector_time_offset"]
+        transmission.coords["wavelength"] = convert_tof_to_wavelength(
+            transmission.coords["tof"], flight_path, time_offset
+        )
+        transmission.coords["energy"] = convert_tof_to_energy(transmission.coords["tof"], flight_path, time_offset)
+    else:
+        logger.warning("Time offset not found in metadata. Cannot add wavelength and energy coordinates.")
+
+
+def _write_tiff_output(
+    output_path: Path,
+    transmission: sc.DataArray,
+    sample: sc.DataArray,
+    *,
+    profile: TofPipelineProfile,
+    metadata: dict,
+    tiff_one_file_per_image: bool,
+    run_progress: ProgressReporter,
+) -> tuple[str, sc.DataArray]:
+    """Write the transmission stack as scitiff.
+
+    Returns what to report as the output **and the array as scitiff needed it** — dims renamed
+    ``tof`` -> ``t`` and every mask combined into one ``scitiff-mask``. That rewritten array is what
+    a TIFF run has always returned to its caller, and tests pin it, so it is handed back rather than
+    left as a local.
+    """
+    rename_map = {}
+    if "tof" in transmission.dims:
+        rename_map["tof"] = "t"  # TIFF stacks typically use 't' for the time dimension
+    if rename_map:
+        transmission = transmission.rename_dims(rename_map)
+
+    model = profile.tiff_detector_model
+    if model is None:
+        model = "Unknown"
+        if "detector" in sample.coords:
+            model = sample.coords["detector"].value
+
+    daqmetadata = {
+        "facility": "SNS",
+        "instrument": "VENUS",
+        "detector_type": model,
+        "source_type": "neutron",
+    }
+
+    # Combine all masks and broadcast to the shape of the transmission data.
+    # Mask must be same shape as the image data for scitiff. Broadcast each mask by DIM NAME
+    # (scipp), so both a spatial (y, x) mask and a 1-D per-frame (t) mask expand correctly to
+    # the full (t, y, x) stack.
+    if transmission.masks:
+        combined_mask = np.zeros_like(transmission.values, dtype=bool)
+        for mask in transmission.masks.values():
+            combined_mask |= sc.broadcast(mask, sizes=transmission.sizes).values
+
+        # remove other masks
+        transmission.masks.clear()
+        # add combined mask back in with name "scitiff-mask"
+        transmission.masks["scitiff-mask"] = sc.array(dims=transmission.dims, values=combined_mask, dtype=bool)
+
+    written_paths = write_tiff_stack(
+        output_path,
+        transmission,
+        metadata=metadata,
+        daqmetadata=daqmetadata,
+        one_file_per_image=tiff_one_file_per_image,
+        progress=run_progress.for_stage(
+            STAGE_EXPORT,
+            total=tiff_export_step_count(transmission, one_file_per_image=tiff_one_file_per_image),
+        ),
+    )
+    # In per-image mode ``output_path`` is only a naming template and is never written, so
+    # report what actually landed on disk rather than a file that does not exist.
+    if len(written_paths) > 1:
+        description = f"{len(written_paths)} files, {written_paths[0].name} .. {written_paths[-1].name}"
+    else:
+        description = str(written_paths[0])
+    return description, transmission
+
+
+def _export_transmission(
+    output_path: Path,
+    transmission: sc.DataArray,
+    sample: sc.DataArray,
+    *,
+    profile: TofPipelineProfile,
+    metadata: dict,
+    tiff_one_file_per_image: bool,
+    run_progress: ProgressReporter,
+) -> tuple[str, sc.DataArray]:
+    """Write the result in the format ``output_path``'s suffix selects.
+
+    Returns the description to log and the transmission as written — the TIFF path rewrites it (see
+    :func:`_write_tiff_output`), the HDF5 path leaves it alone.
+    """
+    if output_path.suffix.lower() in (".hdf5", ".h5"):
+        hot_kwargs = {} if profile.hdf5_hot_pixel_mask is None else {"hot_pixel_mask": profile.hdf5_hot_pixel_mask}
+        write_hdf5(
+            output_path,
+            transmission,
+            dead_pixel_mask="dead_pixels",
+            metadata=metadata,
+            progress=run_progress.for_stage(STAGE_EXPORT, total=hdf5_export_step_count(transmission, metadata)),
+            **hot_kwargs,
+        )
+        return str(output_path), transmission
+    if output_path.suffix.lower() in (".tiff", ".tif"):
+        return _write_tiff_output(
+            output_path,
+            transmission,
+            sample,
+            profile=profile,
+            metadata=metadata,
+            tiff_one_file_per_image=tiff_one_file_per_image,
+            run_progress=run_progress,
+        )
+    raise ValueError(f"Unsupported output file format: {output_path.suffix}")
+
+
+def _export_spectrum(
+    output_path: Path,
+    spectrum: sc.DataArray,
+    *,
+    metadata: dict,
+    bin_indices: Optional[list[int]],
+    run_progress: ProgressReporter,
+) -> str:
+    """Write a 1-D transmission spectrum: the ASCII table, and HDF5 alongside it.
+
+    Takes no :class:`TofPipelineProfile`: the profile's fields are all about image output — the
+    dead/hot mask names the HDF5 writer is given, and the TIFF detector model — and a region mean has
+    consumed the spatial masks by this point, so none of them apply.
+
+    ``.txt`` writes both — the three-column table the downstream fitting tools read, plus an HDF5
+    sibling carrying the provenance, the masks and the time axis that three columns cannot hold.
+    ``.hdf5``/``.h5`` writes only the HDF5.
+
+    ``.tiff``/``.tif`` is refused, and refused HERE rather than left to the writer. A 1-D spectrum
+    reaching :func:`~neunorm.exporters.tiff_writer.write_tiff_stack` after the pipelines' usual
+    ``tof`` -> ``t`` rename does not fail: it writes a multi-page TIFF of 1x1-pixel images, one per
+    bin, which even reads back cleanly. Nothing downstream would flag it.
+    """
+    suffix = output_path.suffix.lower()
+    if suffix in (".tiff", ".tif"):
+        raise ValueError(
+            f"spectrum_roi produces a 1-D spectrum, which cannot be written as a TIFF image stack "
+            f"(got {output_path.name}). Use '.txt' for the three-column ASCII spectrum (an HDF5 file "
+            "is written alongside it) or '.hdf5' for HDF5 only."
+        )
+    if suffix in (".hdf5", ".h5"):
+        write_hdf5(
+            output_path,
+            spectrum,
+            metadata=metadata,
+            progress=run_progress.for_stage(STAGE_EXPORT, total=hdf5_export_step_count(spectrum, metadata)),
+        )
+        return str(output_path)
+    if suffix == ".txt":
+        hdf5_path = output_path.with_suffix(".hdf5")
+        _refuse_to_overwrite_an_input(hdf5_path, metadata)
+        # ONE reporter shared by both writers: each borrows it and shares its counter cell, so the
+        # export bar advances continuously across the two files. That also means each writer's own
+        # `total=` is ignored, so the combined total has to be declared here.
+        export = run_progress.for_stage(
+            STAGE_EXPORT,
+            total=ascii_spectrum_export_step_count(spectrum) + hdf5_export_step_count(spectrum, metadata),
+        )
+        write_ascii_spectrum(output_path, spectrum, bin_indices, progress=export)
+        write_hdf5(hdf5_path, spectrum, metadata=metadata, progress=export)
+        return f"{output_path} (+ {hdf5_path.name})"
+    raise ValueError(f"Unsupported output file format: {output_path.suffix}")
+
+
+def _input_paths(metadata: dict) -> set:
+    """Every input file path the run recorded, resolved, flattened out of the nested per-run lists."""
+    found = set()
+
+    def walk(value):
+        if isinstance(value, str):
+            try:
+                found.add(Path(value).resolve())
+            except OSError:  # pragma: no cover - a path the filesystem cannot resolve is not an input
+                pass
+        elif isinstance(value, (list, tuple)):
+            for item in value:
+                walk(item)
+
+    for key, value in metadata.items():
+        if key.endswith("_paths"):
+            walk(value)
+    return found
+
+
+def _refuse_to_overwrite_an_input(hdf5_path: Path, metadata: dict) -> None:
+    """Refuse to write the HDF5 sibling on top of one of the run's own input files.
+
+    This is the one place in the package that writes a file the user did not name: a ``.txt`` output
+    also produces ``<stem>.hdf5``. ``write_hdf5`` opens with mode ``"w"``, which truncates, and a run's
+    metadata file is plausibly named ``<stem>.hdf5`` beside where a user would ask for ``<stem>.txt``, so
+    the derived path is checked against the run's inputs before anything is written.
+
+    Overwriting a file that is NOT an input is left alone: replacing your own previous output is normal
+    and is what every other writer here does.
+    """
+    resolved = hdf5_path.resolve() if hdf5_path.exists() else None
+    if resolved is not None and resolved in _input_paths(metadata):
+        raise ValueError(
+            f"writing the spectrum to {hdf5_path.name} would overwrite one of this run's own input "
+            f"files ({hdf5_path}). A '.txt' output also writes '<stem>.hdf5' alongside it, and that "
+            "path is an input here. Choose a different output name or an output directory of its own."
+        )
+
+
+def _warn_on_spectrum_roi_frame(roi, rebin_by_spatial) -> None:
+    """Say out loud which pixel frame ``spectrum_roi`` was resolved in, when it is not the detector's.
+
+    The crop and the spatial rebin both run before the region is collapsed, so the indices are
+    resolved against the array as it is at that point. ``background_roi`` carries the same caveat in
+    its docstrings, and this one is more surprising because a rebin factor rescales the indices as
+    well as shifting them. The region still selects real pixels either way, and the spectrum still
+    looks entirely plausible, which is exactly why this is said rather than left in the docs.
+    """
+    if roi:
+        logger.warning(
+            "spectrum_roi indices are resolved AFTER the roi={} crop, so they are offsets into the "
+            "cropped image, not detector pixels.",
+            tuple(roi),
+        )
+    if rebin_by_spatial is not None:
+        logger.warning(
+            "spectrum_roi indices are resolved AFTER rebin_by_spatial={}, so one index step is that "
+            "many detector pixels.",
+            rebin_by_spatial,
+        )
+
+
+def reduce_tof_stacks(
+    sample: sc.DataArray,
+    ob: sc.DataArray,
+    *,
+    output_path: Path,
+    profile: TofPipelineProfile,
+    metadata: dict,
+    roi: Optional[tuple] = None,
+    air_roi: Optional[RegionLike] = None,
+    rebin_by_tof=False,
+    rebin_by_spatial=None,
+    rebin_reduction=None,
+    flight_path: sc.Variable,
+    tiff_one_file_per_image: bool = False,
+    spectrum_roi: Optional[RegionsLike] = None,
+    spectrum_roi_strict: bool = True,
+    run_progress: ProgressReporter,
+) -> sc.DataArray:
+    """Crop, mask, rebin, normalize, label and write — the part every VENUS TOF pipeline shares.
+
+    Called with both stacks already loaded and run-combined. The steps run in the order the three
+    pipelines have always run them: crop, dead/hot detection, spatial rebin (re-detecting the masks),
+    TOF rebin, normalization, air-region correction, wavelength/energy labelling, export.
+
+    That order is why an ROI resolved at normalization time is expressed in **post-crop,
+    post-spatial-rebin** pixels rather than detector pixels.
+
+    With ``spectrum_roi`` the last three steps change: the region is collapsed to one value per bin
+    and divided once, giving a 1-D transmission spectrum written as a three-column ASCII file — the
+    "resonance mode" reduction. Everything before it, including the rebinning, is identical, so a
+    spectrum run and an image run of the same data see the same counts.
+
+    Parameters
+    ----------
+    sample, ob : sc.DataArray
+        The combined sample and open-beam stacks.
+    output_path : Path
+        Where to write; the suffix selects the writer.
+    profile : TofPipelineProfile
+        The per-detector differences.
+    metadata : dict
+        Provenance assembled by the entry point. ``roi``/``air_roi``/``spectrum_roi`` provenance is
+        added here, so every pipeline records it identically.
+    roi : tuple, optional
+        Crop bounds, already coerced by :func:`coerce_roi_arguments`.
+    air_roi : ROI, MaskROI, or tuple, optional
+        Air region for the post-normalization scale correction. Image mode only — it scales an image
+        so its air region reads 1.0, which is meaningless once the output is one number per bin.
+    rebin_by_tof, rebin_by_spatial, rebin_reduction
+        Rebinning arguments, forwarded as the pipelines document them.
+    flight_path : sc.Variable
+        Source-to-detector distance for the TOF conversions.
+    tiff_one_file_per_image : bool
+        TIFF output only: one file per spectral image. Image mode only.
+    spectrum_roi : ROI, MaskROI, tuple, or a sequence of them, optional
+        Switches the run to spectrum mode over this region.
+    spectrum_roi_strict : bool, optional
+        Whether a non-positive or non-finite open-beam region mean raises. See
+        :func:`~neunorm.processing.spectrum_reducer.normalize_roi_spectrum`.
+    run_progress : ProgressReporter
+        The run's reporter, already resolved by the entry point.
+
+    Returns
+    -------
+    sc.DataArray
+        The normalized transmission that was written — an image stack, or a 1-D spectrum under
+        ``spectrum_roi``.
+    """
+    if spectrum_roi is not None:
+        if air_roi is not None:
+            raise ValueError(
+                "air_roi and spectrum_roi cannot be combined: the air correction rescales an image so "
+                "its air region reads 1.0, which has no meaning for a spectrum of one value per bin. "
+                "Drop air_roi, or run in image mode."
+            )
+        if tiff_one_file_per_image:
+            raise ValueError(
+                "tiff_one_file_per_image applies to TIFF image output, which spectrum_roi does not "
+                "produce. Drop it, or run in image mode."
+            )
+        _warn_on_spectrum_roi_frame(roi, rebin_by_spatial)
+
+    # Apply ROI if specified
+    if roi:
+        sample = apply_roi(sample, roi)
+        ob = apply_roi(ob, roi)
+
+    # Dead (and hot) pixel detection
+    _attach_pixel_masks(sample, ob, profile)
+
+    n_frames_before_rebin = sample.sizes.get("tof")
+
+    sample, ob, resolved_spec = _apply_rebinning(
+        sample,
+        ob,
+        profile=profile,
+        rebin_by_spatial=rebin_by_spatial,
+        rebin_by_tof=rebin_by_tof,
+        rebin_reduction=rebin_reduction,
+        run_progress=run_progress,
+    )
+
+    if roi:
+        metadata["roi_applied"] = region_provenance(roi)
+
+    if spectrum_roi is not None:
+        regions = as_region_list(spectrum_roi, arg_name="spectrum_roi")
+        # Collapse the region to one value per bin BEFORE dividing: (Sum a)/(Sum b) != Sum(a/b), so
+        # a region-level measurement has to be built from region-level counts.
+        spectrum = normalize_roi_spectrum(
+            sample,
+            ob,
+            regions,
+            proton_charge_sample=sample.coords["proton_charge"],
+            proton_charge_ob=ob.coords["proton_charge"],
+            spectrum_roi_strict=spectrum_roi_strict,
+            progress=run_progress.for_stage(
+                STAGE_REDUCE_SPECTRUM,
+                total=normalize_roi_spectrum_step_count(proton_charge_sample=sample.coords["proton_charge"]),
+            ),
+        )
+        _add_derived_coords(spectrum, sample, flight_path)
+        # `resolved_spec`, not `rebin_by_tof`: with rebin_by_tof=True the factor came from the
+        # statistics analysis, and recording the literal True would leave the file unable to say how
+        # many frames went into a point.
+        metadata.update(spectrum_reduction_provenance(regions, reduction=rebin_reduction, rebin_by_tof=resolved_spec))
+        _warn_on_a_gapped_spectrum(resolved_spec, n_frames_before_rebin)
+        bin_indices = spectrum_bin_indices(n_frames_before_rebin, resolved_spec)
+        if bin_indices is not None:
+            metadata["spectrum_bin_first_frame"] = bin_indices
+        output_description = _export_spectrum(
+            output_path,
+            spectrum,
+            metadata=metadata,
+            bin_indices=bin_indices,
+            run_progress=run_progress,
+        )
+        logger.success("{} pipeline completed successfully. Output written to {}", profile.label, output_description)
+        return spectrum
+
+    # Normalization
+    transmission = normalize_transmission(
+        sample=sample,
+        ob=ob,
+        proton_charge_sample=sample.coords["proton_charge"],
+        proton_charge_ob=ob.coords["proton_charge"],
+        progress=run_progress.for_stage(
+            STAGE_NORMALIZE,
+            total=normalize_step_count(proton_charge_sample=sample.coords["proton_charge"]),
+        ),
+    )
+
+    # Air region correction (optional)
+    if air_roi is not None:
+        transmission = apply_air_region_correction(transmission, air_roi)
+
+    _add_derived_coords(transmission, sample, flight_path)
+
+    if air_roi is not None:
+        metadata["air_roi"] = region_provenance(air_roi)
+
+    output_description, transmission = _export_transmission(
+        output_path,
+        transmission,
+        sample,
+        profile=profile,
+        metadata=metadata,
+        tiff_one_file_per_image=tiff_one_file_per_image,
+        run_progress=run_progress,
+    )
+
+    logger.success("{} pipeline completed successfully. Output written to {}", profile.label, output_description)
+    return transmission

--- a/src/neunorm/pipelines/venus_tpx1.py
+++ b/src/neunorm/pipelines/venus_tpx1.py
@@ -8,40 +8,36 @@ from typing import Literal, Optional, Sequence
 
 import numpy as np
 import scipp as sc
-from loguru import logger
 
 from neunorm import __version__
-from neunorm.data_models.roi import (
-    MaskROI,
-    RegionLike,
-    ROILike,
-    as_roi_bounds,
-    region_provenance,
-)
-from neunorm.exporters.hdf5_writer import hdf5_export_step_count, write_hdf5
-from neunorm.exporters.tiff_writer import tiff_export_step_count, write_tiff_stack
+from neunorm.data_models.roi import RegionLike, RegionsLike, ROILike
 from neunorm.loaders.metadata_loader import load_metadata
 from neunorm.loaders.tiff_loader import load_tiff_stack
-from neunorm.processing.air_region_corrector import apply_air_region_correction
-from neunorm.processing.normalizer import normalize_step_count, normalize_transmission
-from neunorm.processing.roi_clipper import apply_roi
+from neunorm.pipelines._tof_spine import (
+    TofPipelineProfile,
+    coerce_roi_arguments,
+    reduce_tof_stacks,
+    require_matching_group_counts,
+)
 from neunorm.processing.run_combiner import combine_runs
-from neunorm.processing.spatial_rebinner import rebin_spatial
-from neunorm.tof.coordinate_converter import convert_tof_to_energy, convert_tof_to_wavelength
-from neunorm.tof.histogram_rebinner import rebin_tof
-from neunorm.tof.pixel_detector import detect_dead_pixels
-from neunorm.tof.statistics_analyzer import analyze_statistics
 from neunorm.utils.constants import VENUS_FLIGHT_PATH_M
 from neunorm.utils.progress import (
     STAGE_COMBINE_RUNS,
-    STAGE_EXPORT,
     STAGE_LOAD_OB,
     STAGE_LOAD_SAMPLE,
-    STAGE_NORMALIZE,
-    STAGE_REBIN_TOF,
     Progress,
     resolve_progress,
     total_across_groups,
+)
+
+#: TPX1 detects no hot pixels, re-detects its masks from the open beam after a spatial rebin, passes
+#: no ``hot_pixel_mask`` to the HDF5 writer, and reads its TIFF detector model from the metadata.
+_TPX1_PROFILE = TofPipelineProfile(
+    label="VENUS TPX1",
+    detect_hot=False,
+    remask_after_spatial_rebin_from="ob",
+    hdf5_hot_pixel_mask=None,
+    tiff_detector_model=None,
 )
 
 
@@ -62,7 +58,7 @@ def _tof_bin_edges_from_left_edges(spectra_tof: sc.Variable) -> sc.Variable:
     return sc.array(dims=["tof"], values=np.append(values, closing), unit=spectra_tof.unit)
 
 
-def run_venus_tpx1_pipeline(  # noqa: C901
+def run_venus_tpx1_pipeline(
     sample_hdf5_paths: Sequence[str | Path],
     ob_hdf5_paths: Sequence[str | Path],
     sample_tiff_paths: Sequence[Sequence[str | Path]],
@@ -76,6 +72,8 @@ def run_venus_tpx1_pipeline(  # noqa: C901
     *,
     rebin_reduction: Optional[Literal["mean", "sum", "median"]] = None,
     tiff_one_file_per_image: bool = False,
+    spectrum_roi: Optional[RegionsLike] = None,
+    spectrum_roi_strict: bool = True,
     progress: Progress = False,
 ) -> sc.DataArray:
     """Execute VENUS TPX1 normalization pipeline.
@@ -170,22 +168,10 @@ def run_venus_tpx1_pipeline(  # noqa: C901
     """
     # Accept an ROI or a bare (x0, y0, x1, y1) tuple for every ROI argument; coerce to bounds
     # tuples up front so cropping and provenance see a consistent form.
-    if roi is not None:
-        roi = as_roi_bounds(roi)
-    if air_roi is not None:
-        air_roi = air_roi if isinstance(air_roi, MaskROI) else as_roi_bounds(air_roi)
+    roi, air_roi = coerce_roi_arguments(roi, air_roi)
 
     # length of hdf5 paths and tiff paths should match for both sample and OB
-    if len(sample_hdf5_paths) != len(sample_tiff_paths):
-        raise ValueError(
-            f"Number of sample HDF5 paths ({len(sample_hdf5_paths)}) does not match number of sample TIFF path groups "
-            f"({len(sample_tiff_paths)})."
-        )
-    if len(ob_hdf5_paths) != len(ob_tiff_paths):
-        raise ValueError(
-            f"Number of OB HDF5 paths ({len(ob_hdf5_paths)}) does not match number of OB TIFF path groups "
-            f"({len(ob_tiff_paths)})."
-        )
+    require_matching_group_counts(sample_hdf5_paths, sample_tiff_paths, ob_hdf5_paths, ob_tiff_paths)
 
     # One reporter for the whole run, resolved exactly once: a second resolve of `progress=True`
     # would build a second tqdm sink and a duplicate set of bars. Each stage below takes its own
@@ -261,73 +247,6 @@ def run_venus_tpx1_pipeline(  # noqa: C901
         )
         combine()
 
-        # Apply ROI if specified
-        if roi:
-            sample = apply_roi(sample, roi)
-            ob = apply_roi(ob, roi)
-
-        # Dead pixel detection
-        sample.masks["dead_pixels"] = detect_dead_pixels(ob)
-
-        # Spatial rebinning (optional)
-        if rebin_by_spatial is not None:
-            sample = rebin_spatial(sample, rebin_by_spatial)
-            ob = rebin_spatial(ob, rebin_by_spatial)
-            # redo mask after rebinning
-            sample.masks["dead_pixels"] = detect_dead_pixels(ob)
-
-        # TOF rebinning (optional): an integer factor, ``True`` for the statistics-based recommended
-        # factor, or an explicit ``[[start, stop], ...]`` bin list. ``rebin_reduction`` selects how
-        # frames combine (default: sum for a factor, mean for a bin list); see ``rebin_tof``.
-        # A bin list/tuple (even empty) is an explicit rebin request; an empty one must surface as an error
-        # from ``rebin_tof`` rather than be silently skipped by the plain falsy check.
-        if rebin_by_tof or isinstance(rebin_by_tof, (list, tuple)):
-            spec = rebin_by_tof
-            if spec is True:
-                spec = analyze_statistics(ob).recommended_rebinning
-                logger.info(f"Recommended TOF rebinning factor based on statistics analysis: {spec}")
-            if isinstance(spec, bool) or not isinstance(spec, (int, np.integer, list, tuple)):
-                raise ValueError(
-                    f"rebin_by_tof must be a bool, an int factor, or a list/tuple of [start, stop] pairs; got {spec!r}"
-                )
-            # rebin_tof takes no progress argument of its own, so the pipeline names the two calls
-            # around it: with a median reduction this is one of the slowest stages in the run.
-            rebin = run_progress.for_stage(STAGE_REBIN_TOF, total=2)
-            rebin.note("rebinning sample TOF")
-            sample = rebin_tof(sample, spec, reduction=rebin_reduction)
-            rebin()
-            rebin.note("rebinning open beam TOF")
-            ob = rebin_tof(ob, spec, reduction=rebin_reduction)
-            rebin()
-
-        # Normalization
-        transmission = normalize_transmission(
-            sample=sample,
-            ob=ob,
-            proton_charge_sample=sample.coords["proton_charge"],
-            proton_charge_ob=ob.coords["proton_charge"],
-            progress=run_progress.for_stage(
-                STAGE_NORMALIZE,
-                total=normalize_step_count(proton_charge_sample=sample.coords["proton_charge"]),
-            ),
-        )
-
-        # Air region correction (optional)
-        if air_roi is not None:
-            transmission = apply_air_region_correction(transmission, air_roi)
-
-        # Add wavelength and energy coordinates converted from TOF using the configurable flight
-        # path and the time offset from the metadata.
-        if "detector_time_offset" in sample.coords:
-            time_offset = sample.coords["detector_time_offset"]
-            transmission.coords["wavelength"] = convert_tof_to_wavelength(
-                transmission.coords["tof"], flight_path, time_offset
-            )
-            transmission.coords["energy"] = convert_tof_to_energy(transmission.coords["tof"], flight_path, time_offset)
-        else:
-            logger.warning("Time offset not found in metadata. Cannot add wavelength and energy coordinates.")
-
-        # Write output
         metadata = {
             "sample_hdf5_paths": [str(run) for run in sample_hdf5_paths],
             "ob_hdf5_paths": [str(run) for run in ob_hdf5_paths],
@@ -337,73 +256,20 @@ def run_venus_tpx1_pipeline(  # noqa: C901
             "version": __version__,
         }
 
-        if roi:
-            metadata["roi_applied"] = region_provenance(roi)
-
-        if air_roi is not None:
-            metadata["air_roi"] = region_provenance(air_roi)
-
-        output_description = str(output_path)
-        if output_path.suffix.lower() in (".hdf5", ".h5"):
-            write_hdf5(
-                output_path,
-                transmission,
-                dead_pixel_mask="dead_pixels",
-                metadata=metadata,
-                progress=run_progress.for_stage(STAGE_EXPORT, total=hdf5_export_step_count(transmission, metadata)),
-            )
-        elif output_path.suffix.lower() in (".tiff", ".tif"):
-            rename_map = {}
-            if "tof" in transmission.dims:
-                rename_map["tof"] = "t"  # TIFF stacks typically use 't' for the time dimension
-            if rename_map:
-                transmission = transmission.rename_dims(rename_map)
-
-            model = "Unknown"
-            if "detector" in sample.coords:
-                model = sample.coords["detector"].value
-
-            daqmetadata = {
-                "facility": "SNS",
-                "instrument": "VENUS",
-                "detector_type": model,
-                "source_type": "neutron",
-            }
-
-            # Combine all masks and broadcast to the shape of the transmission data.
-            # Mask must be same shape as the image data for scitiff. Broadcast each mask by DIM NAME
-            # (scipp), so both a spatial (y, x) mask and a 1-D per-frame (t) mask expand correctly to
-            # the full (t, y, x) stack.
-            if transmission.masks:
-                combined_mask = np.zeros_like(transmission.values, dtype=bool)
-                for mask in transmission.masks.values():
-                    combined_mask |= sc.broadcast(mask, sizes=transmission.sizes).values
-
-                # remove other masks
-                transmission.masks.clear()
-                # add combined mask back in with name "scitiff-mask"
-                transmission.masks["scitiff-mask"] = sc.array(dims=transmission.dims, values=combined_mask, dtype=bool)
-
-            written_paths = write_tiff_stack(
-                output_path,
-                transmission,
-                metadata=metadata,
-                daqmetadata=daqmetadata,
-                one_file_per_image=tiff_one_file_per_image,
-                progress=run_progress.for_stage(
-                    STAGE_EXPORT,
-                    total=tiff_export_step_count(transmission, one_file_per_image=tiff_one_file_per_image),
-                ),
-            )
-            # In per-image mode ``output_path`` is only a naming template and is never written, so
-            # report what actually landed on disk rather than a file that does not exist.
-            if len(written_paths) > 1:
-                output_description = f"{len(written_paths)} files, {written_paths[0].name} .. {written_paths[-1].name}"
-            else:
-                output_description = str(written_paths[0])
-
-        else:
-            raise ValueError(f"Unsupported output file format: {output_path.suffix}")
-
-        logger.success("VENUS TPX1 pipeline completed successfully. Output written to {}", output_description)
-        return transmission
+        return reduce_tof_stacks(
+            sample,
+            ob,
+            output_path=output_path,
+            profile=_TPX1_PROFILE,
+            metadata=metadata,
+            roi=roi,
+            air_roi=air_roi,
+            rebin_by_tof=rebin_by_tof,
+            rebin_by_spatial=rebin_by_spatial,
+            rebin_reduction=rebin_reduction,
+            flight_path=flight_path,
+            tiff_one_file_per_image=tiff_one_file_per_image,
+            spectrum_roi=spectrum_roi,
+            spectrum_roi_strict=spectrum_roi_strict,
+            run_progress=run_progress,
+        )

--- a/src/neunorm/pipelines/venus_tpx3_event.py
+++ b/src/neunorm/pipelines/venus_tpx3_event.py
@@ -6,49 +6,43 @@ from datetime import datetime
 from pathlib import Path
 from typing import Literal, Optional, Sequence
 
-import numpy as np
 import scipp as sc
-from loguru import logger
 
 from neunorm import __version__
-from neunorm.data_models.roi import (
-    MaskROI,
-    RegionLike,
-    ROILike,
-    as_roi_bounds,
-    region_provenance,
-)
+from neunorm.data_models.roi import RegionLike, RegionsLike, ROILike
 from neunorm.data_models.tof import BinningConfig
-from neunorm.exporters.hdf5_writer import hdf5_export_step_count, write_hdf5
-from neunorm.exporters.tiff_writer import tiff_export_step_count, write_tiff_stack
 from neunorm.loaders.event_loader import LOAD_EVENT_NEXUS_STEPS, load_event_nexus
 from neunorm.loaders.metadata_loader import load_metadata
-from neunorm.processing.air_region_corrector import apply_air_region_correction
-from neunorm.processing.normalizer import normalize_step_count, normalize_transmission
-from neunorm.processing.roi_clipper import apply_roi
+from neunorm.pipelines._tof_spine import (
+    TofPipelineProfile,
+    coerce_roi_arguments,
+    reduce_tof_stacks,
+)
 from neunorm.processing.run_combiner import combine_runs
-from neunorm.processing.spatial_rebinner import rebin_spatial
-from neunorm.tof.coordinate_converter import convert_tof_to_energy, convert_tof_to_wavelength
 from neunorm.tof.event_converter import convert_events_to_histogram
-from neunorm.tof.histogram_rebinner import rebin_tof
-from neunorm.tof.pixel_detector import detect_dead_pixels, detect_hot_pixels
-from neunorm.tof.statistics_analyzer import analyze_statistics
 from neunorm.utils.constants import VENUS_FLIGHT_PATH_M
 from neunorm.utils.progress import (
     STAGE_COMBINE_RUNS,
-    STAGE_EXPORT,
     STAGE_HISTOGRAM,
     STAGE_LOAD_OB,
     STAGE_LOAD_SAMPLE,
-    STAGE_NORMALIZE,
-    STAGE_REBIN_TOF,
     Progress,
     resolve_progress,
     total_across_groups,
 )
 
+#: Event mode detects hot pixels, re-detects from the open beam after a spatial rebin, and hard-codes
+#: its TIFF detector model rather than reading a ``detector`` coordinate.
+_TPX3_EVENT_PROFILE = TofPipelineProfile(
+    label="VENUS TPX3 event",
+    detect_hot=True,
+    remask_after_spatial_rebin_from="ob",
+    hdf5_hot_pixel_mask="hot_pixels",
+    tiff_detector_model="TPX3",
+)
 
-def run_venus_tpx3_event_pipeline(  # noqa: C901
+
+def run_venus_tpx3_event_pipeline(
     sample_paths: Sequence[str | Path],
     ob_paths: Sequence[str | Path],
     binning: BinningConfig,
@@ -64,6 +58,8 @@ def run_venus_tpx3_event_pipeline(  # noqa: C901
     *,
     rebin_reduction: Optional[Literal["mean", "sum", "median"]] = None,
     tiff_one_file_per_image: bool = False,
+    spectrum_roi: Optional[RegionsLike] = None,
+    spectrum_roi_strict: bool = True,
     progress: Progress = False,
 ) -> sc.DataArray:
     """Execute VENUS TPX3 event normalization pipeline.
@@ -165,10 +161,7 @@ def run_venus_tpx3_event_pipeline(  # noqa: C901
     """
     # Accept an ROI or a bare (x0, y0, x1, y1) tuple for every ROI argument; coerce to bounds
     # tuples up front so cropping and provenance see a consistent form.
-    if roi is not None:
-        roi = as_roi_bounds(roi)
-    if air_roi is not None:
-        air_roi = air_roi if isinstance(air_roi, MaskROI) else as_roi_bounds(air_roi)
+    roi, air_roi = coerce_roi_arguments(roi, air_roi)
 
     # One reporter for the whole run, resolved exactly once: a second resolve of `progress=True`
     # would build a second tqdm sink and a duplicate set of bars. Each stage below takes its own
@@ -272,77 +265,6 @@ def run_venus_tpx3_event_pipeline(  # noqa: C901
         )
         combine()
 
-        # Apply ROI if specified
-        if roi:
-            sample = apply_roi(sample, roi)
-            ob = apply_roi(ob, roi)
-
-        # Dead pixel detection
-        sample.masks["dead_pixels"] = detect_dead_pixels(ob)
-
-        # Hot pixel detection
-        sample.masks["hot_pixels"] = detect_hot_pixels(ob)
-
-        # Spatial rebinning (optional)
-        if rebin_by_spatial is not None:
-            sample = rebin_spatial(sample, rebin_by_spatial)
-            ob = rebin_spatial(ob, rebin_by_spatial)
-            # redo mask after rebinning
-            sample.masks["dead_pixels"] = detect_dead_pixels(ob)
-            sample.masks["hot_pixels"] = detect_hot_pixels(ob)
-
-        # TOF rebinning (optional): applied to the histogrammed event stack. An integer factor, ``True``
-        # for the statistics-based recommended factor, or an explicit ``[[start, stop], ...]`` bin list.
-        # ``rebin_reduction`` selects how frames combine (default: sum for a factor, mean for a bin list).
-        # A bin list/tuple (even empty) is an explicit rebin request; an empty one must surface as an error
-        # from ``rebin_tof`` rather than be silently skipped by the plain falsy check.
-        if rebin_by_tof or isinstance(rebin_by_tof, (list, tuple)):
-            spec = rebin_by_tof
-            if spec is True:
-                spec = analyze_statistics(ob).recommended_rebinning
-                logger.info(f"Recommended TOF rebinning factor based on statistics analysis: {spec}")
-            if isinstance(spec, bool) or not isinstance(spec, (int, np.integer, list, tuple)):
-                raise ValueError(
-                    f"rebin_by_tof must be a bool, an int factor, or a list/tuple of [start, stop] pairs; got {spec!r}"
-                )
-            # rebin_tof takes no progress argument of its own, so the pipeline names the two calls
-            # around it: with a median reduction this is one of the slowest stages in the run.
-            rebin = run_progress.for_stage(STAGE_REBIN_TOF, total=2)
-            rebin.note("rebinning sample TOF")
-            sample = rebin_tof(sample, spec, reduction=rebin_reduction)
-            rebin()
-            rebin.note("rebinning open beam TOF")
-            ob = rebin_tof(ob, spec, reduction=rebin_reduction)
-            rebin()
-
-        # Normalization
-        transmission = normalize_transmission(
-            sample=sample,
-            ob=ob,
-            proton_charge_sample=sample.coords["proton_charge"],
-            proton_charge_ob=ob.coords["proton_charge"],
-            progress=run_progress.for_stage(
-                STAGE_NORMALIZE,
-                total=normalize_step_count(proton_charge_sample=sample.coords["proton_charge"]),
-            ),
-        )
-
-        # Air region correction (optional)
-        if air_roi is not None:
-            transmission = apply_air_region_correction(transmission, air_roi)
-
-        # Add wavelength and energy coordinates converted from TOF using the same flight path as
-        # the binning step and the time offset from the metadata.
-        if "detector_time_offset" in sample.coords:
-            time_offset = sample.coords["detector_time_offset"]
-            transmission.coords["wavelength"] = convert_tof_to_wavelength(
-                transmission.coords["tof"], flight_path, time_offset
-            )
-            transmission.coords["energy"] = convert_tof_to_energy(transmission.coords["tof"], flight_path, time_offset)
-        else:
-            logger.warning("Time offset not found in metadata. Cannot add wavelength and energy coordinates.")
-
-        # Write output
         metadata = {
             "sample_paths": [str(run) for run in sample_paths],
             "ob_paths": [str(run) for run in ob_paths],
@@ -350,69 +272,20 @@ def run_venus_tpx3_event_pipeline(  # noqa: C901
             "version": __version__,
         }
 
-        if roi:
-            metadata["roi_applied"] = region_provenance(roi)
-
-        if air_roi is not None:
-            metadata["air_roi"] = region_provenance(air_roi)
-
-        output_description = str(output_path)
-        if output_path.suffix.lower() in (".hdf5", ".h5"):
-            write_hdf5(
-                output_path,
-                transmission,
-                dead_pixel_mask="dead_pixels",
-                hot_pixel_mask="hot_pixels",
-                metadata=metadata,
-                progress=run_progress.for_stage(STAGE_EXPORT, total=hdf5_export_step_count(transmission, metadata)),
-            )
-        elif output_path.suffix.lower() in (".tiff", ".tif"):
-            rename_map = {}
-            if "tof" in transmission.dims:
-                rename_map["tof"] = "t"  # TIFF stacks typically use 't' for the time dimension
-            if rename_map:
-                transmission = transmission.rename_dims(rename_map)
-
-            daqmetadata = {
-                "facility": "SNS",
-                "instrument": "VENUS",
-                "detector_type": "TPX3",
-                "source_type": "neutron",
-            }
-
-            # Combine all masks and broadcast to the shape of the transmission data.
-            # Mask must be same shape as the image data for scitiff.
-            if transmission.masks:
-                combined_mask = np.zeros_like(transmission.values, dtype=bool)
-                for mask in transmission.masks.values():
-                    # dim-aware broadcast: a (y, x) mask and a 1-D per-frame (t) mask both expand to (t, y, x)
-                    combined_mask |= sc.broadcast(mask, sizes=transmission.sizes).values
-
-                # remove other masks
-                transmission.masks.clear()
-                # add combined mask back in with name "scitiff-mask"
-                transmission.masks["scitiff-mask"] = sc.array(dims=transmission.dims, values=combined_mask, dtype=bool)
-
-            written_paths = write_tiff_stack(
-                output_path,
-                transmission,
-                metadata=metadata,
-                daqmetadata=daqmetadata,
-                one_file_per_image=tiff_one_file_per_image,
-                progress=run_progress.for_stage(
-                    STAGE_EXPORT,
-                    total=tiff_export_step_count(transmission, one_file_per_image=tiff_one_file_per_image),
-                ),
-            )
-            # In per-image mode ``output_path`` is only a naming template and is never written, so
-            # report what actually landed on disk rather than a file that does not exist.
-            if len(written_paths) > 1:
-                output_description = f"{len(written_paths)} files, {written_paths[0].name} .. {written_paths[-1].name}"
-            else:
-                output_description = str(written_paths[0])
-
-        else:
-            raise ValueError(f"Unsupported output file format: {output_path.suffix}")
-
-        logger.success("VENUS TPX3 event pipeline completed successfully. Output written to {}", output_description)
-        return transmission
+        return reduce_tof_stacks(
+            sample,
+            ob,
+            output_path=output_path,
+            profile=_TPX3_EVENT_PROFILE,
+            metadata=metadata,
+            roi=roi,
+            air_roi=air_roi,
+            rebin_by_tof=rebin_by_tof,
+            rebin_by_spatial=rebin_by_spatial,
+            rebin_reduction=rebin_reduction,
+            flight_path=flight_path,
+            tiff_one_file_per_image=tiff_one_file_per_image,
+            spectrum_roi=spectrum_roi,
+            spectrum_roi_strict=spectrum_roi_strict,
+            run_progress=run_progress,
+        )

--- a/src/neunorm/pipelines/venus_tpx3_histogram.py
+++ b/src/neunorm/pipelines/venus_tpx3_histogram.py
@@ -6,46 +6,42 @@ from datetime import datetime
 from pathlib import Path
 from typing import Literal, Optional, Sequence
 
-import numpy as np
 import scipp as sc
-from loguru import logger
 
 from neunorm import __version__
-from neunorm.data_models.roi import (
-    MaskROI,
-    RegionLike,
-    ROILike,
-    as_roi_bounds,
-    region_provenance,
-)
-from neunorm.exporters.hdf5_writer import hdf5_export_step_count, write_hdf5
-from neunorm.exporters.tiff_writer import tiff_export_step_count, write_tiff_stack
+from neunorm.data_models.roi import RegionLike, RegionsLike, ROILike
 from neunorm.loaders.metadata_loader import load_metadata
 from neunorm.loaders.tiff_loader import load_tiff_stack
-from neunorm.processing.air_region_corrector import apply_air_region_correction
-from neunorm.processing.normalizer import normalize_step_count, normalize_transmission
-from neunorm.processing.roi_clipper import apply_roi
+from neunorm.pipelines._tof_spine import (
+    TofPipelineProfile,
+    coerce_roi_arguments,
+    reduce_tof_stacks,
+    require_matching_group_counts,
+)
 from neunorm.processing.run_combiner import combine_runs
-from neunorm.processing.spatial_rebinner import rebin_spatial
-from neunorm.tof.coordinate_converter import convert_tof_to_energy, convert_tof_to_wavelength
-from neunorm.tof.histogram_rebinner import rebin_tof
-from neunorm.tof.pixel_detector import detect_dead_pixels, detect_hot_pixels
-from neunorm.tof.statistics_analyzer import analyze_statistics
 from neunorm.utils.constants import VENUS_FLIGHT_PATH_M
 from neunorm.utils.progress import (
     STAGE_COMBINE_RUNS,
-    STAGE_EXPORT,
     STAGE_LOAD_OB,
     STAGE_LOAD_SAMPLE,
-    STAGE_NORMALIZE,
-    STAGE_REBIN_TOF,
     Progress,
     resolve_progress,
     total_across_groups,
 )
 
+#: TPX3 histogram mode detects hot pixels as well as dead ones. Note it re-detects both from the
+#: SAMPLE after a spatial rebin, where its own pre-rebin detection — and both other TOF pipelines —
+#: read the open beam. Recorded rather than corrected: changing it changes this pipeline's masks.
+_TPX3_HISTOGRAM_PROFILE = TofPipelineProfile(
+    label="VENUS TPX3 histogram",
+    detect_hot=True,
+    remask_after_spatial_rebin_from="sample",
+    hdf5_hot_pixel_mask="hot_pixels",
+    tiff_detector_model=None,
+)
 
-def run_venus_tpx3_histogram_pipeline(  # noqa: C901
+
+def run_venus_tpx3_histogram_pipeline(
     sample_hdf5_paths: Sequence[str | Path],
     ob_hdf5_paths: Sequence[str | Path],
     sample_tiff_paths: Sequence[Sequence[str | Path]],
@@ -59,6 +55,8 @@ def run_venus_tpx3_histogram_pipeline(  # noqa: C901
     *,
     rebin_reduction: Optional[Literal["mean", "sum", "median"]] = None,
     tiff_one_file_per_image: bool = False,
+    spectrum_roi: Optional[RegionsLike] = None,
+    spectrum_roi_strict: bool = True,
     progress: Progress = False,
 ) -> sc.DataArray:
     """Execute VENUS TPX3 histogram normalization pipeline.
@@ -154,22 +152,10 @@ def run_venus_tpx3_histogram_pipeline(  # noqa: C901
     """
     # Accept an ROI or a bare (x0, y0, x1, y1) tuple for every ROI argument; coerce to bounds
     # tuples up front so cropping and provenance see a consistent form.
-    if roi is not None:
-        roi = as_roi_bounds(roi)
-    if air_roi is not None:
-        air_roi = air_roi if isinstance(air_roi, MaskROI) else as_roi_bounds(air_roi)
+    roi, air_roi = coerce_roi_arguments(roi, air_roi)
 
     # length of hdf5 paths and tiff paths should match for both sample and OB
-    if len(sample_hdf5_paths) != len(sample_tiff_paths):
-        raise ValueError(
-            f"Number of sample HDF5 paths ({len(sample_hdf5_paths)}) does not match number of sample TIFF path groups "
-            f"({len(sample_tiff_paths)})."
-        )
-    if len(ob_hdf5_paths) != len(ob_tiff_paths):
-        raise ValueError(
-            f"Number of OB HDF5 paths ({len(ob_hdf5_paths)}) does not match number of OB TIFF path groups "
-            f"({len(ob_tiff_paths)})."
-        )
+    require_matching_group_counts(sample_hdf5_paths, sample_tiff_paths, ob_hdf5_paths, ob_tiff_paths)
 
     # One reporter for the whole run, resolved exactly once: a second resolve of `progress=True`
     # would build a second tqdm sink and a duplicate set of bars. Each stage below takes its own
@@ -253,77 +239,6 @@ def run_venus_tpx3_histogram_pipeline(  # noqa: C901
         )
         combine()
 
-        # Apply ROI if specified
-        if roi:
-            sample = apply_roi(sample, roi)
-            ob = apply_roi(ob, roi)
-
-        # Dead pixel detection
-        sample.masks["dead_pixels"] = detect_dead_pixels(ob)
-
-        # Hot pixel detection
-        sample.masks["hot_pixels"] = detect_hot_pixels(ob)
-
-        # Spatial rebinning (optional)
-        if rebin_by_spatial is not None:
-            sample = rebin_spatial(sample, rebin_by_spatial)
-            ob = rebin_spatial(ob, rebin_by_spatial)
-            # redo mask after rebinning
-            sample.masks["dead_pixels"] = detect_dead_pixels(sample)
-            sample.masks["hot_pixels"] = detect_hot_pixels(sample)
-
-        # TOF rebinning (optional): an integer factor, ``True`` for the statistics-based recommended
-        # factor, or an explicit ``[[start, stop], ...]`` bin list. ``rebin_reduction`` selects how
-        # frames combine (default: sum for a factor, mean for a bin list); see ``rebin_tof``.
-        # A bin list/tuple (even empty) is an explicit rebin request; an empty one must surface as an error
-        # from ``rebin_tof`` rather than be silently skipped by the plain falsy check.
-        if rebin_by_tof or isinstance(rebin_by_tof, (list, tuple)):
-            spec = rebin_by_tof
-            if spec is True:
-                spec = analyze_statistics(ob).recommended_rebinning
-                logger.info(f"Recommended TOF rebinning factor based on statistics analysis: {spec}")
-            if isinstance(spec, bool) or not isinstance(spec, (int, np.integer, list, tuple)):
-                raise ValueError(
-                    f"rebin_by_tof must be a bool, an int factor, or a list/tuple of [start, stop] pairs; got {spec!r}"
-                )
-            # rebin_tof takes no progress argument of its own, so the pipeline names the two calls
-            # around it: with a median reduction this is one of the slowest stages in the run.
-            rebin = run_progress.for_stage(STAGE_REBIN_TOF, total=2)
-            rebin.note("rebinning sample TOF")
-            sample = rebin_tof(sample, spec, reduction=rebin_reduction)
-            rebin()
-            rebin.note("rebinning open beam TOF")
-            ob = rebin_tof(ob, spec, reduction=rebin_reduction)
-            rebin()
-
-        # Normalization
-        transmission = normalize_transmission(
-            sample=sample,
-            ob=ob,
-            proton_charge_sample=sample.coords["proton_charge"],
-            proton_charge_ob=ob.coords["proton_charge"],
-            progress=run_progress.for_stage(
-                STAGE_NORMALIZE,
-                total=normalize_step_count(proton_charge_sample=sample.coords["proton_charge"]),
-            ),
-        )
-
-        # Air region correction (optional)
-        if air_roi is not None:
-            transmission = apply_air_region_correction(transmission, air_roi)
-
-        # Add wavelength and energy coordinates converted from TOF using the configurable flight
-        # path and the time offset from the metadata.
-        if "detector_time_offset" in sample.coords:
-            time_offset = sample.coords["detector_time_offset"]
-            transmission.coords["wavelength"] = convert_tof_to_wavelength(
-                transmission.coords["tof"], flight_path, time_offset
-            )
-            transmission.coords["energy"] = convert_tof_to_energy(transmission.coords["tof"], flight_path, time_offset)
-        else:
-            logger.warning("Time offset not found in metadata. Cannot add wavelength and energy coordinates.")
-
-        # Write output
         metadata = {
             "sample_hdf5_paths": [str(run) for run in sample_hdf5_paths],
             "ob_hdf5_paths": [str(run) for run in ob_hdf5_paths],
@@ -333,73 +248,20 @@ def run_venus_tpx3_histogram_pipeline(  # noqa: C901
             "version": __version__,
         }
 
-        if roi:
-            metadata["roi_applied"] = region_provenance(roi)
-
-        if air_roi is not None:
-            metadata["air_roi"] = region_provenance(air_roi)
-
-        output_description = str(output_path)
-        if output_path.suffix.lower() in (".hdf5", ".h5"):
-            write_hdf5(
-                output_path,
-                transmission,
-                dead_pixel_mask="dead_pixels",
-                hot_pixel_mask="hot_pixels",
-                metadata=metadata,
-                progress=run_progress.for_stage(STAGE_EXPORT, total=hdf5_export_step_count(transmission, metadata)),
-            )
-        elif output_path.suffix.lower() in (".tiff", ".tif"):
-            rename_map = {}
-            if "tof" in transmission.dims:
-                rename_map["tof"] = "t"  # TIFF stacks typically use 't' for the time dimension
-            if rename_map:
-                transmission = transmission.rename_dims(rename_map)
-
-            model = "Unknown"
-            if "detector" in sample.coords:
-                model = sample.coords["detector"].value
-
-            daqmetadata = {
-                "facility": "SNS",
-                "instrument": "VENUS",
-                "detector_type": model,
-                "source_type": "neutron",
-            }
-
-            # Combine all masks and broadcast to the shape of the transmission data.
-            # Mask must be same shape as the image data for scitiff.
-            if transmission.masks:
-                combined_mask = np.zeros_like(transmission.values, dtype=bool)
-                for mask in transmission.masks.values():
-                    # dim-aware broadcast: a (y, x) mask and a 1-D per-frame (t) mask both expand to (t, y, x)
-                    combined_mask |= sc.broadcast(mask, sizes=transmission.sizes).values
-
-                # remove other masks
-                transmission.masks.clear()
-                # add combined mask back in with name "scitiff-mask"
-                transmission.masks["scitiff-mask"] = sc.array(dims=transmission.dims, values=combined_mask, dtype=bool)
-
-            written_paths = write_tiff_stack(
-                output_path,
-                transmission,
-                metadata=metadata,
-                daqmetadata=daqmetadata,
-                one_file_per_image=tiff_one_file_per_image,
-                progress=run_progress.for_stage(
-                    STAGE_EXPORT,
-                    total=tiff_export_step_count(transmission, one_file_per_image=tiff_one_file_per_image),
-                ),
-            )
-            # In per-image mode ``output_path`` is only a naming template and is never written, so
-            # report what actually landed on disk rather than a file that does not exist.
-            if len(written_paths) > 1:
-                output_description = f"{len(written_paths)} files, {written_paths[0].name} .. {written_paths[-1].name}"
-            else:
-                output_description = str(written_paths[0])
-
-        else:
-            raise ValueError(f"Unsupported output file format: {output_path.suffix}")
-
-        logger.success("VENUS TPX3 histogram pipeline completed successfully. Output written to {}", output_description)
-        return transmission
+        return reduce_tof_stacks(
+            sample,
+            ob,
+            output_path=output_path,
+            profile=_TPX3_HISTOGRAM_PROFILE,
+            metadata=metadata,
+            roi=roi,
+            air_roi=air_roi,
+            rebin_by_tof=rebin_by_tof,
+            rebin_by_spatial=rebin_by_spatial,
+            rebin_reduction=rebin_reduction,
+            flight_path=flight_path,
+            tiff_one_file_per_image=tiff_one_file_per_image,
+            spectrum_roi=spectrum_roi,
+            spectrum_roi_strict=spectrum_roi_strict,
+            run_progress=run_progress,
+        )

--- a/src/neunorm/processing/normalizer.py
+++ b/src/neunorm/processing/normalizer.py
@@ -112,9 +112,17 @@ def _unmasked_count(region: sc.DataArray) -> sc.Variable:
 
     Sums a dimensionless field of ones carrying the region's masks, so masked pixels are excluded and
     a per-image ``(spectral, x, y)`` mask yields a per-spectral count (a scalar for a 2D/absent mask).
+
+    The counter is BUILT rather than copied from ``region``. A ``region.copy()`` here duplicates the
+    region's values and variances only to overwrite them with ones, which doubles peak memory for a
+    region the size of the frame — and ``roi_mean_spectrum`` is called with the whole detector when
+    ``detect_resonances`` is given no region. The returned shape is unchanged: the sizes and the masks
+    are the same, so the count is the same per-spectral vector it always was.
     """
-    counter = region.copy()
-    counter.data = sc.ones(sizes=region.data.sizes, dtype="int64", unit="one")
+    counter = sc.DataArray(
+        sc.ones(sizes=region.data.sizes, dtype="int64", unit="one"),
+        masks={name: mask for name, mask in region.masks.items()},
+    )
     return sc.sum(counter, dim=["x", "y"]).data
 
 

--- a/src/neunorm/processing/spectrum_reducer.py
+++ b/src/neunorm/processing/spectrum_reducer.py
@@ -1,0 +1,466 @@
+"""
+ROI-level spectrum reduction — the reduction behind NeuNorm's "resonance mode".
+
+Where the image mode divides sample by open beam pixel by pixel and returns a stack of images, this
+module collapses a region of interest to **one number per spectral bin first** and divides second,
+returning a 1-D transmission spectrum. That order is the whole point: the ratio of means is not the
+mean of ratios, so a region-level measurement must be built from region-level counts.
+
+The spatial reduction is the same mask-aware pooled region mean the ``background_roi`` and
+``air_roi`` corrections already use — ``sum(counts over the region) / count(unmasked pixels)`` per
+bin — so a region reduces identically whether it is a rectangle, an arbitrary-shape
+:class:`~neunorm.data_models.roi.MaskROI`, or a pooled list of either.
+"""
+
+from typing import Literal, Optional, Union
+
+import numpy as np
+import scipp as sc
+from loguru import logger
+
+from neunorm.data_models.roi import RegionsLike, as_region_list
+from neunorm.processing.normalizer import (
+    _pooled_roi_coefficient,
+    normalize_step_count,
+    normalize_transmission,
+)
+from neunorm.tof.histogram_rebinner import SPECTRA_TOF_COORD
+from neunorm.utils.progress import STAGE_REDUCE_SPECTRUM, ProgressLike, resolve_progress
+
+# The dims a region mean reduces over. Fixed rather than derived: the pooled-coefficient machinery
+# these functions delegate to is itself written against ``x``/``y``.
+_SPATIAL_DIMS = ("x", "y")
+
+
+def normalize_roi_spectrum_step_count(proton_charge_sample=None) -> int:
+    """How many progress steps :func:`normalize_roi_spectrum` reports for these arguments.
+
+    Its two region collapses plus whatever :func:`~neunorm.processing.normalizer.normalize_transmission`
+    reports, because that function is handed a borrowed reporter and a borrowed reporter keeps the
+    OUTER total. Deriving both from one function is what stops the two drifting apart — the same
+    arrangement as :func:`~neunorm.processing.normalizer.normalize_with_dark_step_count`.
+
+    Parameters
+    ----------
+    proton_charge_sample : optional
+        The ``proton_charge_sample`` that will be passed on, or ``None``.
+
+    Returns
+    -------
+    int
+        The number of counted steps. Mask symmetrization is announced with a note and does not
+        advance the count.
+    """
+    return 2 + normalize_step_count(proton_charge_sample=proton_charge_sample)
+
+
+def _surviving_dims(data: sc.DataArray) -> tuple[str, ...]:
+    """The dims left after the spatial ones are reduced away."""
+    return tuple(d for d in data.dims if d not in _SPATIAL_DIMS)
+
+
+def _carry_over(data: sc.DataArray, result: sc.DataArray, keep_dims: tuple[str, ...]) -> None:
+    """Copy the coords and masks a spatial reduction leaves meaningful onto ``result``, in place.
+
+    A coord or mask survives when every dim it carries survived the reduction: scalar metadata
+    (``proton_charge``, ``detector``) and anything on the spectral axis (the ``tof`` bin edges, a
+    per-bin ``spectra_tof``, a missing-bin mask). Spatial ``(y, x)`` coords and the dead/hot pixel
+    masks are consumed by the reduction and are deliberately not carried. Alignment flags are
+    preserved, because they are what decides whether scipp enforces equality on a later binary op.
+    """
+    for name, coord in data.coords.items():
+        if set(coord.dims) <= set(keep_dims):
+            result.coords[name] = coord
+            result.coords.set_aligned(name, coord.aligned)
+    for name, mask in data.masks.items():
+        if set(mask.dims) <= set(keep_dims):
+            result.masks[name] = mask
+
+
+def roi_mean_spectrum(
+    data: sc.DataArray,
+    regions: RegionsLike,
+    *,
+    strict: bool = True,
+    region_arg: str = "spectrum_roi",
+    name: str = "data",
+) -> sc.DataArray:
+    """Collapse one or more spatial regions to a mask-aware **pooled mean per spectral bin**.
+
+    The public form of the pooled region mean that
+    :func:`~neunorm.processing.normalizer.normalize_transmission` uses for ``background_roi`` and
+    :func:`~neunorm.processing.air_region_corrector.apply_air_region_correction` uses for
+    ``air_roi``. That private helper stays the single implementation — this function adds the
+    argument normalization and rebuilds a :class:`scipp.DataArray` around the result so the spectral
+    coordinates survive; it changes no arithmetic.
+
+    ``mean = sum(counts over every region) / count(selected, unmasked pixels)``, evaluated per
+    spectral bin. Reductions are mask-aware on **both** sides of that ratio: a dead or hot pixel is
+    excluded from the summed counts and from the pixel count alike, so a partially masked region
+    still yields its true mean. Regions that overlap within a pooled list are reduced over their
+    **union**, each pixel counted once.
+
+    Do not substitute ``sc.mean(data, dim=["y", "x"])``. scipp reduces one dimension at a time, so
+    under a mask that form is not the pooled mean and the nested ``mean('x').mean('y')`` is
+    order-dependent as well. ``tests/unit/test_roi_spectrum.py`` pins the disagreement so the
+    substitution cannot be made by accident.
+
+    Parameters
+    ----------
+    data : sc.DataArray
+        Counts carrying ``x`` and ``y`` dims, and usually a spectral dim such as ``tof``. Masks are
+        honoured; variances, when present, propagate into the mean.
+    regions : ROI, MaskROI, tuple, or a sequence of them
+        The region(s) to collapse — an :class:`~neunorm.data_models.roi.ROI` (or a bare
+        ``(x0, y0, x1, y1)`` tuple, exclusive stops), an arbitrary-shape
+        :class:`~neunorm.data_models.roi.MaskROI` (selection mask: 1 = pixel in the region), or a
+        sequence mixing those, which are pooled.
+    strict : bool, optional
+        With the default ``True``, a pooled mean that is not strictly positive and finite in every
+        bin raises ``ValueError``. Pass ``False`` where a zero or negative mean is a legitimate
+        measurement rather than a fault — a fully absorbing sample bin, or dark-subtracted counts
+        that scatter below zero. Structural errors (bad bounds, a selection whose shape does not
+        match the data, missing dims) always raise.
+    region_arg : str, optional
+        The caller's argument name, used in error messages. Defaults to ``"spectrum_roi"``.
+    name : str, optional
+        How to describe ``data`` in error messages (e.g. ``"sample"``, ``"open beam"``).
+
+    Returns
+    -------
+    sc.DataArray
+        The pooled mean with the spatial dims reduced away — 1-D over the spectral axis, or a
+        0-D scalar for a plain image. Carries the counts' unit, the propagated variance, and every
+        coordinate and mask whose dims survived the reduction (the ``tof`` bin edges among them, so
+        the result can be rebinned or exported).
+
+    Examples
+    --------
+    >>> spectrum = roi_mean_spectrum(sample, (10, 10, 30, 30))  # doctest: +SKIP
+    """
+    region_list = as_region_list(regions, arg_name=region_arg)
+    coeff = _pooled_roi_coefficient(data, region_list, name, strict=strict, region_arg=region_arg)
+
+    keep_dims = _surviving_dims(data)
+    # No broadcast is needed here, which is worth stating because it looks as though one might be. The
+    # coefficient is `total / n_unmasked`, and while `n_unmasked` IS a bare scalar on the MaskROI path
+    # with purely spatial masks, it is only the divisor: `total` is `sc.sum(region, dim=["x", "y"])`,
+    # which retains every non-spatial dim, so the quotient already carries exactly `keep_dims` for
+    # every input shape, dim order, mask kind and region form.
+    result = sc.DataArray(coeff)
+    _carry_over(data, result, keep_dims)
+    return result
+
+
+def _bin_times(data: sc.DataArray, tof_dim: str) -> Optional[sc.Variable]:
+    """Each bin's representative time, or ``None`` when the axis cannot supply one.
+
+    Prefers an existing ``spectra_tof`` — the per-bin mean of its member frames' left-edge times,
+    which is exactly what the reduction path of :func:`~neunorm.tof.histogram_rebinner.rebin_tof`
+    attaches and is more informative than anything recoverable from the output edges alone.
+
+    That coordinate is only trusted after a containment check, because the **sum** path of
+    ``rebin_tof`` carries unaligned coords through :func:`scipp.rebin`, which SUMS them: a
+    ``spectra_tof`` that survived a sum-mode rebin holds the sum of its member times, not their
+    mean, and is wrong by roughly a factor of the rebinning factor. A summed time falls outside its
+    own bin, so requiring each value to lie within ``[left, right)`` separates a genuine mean time
+    from a corrupted one. When the check fails, or when no ``spectra_tof`` is present at all, the
+    bin's left edge is used and the substitution is logged.
+    """
+    if tof_dim not in data.coords:
+        return None
+    edges = data.coords[tof_dim]
+    n = data.sizes[tof_dim]
+    if edges.sizes.get(tof_dim) != n + 1:
+        # A point coord rather than bin edges: it already is one time per bin.
+        return edges if edges.sizes.get(tof_dim) == n else None
+    left = edges[tof_dim, :n]
+    right = edges[tof_dim, 1:]
+    if SPECTRA_TOF_COORD in data.coords:
+        existing = data.coords[SPECTRA_TOF_COORD]
+        if existing.sizes.get(tof_dim) == n and existing.unit == edges.unit:
+            inside = (existing.values >= left.values) & (existing.values < right.values)
+            if bool(np.all(inside)):
+                return existing
+            logger.warning(
+                "'{}' does not lie within its own TOF bins (first offending bin: {}); it was most "
+                "likely summed by a sum-mode rebin rather than averaged. Using each bin's left edge "
+                "as its representative time instead.",
+                SPECTRA_TOF_COORD,
+                int(np.argmin(inside)),
+            )
+    return left.copy()
+
+
+def _require_matching_axes(
+    sample: sc.DataArray,
+    ob: sc.DataArray,
+    *,
+    sample_label: Optional[str],
+    ob_label: Optional[str],
+) -> None:
+    """Raise a diagnosable error when the two spectra's aligned axes disagree.
+
+    scipp enforces exact equality on an **aligned** coordinate in a binary op, so two spectra whose
+    ``tof`` axes differ raise ``DatasetError: Mismatch in coordinate 'tof' in operation 'divide'`` —
+    accurate but no help in locating the cause. The cause is usually mundane and specific: VENUS
+    TPX1 reads a separate ``*_Spectra.txt`` for the sample and open-beam directories, so a stale or
+    mismatched sidecar puts the two acquisitions on different time axes.
+
+    Reconciling the axes silently is the one thing not done here. Two different time axes mean the
+    numerator and the denominator describe different time windows, and dividing them produces a
+    plausible-looking spectrum that is not a transmission.
+
+    The SIZES are checked as well as the coords, and that check is what catches a mismatch the image
+    mode would have caught for free. Two stacks of different detector extent raise a ``DimensionError``
+    when divided per pixel, but a region collapse removes the spatial dims BEFORE the division, so as
+    long as the region fits in both, two differently-sized detectors divide happily into a spectrum
+    that looks entirely reasonable. Coordinate equality does not cover it, because a stack built by hand
+    need carry no ``x``/``y`` coords at all.
+    """
+    shared = {d: (sample.sizes[d], ob.sizes[d]) for d in sample.dims if d in ob.dims}
+    differing = {d: pair for d, pair in shared.items() if pair[0] != pair[1]}
+    if differing or set(sample.dims) != set(ob.dims):
+        where = ""
+        if sample_label or ob_label:
+            where = f" (sample: {sample_label or 'unlabelled'}; open beam: {ob_label or 'unlabelled'})"
+        raise ValueError(
+            f"sample and open beam have different shapes{where}: sample {dict(sample.sizes)}, open beam "
+            f"{dict(ob.sizes)}. A region collapse would hide this — it removes the spatial dims before "
+            "the division, so two differently-sized detectors would still produce a spectrum."
+        )
+
+    for name in sample.coords:
+        if not sample.coords[name].aligned or name not in ob.coords:
+            continue
+        theirs = ob.coords[name]
+        if sc.identical(sample.coords[name], theirs):
+            continue
+        mine = sample.coords[name]
+        detail = ""
+        if mine.sizes == theirs.sizes and mine.unit == theirs.unit and mine.dtype == theirs.dtype:
+            worst = float(np.max(np.abs(mine.values.astype(float) - theirs.values.astype(float))))
+            detail = f", max deviation {worst:g} {mine.unit}"
+        where = ""
+        if sample_label or ob_label:
+            where = f" (sample: {sample_label or 'unlabelled'}; open beam: {ob_label or 'unlabelled'})"
+        raise ValueError(
+            f"sample and open beam disagree on the aligned '{name}' axis{detail}{where}: "
+            f"sample {mine.sizes} in {mine.unit}, open beam {theirs.sizes} in {theirs.unit}. "
+            "The two acquisitions are on different axes, so their ratio would not be a "
+            "transmission — check that each directory's spectra sidecar belongs to it."
+        )
+
+
+def _symmetrize_masks(sample: sc.DataArray, ob: sc.DataArray) -> tuple[sc.DataArray, sc.DataArray]:
+    """Give sample and open beam the same exclusions, so their region means share a denominator.
+
+    The pipelines attach the dead/hot pixel masks to the sample and leave the open beam unmasked.
+    That is harmless when the division is per pixel — a masked pixel is masked in the result either
+    way — but a region **mean** divides by its own count of unmasked pixels, so an asymmetric mask
+    makes the numerator and the denominator average over different pixel sets. A pixel known to be
+    dead then still contributes to the open beam's mean, inflating it and biasing the transmission
+    low, and the bias does not announce itself.
+
+    Both sides therefore get the union of both sides' masks. Returned as shallow copies: the mask
+    dicts are rewritten, the data and variance buffers are shared, and the caller's arrays are
+    never mutated.
+    """
+    out_sample = sample.copy(deep=False)
+    out_ob = ob.copy(deep=False)
+    for name in set(sample.masks) | set(ob.masks):
+        in_s = sample.masks.get(name)
+        in_o = ob.masks.get(name)
+        if in_s is not None and in_o is not None:
+            if sc.identical(in_s, in_o):
+                continue
+            combined = in_s | in_o
+        else:
+            combined = in_s if in_s is not None else in_o
+        for target, source in ((out_sample, sample), (out_ob, ob)):
+            if not set(combined.dims) <= set(source.dims):
+                raise ValueError(
+                    f"cannot symmetrize mask '{name}' with dims {combined.dims} onto an array with "
+                    f"dims {source.dims}: sample and open beam must have the same dims at this point"
+                )
+            target.masks[name] = combined
+    return out_sample, out_ob
+
+
+def normalize_roi_spectrum(  # noqa: C901
+    sample: sc.DataArray,
+    ob: sc.DataArray,
+    spectrum_roi: RegionsLike,
+    *,
+    proton_charge_sample: Optional[Union[float, sc.Variable]] = None,
+    proton_charge_ob: Optional[Union[float, sc.Variable]] = None,
+    pc_uncertainty: float = 0.005,
+    spectrum_roi_strict: bool = True,
+    symmetrize_masks: bool = True,
+    tof_dim: str = "tof",
+    sample_label: Optional[str] = None,
+    ob_label: Optional[str] = None,
+    progress: ProgressLike = False,
+    stage: str = STAGE_REDUCE_SPECTRUM,
+) -> sc.DataArray:
+    """Reduce a sample and open-beam stack to a 1-D transmission spectrum over one region.
+
+    For each spectral bin the sample's mask-aware pooled mean counts over ``spectrum_roi`` are
+    divided by the open beam's pooled mean over the **same** region, giving one data point per bin.
+
+    Order of operations
+    -------------------
+    The region is collapsed to a scalar per bin **before** the division, never after. The two are
+    not the same quantity::
+
+        (Σ sample) / (Σ ob)   ≠   Σ (sample / ob)
+
+    Averaging per-pixel transmissions instead — the ratio of means replaced by the mean of ratios —
+    biases the result: measured 1.2% apart on synthetic Poisson counts over a 64-pixel region, and
+    the per-pixel form additionally produces NaN wherever an open-beam pixel recorded zero counts in
+    a bin, which is common at fine TOF binning. Collapsing first avoids both.
+    :func:`~neunorm.tof.resonance.aggregate_resonance_image` states the same identity for the
+    spectral direction.
+
+    Any frame-index rebinning belongs **before** this call, applied to both stacks, exactly as in the
+    image mode (``rebin_tof(sample, spec); rebin_tof(ob, spec); normalize_roi_spectrum(...)``). Sum
+    and mean rebinning commute with the region collapse, so that order costs nothing; median does
+    not commute, and the documented order is the one that holds.
+
+    Parameters
+    ----------
+    sample : sc.DataArray
+        Sample counts with ``x``, ``y`` and (usually) a spectral dim, carrying variances.
+    ob : sc.DataArray
+        Open-beam counts on the same axes.
+    spectrum_roi : ROI, MaskROI, tuple, or a sequence of them
+        The region whose mean **is** the measurement — distinct from ``roi`` (which crops),
+        ``background_roi`` (a flux proxy) and ``air_roi`` (a scale correction). Indices are resolved
+        against the arrays as passed: after a pipeline's crop and spatial rebin, that is the
+        post-crop, post-rebin frame.
+    proton_charge_sample, proton_charge_ob : float or sc.Variable, optional
+        Integrated proton charge for the SNS beam correction, forwarded to
+        :func:`~neunorm.processing.normalizer.normalize_transmission` together with
+        ``pc_uncertainty``, so a spectrum carries the same flux correction and the same 0.5%
+        systematic as an image.
+    pc_uncertainty : float, optional
+        Relative proton-charge uncertainty (default 0.005).
+    spectrum_roi_strict : bool, optional
+        Guards the **open beam's** region mean, the denominator: with the default ``True``, a bin
+        whose open-beam mean is not strictly positive and finite raises ``ValueError`` rather than
+        emitting inf or NaN. ``False`` lets it propagate, which is the legacy 1.x behaviour.
+
+        The sample's mean is never guarded this way. Zero counts in the numerator are a real
+        measurement — a fully absorbing bin, a black resonance — and must give transmission 0, not
+        an exception.
+    symmetrize_masks : bool, optional
+        With the default ``True``, both sides are given the union of both sides' masks before the
+        collapse, so the two means average over the same pixels. See :func:`_symmetrize_masks` for
+        why an asymmetric mask biases a region mean when it would not bias a per-pixel division.
+    tof_dim : str, optional
+        Name of the spectral dim. Default ``"tof"``.
+    sample_label, ob_label : str, optional
+        How to describe each input if their axes disagree — a directory or sidecar path makes that
+        error actionable.
+    progress : bool or callable, optional
+        Progress reporting, off by default. Reports the two region collapses and then hands its
+        reporter to ``normalize_transmission``, so one count spans the whole reduction. A caller
+        passing a pre-bound reporter must size it with
+        :func:`normalize_roi_spectrum_step_count`.
+    stage : str, optional
+        Stage label the events carry. Defaults to ``STAGE_REDUCE_SPECTRUM``.
+
+    Returns
+    -------
+    sc.DataArray
+        The transmission spectrum: 1-D over ``tof_dim``, dimensionless, with propagated variances.
+        Carries the ``N + 1`` ``tof`` **bin edges** — so the spectrum can be rebinned again or
+        converted to wavelength or energy — and a ``spectra_tof`` point coordinate giving each bin's
+        representative time.
+
+    Raises
+    ------
+    ValueError
+        If the region is malformed or does not fit the data, if the two inputs disagree on an
+        aligned axis, or (under ``spectrum_roi_strict``) if an open-beam bin's region mean is not
+        strictly positive and finite.
+
+    Examples
+    --------
+    >>> spectrum = normalize_roi_spectrum(sample, ob, (10, 10, 30, 30))  # doctest: +SKIP
+    """
+    region_list = as_region_list(spectrum_roi, arg_name="spectrum_roi")
+    logger.info("Reducing ROI spectrum over region(s) {}", region_list)
+
+    _require_matching_axes(sample, ob, sample_label=sample_label, ob_label=ob_label)
+
+    with resolve_progress(progress, stage, total=normalize_roi_spectrum_step_count(proton_charge_sample)) as report:
+        if symmetrize_masks and (sample.masks or ob.masks):
+            report.note("symmetrizing sample and open-beam masks")
+            sample, ob = _symmetrize_masks(sample, ob)
+
+        report.note("collapsing sample region")
+        # strict=False on the sample: a zero or negative region mean is a legitimate measurement
+        # here (full absorption, or dark-subtracted counts scattering below zero), where in the
+        # denominator it is a fault. The guard belongs on the open beam alone.
+        sample_spectrum = roi_mean_spectrum(sample, region_list, strict=False, region_arg="spectrum_roi", name="sample")
+        report()
+
+        report.note("collapsing open-beam region")
+        ob_spectrum = roi_mean_spectrum(
+            ob, region_list, strict=spectrum_roi_strict, region_arg="spectrum_roi", name="ob"
+        )
+        report()
+
+        transmission = normalize_transmission(
+            sample=sample_spectrum,
+            ob=ob_spectrum,
+            proton_charge_sample=proton_charge_sample,
+            proton_charge_ob=proton_charge_ob,
+            pc_uncertainty=pc_uncertainty,
+            progress=report,
+            stage=stage,
+        )
+
+    # A representative time per bin, recovered from the authoritative bin edges when the input's own
+    # `spectra_tof` is absent or was corrupted by a sum-mode rebin. Left ALIGNED, which is how
+    # `reduce_tof_bins` writes it (histogram_rebinner.py:343 assigns it without clearing the flag),
+    # so a later binary op between two spectra whose time axes disagree is refused rather than
+    # silently reconciled — the same protection `_require_matching_axes` gives this function's own
+    # inputs.
+    if tof_dim in transmission.dims:
+        times = _bin_times(transmission, tof_dim)
+        if times is not None:
+            transmission.coords[SPECTRA_TOF_COORD] = times
+
+    logger.success("✓ ROI spectrum reduced to {} bin(s)", transmission.sizes.get(tof_dim, 1))
+    return transmission
+
+
+def spectrum_reduction_provenance(
+    regions: list,
+    *,
+    reduction: Optional[Literal["mean", "sum", "median"]] = None,
+    rebin_by_tof: object = None,
+) -> dict:
+    """Provenance for one spectrum reduction: what region, and how the frames were binned.
+
+    Kept next to the reduction so the record cannot drift from the arithmetic it describes.
+
+    ``rebin_by_tof`` must be the spec that actually RAN, not the caller's argument. They differ for
+    ``rebin_by_tof=True``, where the factor comes from the statistics analysis: recording ``"True"``
+    leaves the reader unable to say how many frames went into a point. ``reduction`` is likewise
+    recorded as the effective one, because the default flips with the argument type — a factor sums, a
+    bin list takes the mean — so ``None`` would leave the file silent about which happened.
+    """
+    from neunorm.data_models.roi import as_region_provenance
+
+    record: dict = {"spectrum_roi": as_region_provenance(regions)}
+    if rebin_by_tof is not None and rebin_by_tof is not False:
+        record["rebin_by_tof"] = str(rebin_by_tof)
+        if reduction is None:
+            # rebin_tof's own defaults, spelled out rather than left implicit
+            reduction = "mean" if isinstance(rebin_by_tof, (list, tuple)) else "sum"
+    if reduction is not None:
+        record["rebin_reduction"] = reduction
+    return record

--- a/src/neunorm/processing/spectrum_reducer.py
+++ b/src/neunorm/processing/spectrum_reducer.py
@@ -238,8 +238,17 @@ def _require_matching_axes(
             continue
         mine = sample.coords[name]
         detail = ""
-        if mine.sizes == theirs.sizes and mine.unit == theirs.unit and mine.dtype == theirs.dtype:
-            worst = float(np.max(np.abs(mine.values.astype(float) - theirs.values.astype(float))))
+        # The deviation is a convenience in the message, so it must never be the thing that raises.
+        # A NUMERIC check is required as well as matching sizes/unit/dtype: an aligned string coord
+        # (a `detector` label, say) satisfies all three and then has no `.astype`, which would replace
+        # this function's diagnostic with an AttributeError from inside the f-string.
+        if (
+            mine.sizes == theirs.sizes
+            and mine.unit == theirs.unit
+            and mine.dtype == theirs.dtype
+            and np.issubdtype(np.asarray(mine.values).dtype, np.number)
+        ):
+            worst = float(np.max(np.abs(np.asarray(mine.values, dtype=float) - np.asarray(theirs.values, dtype=float))))
             detail = f", max deviation {worst:g} {mine.unit}"
         where = ""
         if sample_label or ob_label:

--- a/src/neunorm/tof/resonance.py
+++ b/src/neunorm/tof/resonance.py
@@ -16,6 +16,9 @@ from pydantic import BaseModel, Field, field_validator
 from scipy.ndimage import gaussian_filter1d
 from scipy.signal import find_peaks
 
+from neunorm.data_models.roi import RegionsLike
+from neunorm.processing.spectrum_reducer import _symmetrize_masks, roi_mean_spectrum
+
 
 class ResonanceDetectionConfig(BaseModel):
     """
@@ -70,53 +73,53 @@ class ResonanceDetectionConfig(BaseModel):
         return v
 
 
-def _calculate_snr_poisson(
+def _calculate_snr_from_variances(
     energy: np.ndarray,
     peak_indices: np.ndarray,
-    spectrum_ta_counts: np.ndarray,
-    spectrum_ob_counts: np.ndarray,
+    transmission: sc.DataArray,
+    spectrum_ob: sc.DataArray,
     window_fraction: float = 0.15,
 ) -> np.ndarray:
+    """SNR per peak, taking sigma_T from the **propagated** variance instead of assuming raw counts.
+
+    Same estimator as the Poisson-counts version this replaced — resonance depth over the quadrature
+    sum of the peak's and the background's transmission uncertainty, with background windows that scale
+    as ``dE/E`` — and the same branch structure, bin for bin. Only where sigma_T comes from differs.
+
+    That substitution is why it exists. The old form hard-coded ``sigma_T = T*sqrt(1/S + 1/OB)``, i.e.
+    ``Var(S) = S``, which holds only for raw summed counts: hand it region **means** and the bracket
+    grows by the pixel count, shrinking every SNR by ``1/sqrt(N_pixels)`` — measured 282.8 -> 28.3 over
+    a 10x10 detector, which takes four detected peaks to zero against the default ``min_snr=50``.
+    Reading the variance the reduction already propagated is scale-free, so the same spectrum gives the
+    same SNR whether it is expressed as sums or as means.
+
+    It is also numerically neutral where the old formula was right. For Poisson pixels
+    ``Var(mean) = sum(Var)/N**2``, so ``Var(T)/T**2 = 1/S_sum + 1/OB_sum`` — algebraically identical to
+    the hard-coded bracket. Measured on synthetic Poisson data the detected peaks are unchanged and the
+    SNR values agree to 1.9e-16 relative.
+
+    Where the two DO differ is input whose variances are not Poisson — dark-subtracted or run-combined
+    counts, whose variances are inflated relative to their values. There the old formula understated
+    sigma_T and this one reports the uncertainty the data actually carries, so the SNR comes out lower,
+    and correctly so. That is a deliberate change, not an incidental one.
+
+    ``spectrum_ob`` is taken only for the ``> 0`` validity tests, so a bin the old code skipped is
+    still skipped for the same reason rather than for a different one.
     """
-    Calculate SNR using Poisson statistics with relative energy windows.
-
-    Uses proper Poisson uncertainty propagation: σ_T = T × √(1/S + 1/OB)
-    Background windows scale with energy (ΔE/E = constant) to match TOF physics.
-
-    Parameters
-    ----------
-    energy : np.ndarray
-        Energy bin centers (eV)
-    peak_indices : np.ndarray
-        Indices of detected peaks in spectrum
-    spectrum_ta_counts : np.ndarray
-        Sample counts (integrated over spatial dimensions)
-    spectrum_ob_counts : np.ndarray
-        Open beam counts (integrated over spatial dimensions)
-    window_fraction : float
-        Relative window size (default: 0.15 = ±15% of peak energy)
-
-    Returns
-    -------
-    np.ndarray
-        SNR value for each peak
-    """
+    values = transmission.values
+    stdevs = np.sqrt(transmission.variances)
+    ob_values = spectrum_ob.values
     snr_values = []
 
     for idx in peak_indices:
         peak_energy = energy[idx]
 
-        # Get counts at peak
-        s_peak = spectrum_ta_counts[idx]
-        ob_peak = spectrum_ob_counts[idx]
-
-        if ob_peak <= 0:
+        if ob_values[idx] <= 0:
             snr_values.append(0.0)
             continue
 
-        # Transmission and uncertainty at peak
-        t_peak = s_peak / ob_peak
-        sigma_t_peak = t_peak * np.sqrt(1.0 / max(s_peak, 1) + 1.0 / max(ob_peak, 1))
+        t_peak = values[idx]
+        sigma_t_peak = stdevs[idx]
 
         # Define background windows in RELATIVE energy
         gap = window_fraction
@@ -129,22 +132,14 @@ def _calculate_snr_poisson(
             snr_values.append(0.0)
             continue
 
-        # Get background counts
-        s_bg = spectrum_ta_counts[bg_region]
-        ob_bg = spectrum_ob_counts[bg_region]
-
         # Only use bins with OB counts > 0
-        valid = ob_bg > 0
+        valid = ob_values[bg_region] > 0
         if np.sum(valid) == 0:
             snr_values.append(0.0)
             continue
 
-        # Calculate transmission and uncertainties in background
-        t_bg = s_bg[valid] / ob_bg[valid]
-        t_background = np.median(t_bg)
-
-        sigma_t_bg_array = t_bg * np.sqrt(1.0 / np.maximum(s_bg[valid], 1) + 1.0 / np.maximum(ob_bg[valid], 1))
-        sigma_t_background = np.median(sigma_t_bg_array)
+        t_background = np.median(values[bg_region][valid])
+        sigma_t_background = np.median(stdevs[bg_region][valid])
 
         # Signal = resonance depth
         signal = abs(t_background - t_peak)
@@ -158,12 +153,87 @@ def _calculate_snr_poisson(
     return np.array(snr_values)
 
 
+def _with_poisson_variances(data: sc.DataArray) -> sc.DataArray:
+    """``data`` with ``Var = counts`` filled in when it carries no variances.
+
+    Counting data has Poisson variance whether or not anything recorded it, and the SNR step needs a
+    variance to read. Synthesizing it here is what makes the variance-routed SNR reproduce the old
+    counts formula exactly on inputs that never carried variances — which is all of the existing
+    resonance test data. Negative values (dark-subtracted counts scattering below zero) are floored at
+    zero rather than given a negative variance.
+
+    The values and the variances are held in the SAME float dtype, because scipp requires it. That is
+    not a detail: ``float32`` is what ``event_converter`` and ``tiff_loader`` produce natively and
+    integer counts are what a hand-built histogram carries, and a mismatched pair raises a scipp dtype
+    error that names nothing in NeuNorm. Integer input is promoted to ``float64``; a float input keeps
+    its own precision.
+    """
+    if data.variances is not None:
+        return data
+    values = np.asarray(data.values)
+    # float32 stays float32; integer and everything else become float64
+    dtype = values.dtype if values.dtype in (np.float32, np.float64) else np.float64
+    values = values.astype(dtype, copy=False)
+    out = data.copy(deep=False)
+    out.data = sc.array(
+        dims=data.dims,
+        values=values,
+        variances=np.clip(values, 0.0, None).astype(dtype, copy=False),
+        unit=data.unit,
+    )
+    return out
+
+
+def _region_spectra(
+    hist_ta: sc.DataArray,
+    hist_ob: sc.DataArray,
+    spectrum_roi: Optional[RegionsLike],
+) -> tuple[sc.DataArray, sc.DataArray]:
+    """Sample and open-beam spectra as mask-aware pooled region **means** over the same region.
+
+    ``spectrum_roi=None`` uses the whole detector, which is what this function replaced —
+    ``hist.sum(["x", "y"])`` on each side independently. Two changes come with it, and only the second
+    is about the mean:
+
+    Both sides are given the union of both sides' masks first. A region mean divides by its own count
+    of unmasked pixels, so masking a dead pixel on the sample alone makes the numerator and the
+    denominator average over different pixel sets — and the dead pixel still inflates the open beam.
+    Measured with one of four pixels dead under non-uniform flux: 0.400 from the ratio of sums, 0.533
+    from the ratio of means, 0.800 once the masks match, against a true 0.800. **The mean alone does
+    not fix this**; it removes the ``N_s != N_o`` scale error, and mask symmetry removes the bias.
+
+    A stack with no ``x``/``y`` dims is already a spectrum and is passed through, so callers handing in
+    pre-reduced data keep working.
+    """
+    if "x" not in hist_ta.dims or "y" not in hist_ta.dims:
+        if spectrum_roi is not None:
+            raise ValueError(
+                f"spectrum_roi needs 'x' and 'y' dimensions to select a region; got dims {hist_ta.dims}. "
+                "The input looks already reduced to a spectrum."
+            )
+        return _with_poisson_variances(hist_ta), _with_poisson_variances(hist_ob)
+
+    ta = _with_poisson_variances(hist_ta)
+    ob = _with_poisson_variances(hist_ob)
+    ta, ob = _symmetrize_masks(ta, ob)
+
+    regions = spectrum_roi if spectrum_roi is not None else (0, 0, ta.sizes["x"], ta.sizes["y"])
+    # strict=False on both sides: a fully absorbing bin (transmission 0) is exactly what a resonance
+    # dip looks like, and an empty open-beam bin is handled downstream by the `> 0` validity tests
+    # rather than by aborting a detection run.
+    spectrum_ta = roi_mean_spectrum(ta, regions, strict=False, region_arg="spectrum_roi", name="hist_ta")
+    spectrum_ob = roi_mean_spectrum(ob, regions, strict=False, region_arg="spectrum_roi", name="hist_ob")
+    return spectrum_ta, spectrum_ob
+
+
 def detect_resonances(
     hist_ta: sc.DataArray,
     hist_ob: sc.DataArray,
     config: Optional[ResonanceDetectionConfig] = None,
     known_resonances: Optional[np.ndarray] = None,
     validation_tolerance: float = 0.05,
+    *,
+    spectrum_roi: Optional[RegionsLike] = None,
 ) -> Dict:
     """
     Auto-detect resonance dips in neutron transmission data.
@@ -171,7 +241,7 @@ def detect_resonances(
     Uses tiered filtering approach:
     1. Background subtraction (Gaussian filter)
     2. Initial peak detection (scipy.signal.find_peaks)
-    3. SNR filtering (Poisson statistics with relative energy windows)
+    3. SNR filtering (from the propagated transmission variance, with relative energy windows)
     4. Peak shape filtering (width and prominence/width ratio)
 
     Parameters
@@ -186,6 +256,23 @@ def detect_resonances(
         Known resonance energies (eV) for validation
     validation_tolerance : float
         Relative tolerance for matching known resonances (default: 0.05 = ±5%)
+    spectrum_roi : ROI, MaskROI, tuple, or a sequence of them, optional
+        Restrict the integrated spectrum to a region instead of the whole detector, so a resonance is
+        looked for where the sample actually is. ``None`` (default) uses the whole detector, which is
+        the historical behaviour. Indices are resolved against the arrays as passed.
+
+    Notes
+    -----
+    The integrated spectrum is a mask-aware pooled region **mean**, and both inputs are given the union
+    of both inputs' masks before it is taken. Two independent reductions —
+    ``hist_ta.sum(["x", "y"])`` and ``hist_ob.sum(["x", "y"])`` — are each mask-aware, but a mask
+    present on only one side excludes a pixel from that side alone, so the numerator and the
+    denominator cover different pixels and the ratio is biased. Measured with one of four pixels dead
+    under non-uniform flux: 0.400 from the ratio of sums against a true 0.800.
+
+    The SNR is computed from the propagated transmission variance rather than from a hard-coded Poisson
+    formula over raw counts, which is what lets the spectrum be a mean at all. For Poisson counts the
+    two agree to floating-point round-off, so detection on counting data is unchanged.
 
     Returns
     -------
@@ -212,10 +299,14 @@ def detect_resonances(
     logger.info(f"  SNR window: ±{config.snr_window_fraction * 100:.0f}% of E (relative)")
     logger.info(f"  Min SNR: {config.min_snr}")
 
-    # Step 1: Compute integrated transmission spectrum
+    # Step 1: Compute integrated transmission spectrum — the mask-aware pooled region MEAN of each
+    # side, over the same region, divided once. The region is collapsed before the division because
+    # (Sum a)/(Sum b) != Sum(a/b), the same identity aggregate_resonance_image states for the
+    # spectral direction.
     logger.info("Computing integrated transmission spectrum...")
-    spectrum_ta = hist_ta.sum(["x", "y"])
-    spectrum_ob = hist_ob.sum(["x", "y"])
+    if spectrum_roi is not None:
+        logger.info("  Restricting the spectrum to region(s) {}", spectrum_roi)
+    spectrum_ta, spectrum_ob = _region_spectra(hist_ta, hist_ob, spectrum_roi)
     integrated_transmission = spectrum_ta / spectrum_ob
 
     # Extract numpy arrays
@@ -248,16 +339,13 @@ def detect_resonances(
             "n_shape_filtered": 0,
         }
 
-    # Step 4: SNR filtering with Poisson statistics
-    logger.info("Applying SNR filter (Poisson statistics)...")
-    spectrum_ta_counts = spectrum_ta.values
-    spectrum_ob_counts = spectrum_ob.values
-
-    snr_values = _calculate_snr_poisson(
+    # Step 4: SNR filtering from the propagated transmission variance
+    logger.info("Applying SNR filter (propagated transmission variance)...")
+    snr_values = _calculate_snr_from_variances(
         energy_centers,
         peaks_initial,
-        spectrum_ta_counts,
-        spectrum_ob_counts,
+        integrated_transmission,
+        spectrum_ob,
         window_fraction=config.snr_window_fraction,
     )
 

--- a/src/neunorm/utils/progress.py
+++ b/src/neunorm/utils/progress.py
@@ -64,6 +64,7 @@ STAGE_COMBINE_RUNS = "combine_runs"
 STAGE_GAMMA_FILTER = "gamma_filter"
 STAGE_REBIN_TOF = "rebin_tof"
 STAGE_NORMALIZE = "normalize"
+STAGE_REDUCE_SPECTRUM = "reduce_spectrum"
 STAGE_EXPORT = "export"
 
 __all__ = [
@@ -76,6 +77,7 @@ __all__ = [
     "STAGE_LOAD_SAMPLE",
     "STAGE_NORMALIZE",
     "STAGE_REBIN_TOF",
+    "STAGE_REDUCE_SPECTRUM",
     "NULL_REPORTER",
     "Progress",
     "ProgressCallback",

--- a/tests/unit/test_ascii_spectrum_writer.py
+++ b/tests/unit/test_ascii_spectrum_writer.py
@@ -1,0 +1,329 @@
+"""The ASCII spectrum file is an interoperability contract, so its bytes are pinned here.
+
+NeuNorm's own spectra reader is ``np.loadtxt(path, skiprows=1, delimiter=",")`` — it skips exactly
+one line and parses everything after it as data. That fixes the whole format: comma-delimited, one
+plain header line with no ``#`` prefix (a commented header would be the skipped line and the first
+data row would be lost), one row per bin. These tests therefore read the file back as **text** and
+through that exact reader call, rather than through any NeuNorm helper, so a change to the
+delimiter, the header, the column formats or the bin-index semantics fails here instead of in a
+downstream tool months later.
+
+The three columns are ``bin_index,transmission,uncertainty``; ``uncertainty`` is 1 sigma, so a
+spectrum with no variances has nothing truthful to put there and is rejected rather than written
+with a fabricated column. ``bin_index`` is each bin's **first input frame**, which is what lets a
+rebinned spectrum be traced back to its files: a gapped bin list leaves gaps in the column instead
+of renumbering the rows.
+"""
+
+import filecmp
+import io
+import os
+from contextlib import redirect_stderr
+
+import numpy as np
+import pytest
+import scipp as sc
+
+from neunorm.exporters.ascii_writer import (
+    ASCII_SPECTRUM_HEADER,
+    ascii_spectrum_export_step_count,
+    write_ascii_spectrum,
+)
+from neunorm.pipelines._tof_spine import spectrum_bin_indices
+from neunorm.utils.progress import STAGE_EXPORT, STAGE_REDUCE_SPECTRUM
+
+# The reference file the format was settled on, byte for byte.
+_REFERENCE_HEADER = "bin_index,transmission,uncertainty"
+_REFERENCE_ROW = "0,0.448760,0.010663"
+
+
+def _spectrum(values, stdevs, dim="tof"):
+    """A 1-D transmission spectrum from literal values and 1-sigma uncertainties."""
+    values = np.asarray(values, dtype=float)
+    variances = np.asarray(stdevs, dtype=float) ** 2
+    return sc.DataArray(sc.array(dims=[dim], values=values, variances=variances, unit=""))
+
+
+def _lines(path):
+    return path.read_text().splitlines()
+
+
+def _column(path, index):
+    """The raw text tokens of one column, header row excluded."""
+    return [line.split(",")[index] for line in _lines(path)[1:]]
+
+
+def _collect():
+    events = []
+    return events, events.append
+
+
+# --------------------------------------------------------------------------------------
+# The literal file: one plain header line, one row per bin
+# --------------------------------------------------------------------------------------
+
+
+def test_exactly_one_plain_header_line_and_one_row_per_bin(tmp_path):
+    """The reader skips one line and parses the rest, so a ``#`` prefix or a second header line
+    would silently eat the first bin. Asserted on the text, not on a parsed array, because a
+    parsed array cannot tell a skipped header from a lost data row."""
+    path = tmp_path / "spectrum.txt"
+    write_ascii_spectrum(path, _spectrum([0.5, 0.25, 0.125, 1.0], [0.01, 0.02, 0.03, 0.04]))
+
+    text = path.read_text()
+    lines = text.splitlines()
+
+    assert lines[0] == ASCII_SPECTRUM_HEADER
+    assert lines[0] == _REFERENCE_HEADER, "the header line is the settled format, not a free choice"
+    assert not lines[0].startswith("#")
+    assert len(lines) == 5, f"expected 1 header + 4 data rows, got {lines}"
+    assert "#" not in text, "no comment prefix anywhere: the reader has no comment convention"
+    assert "\t" not in text, "comma-delimited, not tab-delimited"
+    assert text.endswith("\n")
+    for line in lines[1:]:
+        assert len(line.split(",")) == 3, f"three columns per row; got {line!r}"
+        assert " " not in line, f"no padding around the delimiter; got {line!r}"
+
+
+def test_reference_row_is_rendered_exactly(tmp_path):
+    """The agreed example, pinned character for character: a six-decimal fixed-point value and
+    uncertainty, and an integer first column (the default ``%.18e`` would render both value columns
+    in exponent form and the index as ``0.000000000000000000e+00``)."""
+    path = tmp_path / "reference.txt"
+    write_ascii_spectrum(path, _spectrum([0.44876], [0.010663]))
+
+    assert path.read_text() == f"{_REFERENCE_HEADER}\n{_REFERENCE_ROW}\n"
+    assert _lines(path)[1] == "0,0.448760,0.010663"
+
+
+def test_parses_under_the_readers_exact_loadtxt_call(tmp_path):
+    """The interoperability contract itself: the call NeuNorm's spectra reader makes returns the
+    spectrum value by value, with the third column equal to ``sqrt(variance)``."""
+    values = [0.448760, 0.500000, 0.125000, 1.000000]
+    stdevs = [0.010663, 0.002500, 0.123456, 0.050000]
+    path = tmp_path / "spectrum.txt"
+    write_ascii_spectrum(path, _spectrum(values, stdevs))
+
+    table = np.loadtxt(path, skiprows=1, delimiter=",")
+
+    assert table.shape == (4, 3)
+    np.testing.assert_allclose(table[:, 0], np.array([0.0, 1.0, 2.0, 3.0]), atol=0)
+    np.testing.assert_allclose(table[:, 1], np.asarray(values), atol=1e-9)
+    # sqrt of the variances the spectrum carries, computed here with plain numpy from the literals.
+    np.testing.assert_allclose(table[:, 2], np.sqrt(np.asarray(stdevs) ** 2), atol=1e-9)
+
+
+# --------------------------------------------------------------------------------------
+# The bin_index column
+# --------------------------------------------------------------------------------------
+
+
+def test_bin_index_defaults_to_the_row_index(tmp_path):
+    """With no rebinning the column means "file index", and the row index is that same number."""
+    path = tmp_path / "default.txt"
+    write_ascii_spectrum(path, _spectrum([0.5, 0.4, 0.3], [0.01, 0.01, 0.01]))
+
+    assert _column(path, 0) == ["0", "1", "2"]
+
+
+def test_bin_indices_override_the_first_column(tmp_path):
+    """Given indices are written verbatim as integers — not renumbered, not reformatted."""
+    path = tmp_path / "given.txt"
+    write_ascii_spectrum(path, _spectrum([0.5, 0.4, 0.3], [0.01, 0.01, 0.01]), bin_indices=[7, 11, 13])
+
+    assert _column(path, 0) == ["7", "11", "13"]
+
+
+def test_spectrum_bin_indices_are_each_bins_first_input_frame():
+    """Pinned for the four argument shapes a run can take. The first-frame rule is what makes the
+    column traceable back to the input files; the row index would lose that under any rebin."""
+    assert spectrum_bin_indices(6, None) is None, "no rebin: the writer's own row index is the frame index"
+    assert spectrum_bin_indices(6, 2) == [0, 2, 4]
+    assert spectrum_bin_indices(6, [[0, 2], [2, 4], [4, 6]]) == [0, 2, 4]
+    assert spectrum_bin_indices(6, [[0, 2], [4, 6]]) == [0, 4]
+
+
+def test_gapped_bin_list_leaves_the_index_column_gapped(tmp_path):
+    """Frames 2-3 are dropped by the bin list, so they have no row at all and the surviving rows
+    keep their input-frame indices 0 and 4. Renumbering them 0 and 1 would silently claim the
+    second point came from frame 1."""
+    indices = spectrum_bin_indices(6, [[0, 2], [4, 6]])
+    assert indices == [0, 4]
+
+    path = tmp_path / "gapped.txt"
+    write_ascii_spectrum(path, _spectrum([0.448760, 0.500000], [0.010663, 0.002500]), bin_indices=indices)
+
+    first_column = _column(path, 0)
+    assert first_column == ["0", "4"]
+    assert "2" not in first_column, "the dropped 2-3 span must not appear as a row"
+    assert "3" not in first_column
+    assert len(_lines(path)) == 3, "1 header + 2 data rows: no blanked row for the dropped span"
+
+
+# --------------------------------------------------------------------------------------
+# Non-finite values
+# --------------------------------------------------------------------------------------
+
+
+def test_non_finite_values_round_trip_as_nan_and_inf(tmp_path):
+    """A NaN transmission is a real result (an open-beam bin with zero counts), so it must survive
+    the round trip as NaN rather than becoming 0.0 or an unparsable token."""
+    path = tmp_path / "nonfinite.txt"
+    write_ascii_spectrum(
+        path,
+        _spectrum([np.nan, np.inf, -np.inf, 0.500000], [0.500000, 0.250000, 1.000000, np.nan]),
+    )
+
+    assert _column(path, 1) == ["nan", "inf", "-inf", "0.500000"]
+    assert _column(path, 2) == ["0.500000", "0.250000", "1.000000", "nan"]
+
+    table = np.loadtxt(path, skiprows=1, delimiter=",")
+    assert np.isnan(table[0, 1])
+    assert table[1, 1] == np.inf
+    assert table[2, 1] == -np.inf
+    np.testing.assert_allclose(table[3, 1], 0.5, atol=1e-9)
+    np.testing.assert_allclose(table[:3, 2], np.array([0.5, 0.25, 1.0]), atol=1e-9)
+    assert np.isnan(table[3, 2])
+
+
+# --------------------------------------------------------------------------------------
+# Guards — each rejects before any file appears
+# --------------------------------------------------------------------------------------
+
+
+def test_rejects_a_spectrum_that_is_not_one_dimensional(tmp_path):
+    """A three-column format cannot represent an image stack. The message names the dims and sizes,
+    because the caller's mistake is having skipped the spatial reduction."""
+    path = tmp_path / "stack.txt"
+    stack = sc.DataArray(
+        sc.array(dims=["tof", "y", "x"], values=np.full((2, 3, 4), 0.5), variances=np.full((2, 3, 4), 0.01), unit="")
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        write_ascii_spectrum(path, stack)
+
+    message = str(excinfo.value)
+    assert "dims ('tof', 'y', 'x')" in message
+    assert "'tof': 2" in message
+    assert not path.exists(), "rejected before anything was written"
+
+    scalar = sc.DataArray(sc.scalar(0.5, variance=0.01, unit=""))
+    with pytest.raises(ValueError, match="1-D spectrum"):
+        write_ascii_spectrum(tmp_path / "scalar.txt", scalar)
+
+
+def test_rejects_a_spectrum_carrying_no_variances(tmp_path):
+    """The third column is a 1-sigma uncertainty. With no variances there is nothing to put in it,
+    and a zero or a copy of the value would be a fabricated uncertainty leaving in a data file.
+
+    Both bin counts are checked, and the message is matched rather than just the exception type:
+    without this guard a multi-bin spectrum fails downstream in ``np.column_stack`` with an
+    unrelated shape ValueError — which a bare ``pytest.raises(ValueError)`` would accept — while a
+    single-bin spectrum does not fail at all and writes ``nan`` into the uncertainty column."""
+    for n, values in ((3, [0.5, 0.4, 0.3]), (1, [0.5])):
+        path = tmp_path / f"novar{n}.txt"
+        bare = sc.DataArray(sc.array(dims=["tof"], values=np.asarray(values, dtype=float), unit=""))
+        assert bare.variances is None
+
+        with pytest.raises(ValueError, match="carrying variances"):
+            write_ascii_spectrum(path, bare)
+
+        assert not path.exists()
+
+
+def test_rejects_bin_indices_of_the_wrong_length(tmp_path):
+    """One index per bin or none at all: a short or long list would misalign every row's provenance
+    against its value."""
+    spectrum = _spectrum([0.5, 0.4, 0.3], [0.01, 0.01, 0.01])
+
+    for indices in ([0, 1], [0, 1, 2, 3], []):
+        path = tmp_path / f"len{len(indices)}.txt"
+        with pytest.raises(ValueError, match="one index per spectrum bin"):
+            write_ascii_spectrum(path, spectrum, bin_indices=indices)
+        assert not path.exists()
+
+
+def test_rejects_non_integer_bin_indices(tmp_path):
+    """The column is a frame index; a float would render through ``%d`` as a silently truncated
+    integer."""
+    spectrum = _spectrum([0.5, 0.4, 0.3], [0.01, 0.01, 0.01])
+    path = tmp_path / "float_indices.txt"
+
+    with pytest.raises(ValueError, match="must be integers"):
+        write_ascii_spectrum(path, spectrum, bin_indices=[0.0, 1.5, 2.0])
+
+    assert not path.exists()
+
+
+# --------------------------------------------------------------------------------------
+# Paths
+# --------------------------------------------------------------------------------------
+
+
+def test_creates_parent_directories_and_overwrites_an_existing_file(tmp_path):
+    """A pipeline names an output path under a directory tree that may not exist yet, and a re-run
+    must leave the file holding only the new run's rows — a truncating write, not an append."""
+    path = tmp_path / "deep" / "nested" / "spectrum.txt"
+    assert not path.parent.exists()
+
+    write_ascii_spectrum(path, _spectrum([0.5, 0.4, 0.3], [0.01, 0.01, 0.01]))
+    assert len(_lines(path)) == 4
+
+    write_ascii_spectrum(path, _spectrum([0.44876], [0.010663]))
+    assert path.read_text() == f"{_REFERENCE_HEADER}\n{_REFERENCE_ROW}\n"
+
+
+@pytest.mark.skipif(hasattr(os, "geteuid") and os.geteuid() == 0, reason="root ignores directory permissions")
+def test_unwritable_directory_raises_permission_error(tmp_path):
+    """Refused up front with the directory named, rather than part-way through np.savetxt with a
+    half-written file left behind."""
+    spectrum = _spectrum([0.5], [0.01])
+
+    with pytest.raises(PermissionError):
+        write_ascii_spectrum("/spectrum_from_neunorm_test.txt", spectrum)
+
+    with pytest.raises((PermissionError, OSError)):
+        write_ascii_spectrum("/nonexistent/deep/path/spectrum.txt", spectrum)
+
+    assert not (tmp_path / "spectrum.txt").exists()
+
+
+# --------------------------------------------------------------------------------------
+# Progress
+# --------------------------------------------------------------------------------------
+
+
+def test_step_count_predicts_the_events_the_writer_emits(tmp_path):
+    """The declared total is what a pipeline adds into its run-wide export count, so an emit site
+    that reports more or fewer steps than the count promises leaves a bar that never fills or one
+    that overshoots. The step is named before it is counted, so the label on screen is the write
+    currently running."""
+    spectrum = _spectrum([0.5, 0.4, 0.3], [0.01, 0.01, 0.01])
+    assert ascii_spectrum_export_step_count(spectrum) == 1
+
+    events, sink = _collect()
+    write_ascii_spectrum(tmp_path / "progress.txt", spectrum, progress=sink)
+
+    assert {e.total for e in events} == {1}
+    assert max(e.completed for e in events) == 1, "the bar never reached its declared total"
+    assert [(e.completed, e.detail) for e in events] == [(0, "writing ASCII spectrum"), (1, "")]
+    assert {e.stage for e in events} == {STAGE_EXPORT}
+
+    other, other_sink = _collect()
+    write_ascii_spectrum(tmp_path / "staged.txt", spectrum, progress=other_sink, stage=STAGE_REDUCE_SPECTRUM)
+    assert {e.stage for e in other} == {STAGE_REDUCE_SPECTRUM}
+
+
+def test_file_is_byte_identical_whatever_progress_is(tmp_path):
+    """Progress reporting is observation, not participation: the three accepted forms must produce
+    the same bytes, or a user watching a bar would get a different file from one who was not."""
+    spectrum = _spectrum([0.448760, 0.500000, 0.125000], [0.010663, 0.002500, 0.123456])
+    _, sink = _collect()
+
+    quiet = write_ascii_spectrum(tmp_path / "quiet.txt", spectrum, progress=False)
+    watched = write_ascii_spectrum(tmp_path / "watched.txt", spectrum, progress=sink)
+    with redirect_stderr(io.StringIO()):
+        barred = write_ascii_spectrum(tmp_path / "barred.txt", spectrum, progress=True)
+
+    assert filecmp.cmp(quiet, watched, shallow=False)
+    assert filecmp.cmp(quiet, barred, shallow=False)

--- a/tests/unit/test_docs_resonance_examples.py
+++ b/tests/unit/test_docs_resonance_examples.py
@@ -1,0 +1,223 @@
+"""Execute every Python example in ``docs/resonance_mode.md``.
+
+Documentation that does not run is worse than no documentation: a user pastes it, it fails, and they
+cannot tell whether the library or the page is wrong. So the examples are extracted from the page and
+executed here rather than read — the same arrangement ``test_docs_progress_examples.py`` uses for the
+progress page.
+
+Each block runs in a fresh namespace seeded only with the names the page tells the reader to supply —
+the four VENUS TPX1 path arguments, and the two histograms the detector example takes — against
+synthetic TPX1 inputs, with the working directory in a temporary folder so ``output_path="spectrum.txt"``
+lands there. The block text itself is exactly what the page shows.
+"""
+
+import re
+from pathlib import Path
+
+import numpy as np
+import pytest
+import scipp as sc
+from PIL import Image
+
+DOC = Path(__file__).resolve().parents[2] / "docs" / "resonance_mode.md"
+_DETECTOR = 32
+_FRAMES = 6
+
+
+def _tpx1_tiffs(directory, prefix, count, value):
+    """TIFF frames carrying the EXIF metadata run-combining and the VENUS proton charge need."""
+    paths = []
+    for index in range(count):
+        image = Image.fromarray(np.full((_DETECTOR, _DETECTOR), float(value + index), dtype=np.float32))
+        exif = image.getexif()
+        exif[65027] = "ExposureTime:30.000000"
+        exif[65022] = f"RunNo:{1000 + index}"
+        exif[65025] = "ManufacturerStr:DW936_BV"
+        exif[65024] = "IntegratedPCharge:1000.0"
+        path = directory / f"{prefix}_{index:05}.tiff"
+        image.save(path, exif=exif)
+        paths.append(path)
+    return paths
+
+
+def _nexus(path, proton_charge):
+    """The NeXus metadata file TPX1 reads its proton charge and image directory from."""
+    import h5py
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with h5py.File(path, "w") as f:
+        entry = f.create_group("entry")
+        entry.create_dataset("proton_charge", data=[proton_charge])
+        entry.create_dataset("duration", data=[60.0])
+        logs = entry.create_group("DASlogs")
+        logs.create_group("BL10:Det:T1:TSStart_RBV").create_dataset("value", data=[100])
+        logs.create_group("BL10:Det:T1:TSBinSize_RBV").create_dataset("value", data=[5])
+        logs.create_group("BL10:Det:T1:TSSize_RBV").create_dataset("value", data=[_FRAMES])
+        logs.create_group("BL10:Det:TH:DSPT1:TIDelay").create_dataset("average_value", data=[5000])
+        logs.create_group("BL10:Exp:Det").create_dataset("value_strings", data=[[b"MCP TPX1"]])
+        logs.create_group("BL10:Exp:IM:ImageFilePath").create_dataset("value", data=[[b"autoreduce"]])
+    return path
+
+
+def _spectra_file(path, left_edges):
+    """The co-located ``*_Spectra.txt`` sidecar TPX1 reads its TOF axis from."""
+    with open(path, "w") as handle:
+        handle.write("shutter_time,counts\n")
+        for edge in left_edges:
+            handle.write(f"{edge},1000\n")
+    return path
+
+
+def _energy_histogram(scale, *, dips=()):
+    """A small (energy, x, y) histogram for the ``detect_resonances`` example."""
+    n_energy = 200
+    edges = np.geomspace(1.0, 100.0, n_energy + 1)
+    centers = (edges[:-1] + edges[1:]) / 2
+    values = np.full((n_energy, _DETECTOR, _DETECTOR), float(scale))
+    for energy in dips:
+        values *= (1.0 - 0.4 * np.exp(-0.5 * ((centers - energy) / (0.02 * energy)) ** 2))[:, None, None]
+    return sc.DataArray(
+        sc.array(dims=["energy", "x", "y"], values=values, variances=values.copy(), unit="counts"),
+        coords={"energy": sc.array(dims=["energy"], values=edges, unit="eV")},
+    )
+
+
+def _python_blocks(text):
+    """Every ```python fenced block, in page order, with the line it starts on."""
+    blocks = []
+    for match in re.finditer(r"^```python\n(.*?)^```", text, re.MULTILINE | re.DOTALL):
+        line = text[: match.start()].count("\n") + 1
+        blocks.append((line, match.group(1)))
+    return blocks
+
+
+BLOCKS = _python_blocks(DOC.read_text())
+
+
+def test_the_page_has_the_examples_it_should():
+    """Guards the extractor itself: a regex that silently matched nothing would make every example test
+    below pass by vacuum, and would keep passing if the page were emptied."""
+    assert len(BLOCKS) >= 5, f"only found {len(BLOCKS)} python blocks in {DOC.name}"
+    joined = "\n".join(body for _line, body in BLOCKS)
+    assert "spectrum_roi=" in joined, "the basic spectrum-mode example is missing"
+    assert 'np.loadtxt("spectrum.txt", skiprows=1, delimiter=",")' in joined, (
+        "the reader example is missing, and it is the interoperability contract the format exists for"
+    )
+    assert "rebin_by_tof" in joined, "the frame-binning example is missing"
+    assert "normalize_roi_spectrum" in joined, "the without-a-pipeline example is missing"
+    assert "detect_resonances" in joined, "the resonance-detector example is missing"
+
+
+def test_the_page_documents_the_ascii_format_exactly():
+    """The three-column format is a cross-tool contract, so the page must show it verbatim — including
+    the header line and the six-decimal rendering a downstream parser will meet."""
+    text = DOC.read_text()
+    assert "bin_index,transmission,uncertainty" in text
+    assert "0,0.448760,0.010663" in text
+    from neunorm.exporters.ascii_writer import ASCII_SPECTRUM_HEADER
+
+    assert ASCII_SPECTRUM_HEADER in text, "the page's header line has drifted from the writer's"
+
+
+def test_the_page_says_what_the_mode_does_not_do():
+    """The progress page sets the precedent: stating the boundaries is what stops a user assuming a
+    capability that is not there. Named explicitly so the section cannot be quietly dropped."""
+    text = DOC.read_text()
+    assert "## What resonance mode does not do" in text
+    for expected in ("CCD pipelines", "shared-dark", "fit"):
+        assert expected in text, f"the boundaries section no longer mentions {expected!r}"
+
+
+@pytest.fixture
+def documented_namespace(tmp_path, monkeypatch):
+    """The names the page tells the reader to supply, and nothing else.
+
+    Deliberately not seeding ``Path``, ``np`` or ``sc``: a block that forgot its own import would pass
+    here while failing for a reader who pastes it, which is the failure this file exists to catch.
+    """
+    sample_dir = tmp_path / "sample"
+    ob_dir = tmp_path / "ob"
+    sample_dir.mkdir()
+    ob_dir.mkdir()
+    sample_tiffs = _tpx1_tiffs(sample_dir, "sample", _FRAMES, 81)
+    ob_tiffs = _tpx1_tiffs(ob_dir, "ob", _FRAMES, 99)
+    left_edges = [round(0.1 * (i + 1), 1) for i in range(_FRAMES)]
+    _spectra_file(sample_dir / "sample_Spectra.txt", left_edges)
+    _spectra_file(ob_dir / "ob_Spectra.txt", left_edges)
+
+    monkeypatch.chdir(tmp_path)
+
+    # The reader example reads spectrum.txt, which the FIRST example writes. Blocks each get a fresh
+    # namespace and a fresh directory, so seed a real one — written by the real writer, not hand-typed
+    # — and let the pipeline example overwrite it.
+    from neunorm.exporters.ascii_writer import write_ascii_spectrum
+
+    seeded = sc.DataArray(
+        sc.array(
+            dims=["tof"],
+            values=np.array([0.44876, 0.451203, 0.449881]),
+            variances=np.array([0.010663, 0.010701, 0.010684]) ** 2,
+        )
+    )
+    write_ascii_spectrum(tmp_path / "spectrum.txt", seeded)
+
+    return {
+        "__name__": "docs_example",
+        "sample_hdf5_paths": [_nexus(tmp_path / "nexus" / "s.nxs.h5", 12345)],
+        "ob_hdf5_paths": [_nexus(tmp_path / "nexus" / "o.nxs.h5", 24690)],
+        "sample_tiff_paths": [sample_tiffs],
+        "ob_tiff_paths": [ob_tiffs],
+        "hist_sample": _energy_histogram(1000.0, dips=(5.0, 20.0, 50.0)),
+        "hist_ob": _energy_histogram(1000.0),
+    }
+
+
+@pytest.mark.parametrize("line,source", BLOCKS, ids=[f"line{line}" for line, _ in BLOCKS])
+def test_every_documented_example_runs(documented_namespace, line, source):
+    """Run the block verbatim. A NameError means the page shows an incomplete snippet; any other
+    exception means the page shows something that does not work."""
+    try:
+        exec(compile(source, f"{DOC.name}:{line}", "exec"), documented_namespace)  # noqa: S102
+    except NameError as exc:
+        pytest.fail(f"{DOC.name}:{line} references a name the page never defines: {exc}")
+
+
+def test_the_documented_pipeline_example_writes_the_file_the_page_describes(documented_namespace):
+    """The first example claims a three-column ASCII file plus an HDF5 sibling. Run that block and check
+    both, so the page's central promise is verified rather than asserted."""
+    line, source = next((ln, src) for ln, src in BLOCKS if "spectrum.txt" in src and "run_venus_tpx1" in src)
+    exec(compile(source, f"{DOC.name}:{line}", "exec"), documented_namespace)  # noqa: S102
+
+    written = Path("spectrum.txt")
+    assert written.exists()
+    lines = written.read_text().splitlines()
+    assert lines[0] == "bin_index,transmission,uncertainty"
+    assert len(lines) == _FRAMES + 1, "one header line plus one row per frame"
+
+    table = np.loadtxt(written, skiprows=1, delimiter=",")
+    np.testing.assert_array_equal(table[:, 0].astype(int), np.arange(_FRAMES))
+
+    # Uniform synthetic frames make the expected transmission exact arithmetic, so this pins the
+    # NUMBER rather than merely the file's existence. Frame i holds 81+i counts against 99+i, and the
+    # proton charges are 12345 and 24690 -- combine_runs normalizes per run, so the ratio is
+    # ((81+i)/12345) / ((99+i)/24690) = 2*(81+i)/(99+i).
+    expected = 2.0 * (81.0 + np.arange(_FRAMES)) / (99.0 + np.arange(_FRAMES))
+    np.testing.assert_allclose(table[:, 1], expected, rtol=1e-5)
+
+    assert Path("spectrum.hdf5").exists(), "the page promises an HDF5 file alongside the ASCII one"
+    import h5py
+
+    with h5py.File("spectrum.hdf5") as f:
+        for expected_dataset in ("transmission", "uncertainty", "tof", "spectra_tof"):
+            assert expected_dataset in f, f"/{expected_dataset} missing from the HDF5 sibling"
+        assert "metadata/spectrum_roi" in f
+
+
+def test_the_documented_binning_example_gives_the_bin_index_column_the_page_shows(documented_namespace):
+    """The page states rebin_by_tof=2 over six frames yields rows indexed 0, 2, 4. Run it and read the
+    column back out of the file, because that claim is what a user will check first."""
+    line, source = next((ln, src) for ln, src in BLOCKS if "rebin_by_tof=2" in src)
+    exec(compile(source, f"{DOC.name}:{line}", "exec"), documented_namespace)  # noqa: S102
+
+    table = np.loadtxt(Path("binned.txt"), skiprows=1, delimiter=",")
+    np.testing.assert_array_equal(table[:, 0].astype(int), np.array([0, 2, 4]))

--- a/tests/unit/test_resonance_detection.py
+++ b/tests/unit/test_resonance_detection.py
@@ -228,3 +228,73 @@ def test_detect_resonances_with_known_validation():
     assert "recall" in result["validation"]
     assert "precision" in result["validation"]
     assert "n_matched" in result["validation"]
+
+
+class TestVarianceFreeInputDtypes:
+    """``detect_resonances`` accepts variance-free histograms in the dtypes the loaders produce.
+
+    The SNR step reads a propagated variance, so a variance-free input has Poisson variance synthesized
+    for it (``Var = counts``). scipp requires the values and the variances to share a dtype, and
+    ``float32`` is what ``event_converter`` and ``tiff_loader`` produce natively while a hand-built
+    histogram carries integers — so getting this wrong turns any of those into a scipp dtype error that
+    names nothing in NeuNorm.
+    """
+
+    @staticmethod
+    def _histogram(dtype, *, variances=False):
+        n_energy = 120
+        edges = np.geomspace(1.0, 100.0, n_energy + 1)
+        values = np.full((n_energy, 8, 8), 1000).astype(dtype)
+        data = sc.array(dims=["energy", "x", "y"], values=values, unit="counts")
+        if variances:
+            data = sc.array(dims=["energy", "x", "y"], values=values, variances=values.copy(), unit="counts")
+        return sc.DataArray(data, coords={"energy": sc.array(dims=["energy"], values=edges, unit="eV")})
+
+    @pytest.mark.parametrize("dtype", [np.float64, np.float32, np.int64, np.int32])
+    def test_a_variance_free_histogram_is_accepted_whatever_its_count_dtype(self, dtype):
+        """No dtype error, and a well-formed result dict."""
+        from neunorm.tof.resonance import detect_resonances
+
+        result = detect_resonances(self._histogram(dtype), self._histogram(dtype))
+
+        assert isinstance(result, dict)
+        for key in ("resonance_energies", "resonance_indices", "snr_values", "n_initial"):
+            assert key in result
+
+    def test_float32_counts_stay_float32_through_the_region_collapse(self):
+        """Precision is preserved rather than promoted, because promoting doubles the working set.
+
+        The region defaults to the whole detector here, so a promotion to float64 would double peak
+        memory on the largest array in the run.
+        """
+        from neunorm.tof.resonance import _region_spectra
+
+        spectrum_ta, spectrum_ob = _region_spectra(self._histogram(np.float32), self._histogram(np.float32), None)
+
+        assert spectrum_ta.dtype == "float32", f"promoted to {spectrum_ta.dtype}"
+        assert spectrum_ob.dtype == "float32"
+
+    def test_integer_counts_are_promoted_rather_than_given_integer_variances(self):
+        """Integer counts cannot carry a meaningful variance dtype, so they become float64."""
+        from neunorm.tof.resonance import _region_spectra
+
+        spectrum_ta, _ = _region_spectra(self._histogram(np.int64), self._histogram(np.int64), None)
+
+        assert spectrum_ta.dtype == "float64"
+        assert spectrum_ta.variances is not None
+
+    def test_an_input_that_already_carries_variances_is_left_exactly_as_it_is(self):
+        """Synthesis only fills a gap; it must never overwrite a real variance.
+
+        Pinned with a variance deliberately unequal to the counts — the case where overwriting would be
+        both wrong and invisible, since a Poisson-shaped input would hide the substitution.
+        """
+        from neunorm.tof.resonance import _with_poisson_variances
+
+        values = np.array([[100.0, 100.0], [100.0, 100.0]])
+        data = sc.DataArray(sc.array(dims=["x", "y"], values=values, variances=np.full((2, 2), 7.0), unit="counts"))
+
+        out = _with_poisson_variances(data)
+
+        np.testing.assert_array_equal(out.variances, np.full((2, 2), 7.0))
+        assert out is data, "an input that already has variances should be returned untouched"

--- a/tests/unit/test_roi_spectrum.py
+++ b/tests/unit/test_roi_spectrum.py
@@ -1,0 +1,467 @@
+"""Unit tests for ``roi_mean_spectrum``, the mask-aware pooled region mean per spectral bin.
+
+Every expected number here is either a literal or computed with plain numpy from the input array.
+None of them comes from a second call into the function under test: the whole purpose of this file
+is to pin the arithmetic of the region collapse, and an expectation borrowed from the implementation
+pins nothing at all.
+
+The quantity being pinned is ``sum(counts over the selected, unmasked pixels) / count(those
+pixels)`` per spectral bin, with ``Var(mean) = sum(Var over those pixels) / n**2``. It is deliberately
+*not* ``sc.mean(data, dim=["y", "x"])`` — see :class:`TestAntiSimplification`.
+"""
+
+import numpy as np
+import pytest
+import scipp as sc
+
+from neunorm.data_models.roi import ROI, MaskROI
+from neunorm.processing.spectrum_reducer import roi_mean_spectrum
+
+_NT, _NY, _NX = 3, 5, 6
+
+# The rectangle used by most tests: x in [1, 4) and y in [1, 3) -> 3 x 2 = 6 pixels. Stops are
+# EXCLUSIVE, so the numpy expectation is counts[:, 1:3, 1:4] (y first, x second).
+_RECT = (1, 1, 4, 3)
+
+
+def _ramp() -> np.ndarray:
+    """Index ramp shared by the counts and variance builders below."""
+    return np.arange(_NT * _NY * _NX, dtype=float).reshape(_NT, _NY, _NX)
+
+
+def _counts() -> np.ndarray:
+    """Deterministic non-monotonic counts, so selecting the wrong pixel set changes the mean.
+
+    A plain ramp would give the same mean for several different pixel sets (its mean is the midpoint
+    of any symmetric block), which would let an off-by-one in the bounds pass unnoticed.
+    """
+    return (_ramp() % 17) * 3.0 + 5.0
+
+
+def _variances() -> np.ndarray:
+    """Variances on a different cycle from the counts, so ``Var(mean)`` cannot accidentally match."""
+    return (_ramp() % 11) + 1.0
+
+
+def _stack(masks: dict = None) -> sc.DataArray:
+    """A ``(tof, y, x)`` counts stack with variances and optional scipp exclusion masks."""
+    data = sc.DataArray(sc.array(dims=["tof", "y", "x"], values=_counts(), variances=_variances(), unit="counts"))
+    for name, mask in (masks or {}).items():
+        data.masks[name] = mask
+    return data
+
+
+def _selection(*, y: slice, x: slice) -> np.ndarray:
+    """A boolean ``(y, x)`` selection covering one rectangular block (True = pixel in the region)."""
+    sel = np.zeros((_NY, _NX), dtype=bool)
+    sel[y, x] = True
+    return sel
+
+
+def _hand_pooled(selection: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Hand-computed ``(mean, variance-of-mean)`` per tof bin over a boolean ``(y, x)`` selection.
+
+    Plain numpy: fancy-index the pixels the region keeps, sum them, divide by how many there are.
+    """
+    n = int(selection.sum())
+    counts = _counts()[:, selection]
+    variances = _variances()[:, selection]
+    return counts.sum(axis=1) / n, variances.sum(axis=1) / n**2
+
+
+def _dead_mask(pixels: list) -> sc.Variable:
+    """A spatial dead/hot-pixel exclusion mask flagging the given ``(y, x)`` pixels."""
+    dead = np.zeros((_NY, _NX), dtype=bool)
+    for y, x in pixels:
+        dead[y, x] = True
+    return sc.array(dims=["y", "x"], values=dead)
+
+
+class TestRectangleMeanAndVariance:
+    def test_mean_over_a_rectangle_matches_a_numpy_slice(self):
+        """With no mask the pooled mean is the plain arithmetic mean of the region's pixels.
+
+        Pinned against ``counts[:, y0:y1, x0:x1].mean(axis=(1, 2))`` so the reduction cannot quietly
+        acquire a weighting, an extra normalization, or the wrong pixel set.
+        """
+        result = roi_mean_spectrum(_stack(), _RECT)
+
+        expected = _counts()[:, 1:3, 1:4].mean(axis=(1, 2))
+        np.testing.assert_allclose(result.values, expected)
+        np.testing.assert_allclose(result.values, [38.0, 26.0, 22.5])  # the same numbers, written out
+        assert result.dims == ("tof",)
+        assert result.unit == sc.Unit("counts")
+
+    def test_variance_is_summed_variance_over_pixel_count_squared(self):
+        """``Var(mean) = sum(Var) / n**2`` — the variance of a sum of n independent pixels, scaled.
+
+        The wrong-by-n forms (``sum(Var) / n``, i.e. forgetting that the divisor is squared) are
+        pinned as *not* the answer, because they differ only by a factor the eye does not catch.
+        """
+        result = roi_mean_spectrum(_stack(), _RECT)
+
+        summed = _variances()[:, 1:3, 1:4].sum(axis=(1, 2))
+        np.testing.assert_allclose(result.variances, summed / 6**2)
+        assert np.all(np.abs(result.variances - summed / 6) > 1.0)
+
+    def test_rectangle_stops_are_exclusive(self):
+        """``(x0, y0, x1, y1)`` are Python-slice bounds: x1/y1 are past the last pixel.
+
+        Reading them as inclusive would silently widen the region by a row and a column, so the
+        inclusive answer is computed too and required to differ.
+        """
+        result = roi_mean_spectrum(_stack(), _RECT)
+
+        exclusive = _counts()[:, 1:3, 1:4].mean(axis=(1, 2))
+        inclusive = _counts()[:, 1:4, 1:5].mean(axis=(1, 2))
+        np.testing.assert_allclose(result.values, exclusive)
+        assert np.all(np.abs(exclusive - inclusive) > 0.5)
+
+    def test_roi_model_and_bare_tuple_agree(self):
+        """An ``ROI`` given by width/height resolves to the same rectangle as the bare tuple form."""
+        from_tuple = roi_mean_spectrum(_stack(), _RECT)
+        from_model = roi_mean_spectrum(_stack(), ROI(x0=1, y0=1, width=3, height=2))
+
+        np.testing.assert_allclose(from_model.values, _counts()[:, 1:3, 1:4].mean(axis=(1, 2)))
+        np.testing.assert_allclose(from_model.values, from_tuple.values)
+
+
+class TestMaskAwareness:
+    def test_dead_pixels_inside_the_region_leave_both_sum_and_count(self):
+        """A masked pixel contributes to neither the summed counts nor the pixel count.
+
+        The two halves of that statement are pinned separately: dropping the pixel from the sum but
+        not from the denominator (a plain ``width * height`` count) biases the mean low, and dropping
+        it from the denominator but not the sum biases it high. Both wrong answers are computed here
+        and required to differ from the result, so neither substitution can pass.
+        """
+        dead = [(2, 2), (1, 3)]  # both inside x in [1, 4), y in [1, 3)
+        result = roi_mean_spectrum(_stack({"dead": _dead_mask(dead)}), _RECT)
+
+        keep = np.ones((_NY, _NX), dtype=bool)
+        for y, x in dead:
+            keep[y, x] = False
+        surviving = _selection(y=slice(1, 3), x=slice(1, 4)) & keep
+        expected, expected_var = _hand_pooled(surviving)
+        assert int(surviving.sum()) == 4  # 6 pixels in the rectangle, 2 of them masked
+
+        np.testing.assert_allclose(result.values, expected)
+        np.testing.assert_allclose(result.variances, expected_var)
+
+        masked_sum = _counts()[:, surviving].sum(axis=1)
+        plain_pixel_count = 6
+        assert np.all(np.abs(result.values - masked_sum / plain_pixel_count) > 1.0)
+        whole_region_sum = _counts()[:, 1:3, 1:4].sum(axis=(1, 2))
+        assert np.all(np.abs(result.values - whole_region_sum / 4) > 1.0)
+
+    def test_variance_of_a_partially_masked_region_uses_the_unmasked_count(self):
+        """``Var(mean)`` over a masked region divides by the *unmasked* count squared.
+
+        Counting the masked pixels in the denominator understates the variance — the region really
+        was measured with fewer pixels — and an understated uncertainty is the failure mode a user
+        cannot see in the output.
+        """
+        dead = [(1, 1), (2, 3)]
+        result = roi_mean_spectrum(_stack({"dead": _dead_mask(dead)}), _RECT)
+
+        keep = np.ones((_NY, _NX), dtype=bool)
+        for y, x in dead:
+            keep[y, x] = False
+        surviving = _selection(y=slice(1, 3), x=slice(1, 4)) & keep
+        summed_var = _variances()[:, surviving].sum(axis=1)
+
+        np.testing.assert_allclose(result.variances, summed_var / 4**2)
+        assert np.all(np.abs(result.variances - summed_var / 6**2) > 0.01)
+
+
+class TestRegionForms:
+    def test_maskroi_covering_the_rectangle_gives_the_same_answer(self):
+        """A ``MaskROI`` selecting exactly the rectangle's pixels reduces to the same spectrum.
+
+        The two take different code paths (a sliced view versus a bounding-box view carrying the
+        inverse selection as a scipp mask), so their agreement is not free — and a user drawing a
+        rectangular mask in ImageJ must get the rectangle's answer.
+        """
+        masks = {"dead": _dead_mask([(2, 2)])}
+        selection = _selection(y=slice(1, 3), x=slice(1, 4))
+        expected, expected_var = _hand_pooled(selection & ~masks["dead"].values)
+
+        from_rect = roi_mean_spectrum(_stack(masks), _RECT)
+        from_mask = roi_mean_spectrum(_stack(masks), MaskROI(selection=selection))
+
+        np.testing.assert_allclose(from_rect.values, expected)
+        np.testing.assert_allclose(from_mask.values, expected)
+        np.testing.assert_allclose(from_mask.variances, expected_var)
+
+    def test_both_region_forms_reduce_to_the_spectral_dim_alone(self):
+        """The output dims depend only on the input's dims, never on which region form was used.
+
+        Downstream code (the transmission division, the ASCII writer) indexes the spectral axis, so
+        a region form that returned a scalar instead of one value per bin would break it.
+
+        This holds structurally rather than by a correction: the coefficient is ``total / n_unmasked``,
+        and although ``n_unmasked`` collapses to a bare scalar on the MaskROI path with purely spatial
+        masks, ``total`` is a sum over ``x`` and ``y`` only and so retains the spectral dim, which the
+        division then keeps. Pinned here because that is not obvious from reading the reduction, and a
+        reader who assumed otherwise would reach for a broadcast the shapes never require.
+        """
+        from_rect = roi_mean_spectrum(_stack(), _RECT)
+        from_mask = roi_mean_spectrum(_stack(), MaskROI(selection=_selection(y=slice(1, 3), x=slice(1, 4))))
+
+        assert from_rect.dims == ("tof",)
+        assert from_mask.dims == ("tof",)
+        assert from_rect.shape == (_NT,)
+        assert from_mask.shape == (_NT,)
+
+    def test_two_dimensional_input_reduces_to_a_scalar(self):
+        """An image with no spectral dim collapses to a 0-D value, not a length-1 spectrum."""
+        image = sc.DataArray(sc.array(dims=["y", "x"], values=_counts()[0], variances=_variances()[0], unit="counts"))
+
+        result = roi_mean_spectrum(image, _RECT)
+
+        assert result.dims == ()
+        np.testing.assert_allclose(result.value, _counts()[0][1:3, 1:4].mean())
+        np.testing.assert_allclose(result.variance, _variances()[0][1:3, 1:4].sum() / 6**2)
+
+
+class TestPooledRegions:
+    def test_overlapping_pair_counts_each_shared_pixel_once(self):
+        """Pooled regions are reduced over their UNION, not by adding the regions up.
+
+        Accumulating region by region counts the shared pixels twice: it inflates the mean toward
+        the overlap's values, and — because each shared pixel's variance is then added as if it came
+        from a second independent sample — understates the variance. The double-counted answer is
+        computed here and required to differ.
+        """
+        first, second = (0, 0, 3, 3), (1, 1, 5, 4)  # 9 and 12 pixels, sharing a 2x2 block
+        union = _selection(y=slice(0, 3), x=slice(0, 3)) | _selection(y=slice(1, 4), x=slice(1, 5))
+        assert int(union.sum()) == 17  # 9 + 12 - 4 shared
+
+        result = roi_mean_spectrum(_stack(), [first, second])
+
+        expected, expected_var = _hand_pooled(union)
+        np.testing.assert_allclose(result.values, expected)
+        np.testing.assert_allclose(result.variances, expected_var)
+
+        counts = _counts()
+        double_counted = (counts[:, 0:3, 0:3].sum(axis=(1, 2)) + counts[:, 1:4, 1:5].sum(axis=(1, 2))) / 21
+        assert np.all(np.abs(result.values - double_counted) > 0.9)
+
+    def test_overlapping_maskroi_and_rectangle_pool_to_the_same_union(self):
+        """The union rule holds across region forms: a mask overlapping a rectangle is still a union."""
+        selection = _selection(y=slice(0, 3), x=slice(0, 3))
+        union = selection | _selection(y=slice(1, 4), x=slice(1, 5))
+        expected, expected_var = _hand_pooled(union)
+
+        result = roi_mean_spectrum(_stack(), [MaskROI(selection=selection), (1, 1, 5, 4)])
+
+        np.testing.assert_allclose(result.values, expected)
+        np.testing.assert_allclose(result.variances, expected_var)
+
+    def test_disjoint_pair_pools_both_regions(self):
+        """Two regions that do not touch pool into one mean over all their pixels together.
+
+        Not the mean of the two region means. The two regions here hold DIFFERENT pixel counts — 4 and
+        6 — and that is what makes the distinction observable: pooling weights every pixel equally,
+        where averaging the two region means would weight each pixel of the 4-pixel region 1.5x as
+        heavily. With equal-sized regions the two forms coincide exactly and this test would pin
+        nothing, so the mean-of-means is computed here and required to differ.
+        """
+        first, second = (0, 0, 2, 2), (3, 3, 6, 5)
+        sel_first = _selection(y=slice(0, 2), x=slice(0, 2))
+        sel_second = _selection(y=slice(3, 5), x=slice(3, 6))
+        union = sel_first | sel_second
+        expected, expected_var = _hand_pooled(union)
+
+        # the wrong form, for contrast: each region's own mean, then their unweighted average
+        mean_of_means = np.mean([_hand_pooled(sel_first)[0], _hand_pooled(sel_second)[0]], axis=0)
+
+        result = roi_mean_spectrum(_stack(), [first, second])
+
+        assert int(sel_first.sum()) == 4
+        assert int(sel_second.sum()) == 6
+        assert int(union.sum()) == 10, "disjoint, so the union holds the sum of the two counts"
+        assert not np.allclose(expected, mean_of_means), (
+            "the regions must differ in size enough that pooling and averaging-of-means disagree, or "
+            f"this test cannot fail: pooled={expected} mean_of_means={mean_of_means}"
+        )
+        np.testing.assert_allclose(result.values, expected)
+        np.testing.assert_allclose(result.variances, expected_var)
+        assert not np.allclose(result.values, mean_of_means)
+
+
+class TestAntiSimplification:
+    def test_pooled_mean_disagrees_with_scipp_dimension_wise_mean(self):
+        """``sc.mean(region, dim=["y", "x"])`` is NOT this pooled mean once a pixel is masked.
+
+        scipp reduces one dimension at a time, so that call averages each column over its own
+        surviving rows and then averages those column means — an unweighted average of unequally
+        sampled columns. The pooled mean instead divides the total counts by the total number of
+        surviving pixels, which is the region's actual mean. The nested spelling
+        ``mean("x").mean("y")`` is a third, order-dependent number.
+
+        On the 3x3 block below (counts 1..9, with x=2 masked in rows y=1 and y=2, leaving 7 pixels
+        summing to 30):
+
+        * pooled            = 30 / 7      = 4.2857...   <- what roi_mean_spectrum returns
+        * sc.mean(["y","x"]) = (4+5+3) / 3 = 4.0        <- column means, then averaged
+        * mean("x").mean("y") = (2+4.5+7.5) / 3 = 4.667 <- row means, then averaged
+
+        Substituting either scipp form would change every transmission spectrum this library
+        produces over a detector with dead pixels, silently.
+        """
+        counts = np.array(
+            [
+                [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
+                [[10.0, 20.0, 30.0], [40.0, 50.0, 60.0], [70.0, 80.0, 90.0]],
+            ]
+        )
+        block = sc.DataArray(sc.array(dims=["tof", "y", "x"], values=counts.copy(), unit="counts"))
+        dead = np.zeros((3, 3), dtype=bool)
+        dead[1, 2] = True
+        dead[2, 2] = True
+        block.masks["dead"] = sc.array(dims=["y", "x"], values=dead)
+
+        pooled = roi_mean_spectrum(block, (0, 0, 3, 3))
+        dimension_wise = sc.mean(block, dim=["y", "x"])
+        nested = sc.mean(sc.mean(block, dim="x"), dim="y")
+
+        np.testing.assert_allclose(pooled.values, [30.0 / 7.0, 300.0 / 7.0])
+        np.testing.assert_allclose(dimension_wise.values, [4.0, 40.0])
+        np.testing.assert_allclose(nested.values, [14.0 / 3.0, 140.0 / 3.0])
+        assert np.all(np.abs(pooled.values - dimension_wise.values) > 0.25)
+        assert np.all(np.abs(pooled.values - nested.values) > 0.25)
+
+
+class TestSurvivingCoordsAndMasks:
+    def _annotated(self) -> sc.DataArray:
+        """A stack carrying every kind of coord and mask a pipeline attaches before this reduction."""
+        per_bin = sc.array(dims=["tof"], values=[False, False, True])
+        data = _stack({"dead": _dead_mask([(2, 2)]), "missing_bin": per_bin})
+        data.coords["tof"] = sc.array(dims=["tof"], values=[0.0, 1.0, 2.0, 3.0], unit="us")  # N + 1 edges
+        data.coords["y"] = sc.array(dims=["y"], values=np.arange(_NY, dtype=float), unit="mm")
+        data.coords["x"] = sc.array(dims=["x"], values=np.arange(_NX, dtype=float), unit="mm")
+        data.coords["proton_charge"] = sc.scalar(1.5, unit="C")
+        data.coords["spectra_tof"] = sc.array(dims=["tof"], values=[0.4, 1.4, 2.4], unit="us")
+        data.coords.set_aligned("spectra_tof", False)
+        return data
+
+    def test_spectral_coords_survive_and_spatial_ones_do_not(self):
+        """The reduction keeps what still has meaning and drops what it consumed.
+
+        The ``N + 1`` ``tof`` bin edges must survive — without them the spectrum cannot be rebinned
+        again or converted to wavelength — as must scalar metadata such as ``proton_charge``. The
+        ``(y, x)`` pixel-position coords describe an axis that no longer exists, so keeping them
+        would leave a DataArray whose coords contradict its dims.
+        """
+        result = roi_mean_spectrum(self._annotated(), _RECT)
+
+        assert set(result.coords) == {"tof", "spectra_tof", "proton_charge"}
+        assert "y" not in result.coords
+        assert "x" not in result.coords
+        assert result.coords["tof"].sizes == {"tof": _NT + 1}
+        assert result.coords.is_edges("tof")
+        np.testing.assert_allclose(result.coords["tof"].values, [0.0, 1.0, 2.0, 3.0])
+        assert result.coords["proton_charge"].dims == ()
+        np.testing.assert_allclose(result.coords["proton_charge"].value, 1.5)
+
+    def test_alignment_flags_are_preserved(self):
+        """Whether a coord is aligned decides if scipp refuses a later mismatched binary op.
+
+        Re-attaching a coord defaults it to aligned, so an unaligned ``spectra_tof`` silently
+        becoming aligned would start rejecting divisions that used to work — and an aligned ``tof``
+        silently becoming unaligned would start permitting divisions between different time axes,
+        which is the worse direction.
+        """
+        result = roi_mean_spectrum(self._annotated(), _RECT)
+
+        assert result.coords["tof"].aligned is True
+        assert result.coords["spectra_tof"].aligned is False
+
+    def test_per_bin_masks_survive_and_pixel_masks_do_not(self):
+        """A per-bin mask still applies to the spectrum; the dead-pixel mask has been consumed.
+
+        The dead/hot pixel masks were folded into the mean (that is what makes it mask-aware), so
+        carrying them onto a result with no spatial dims is both meaningless and, for a downstream
+        guard reading ``masks``, actively misleading. A ``(tof,)`` mask marking bins that hold no
+        data is the opposite: it must reach the exporter so those rows can be omitted.
+        """
+        result = roi_mean_spectrum(self._annotated(), _RECT)
+
+        assert set(result.masks) == {"missing_bin"}
+        assert result.masks["missing_bin"].dims == ("tof",)
+        assert list(result.masks["missing_bin"].values) == [False, False, True]
+
+
+class TestStrictGuard:
+    def _flat(self, value: float) -> sc.DataArray:
+        values = np.full((_NT, _NY, _NX), value)
+        counts = sc.array(dims=["tof", "y", "x"], values=values, variances=np.ones_like(values), unit="counts")
+        return sc.DataArray(counts)
+
+    @pytest.mark.parametrize("value", [0.0, -2.0])
+    def test_strict_rejects_a_non_positive_region_mean(self, value):
+        """As a denominator, a region mean of zero or less is a fault, and must not become inf/NaN.
+
+        The guard exists so the failure is reported where it can be diagnosed (the region contains
+        no beam) rather than surfacing later as a spectrum full of inf.
+        """
+        with pytest.raises(ValueError, match="pooled mean must be strictly positive and finite"):
+            roi_mean_spectrum(self._flat(value), _RECT, name="ob")
+
+    def test_strict_error_names_the_argument_and_the_array(self):
+        """The message must say which argument and which input, or the user cannot act on it."""
+        with pytest.raises(ValueError) as excinfo:
+            roi_mean_spectrum(self._flat(0.0), _RECT, region_arg="spectrum_roi", name="open beam")
+
+        message = str(excinfo.value)
+        assert "spectrum_roi" in message
+        assert "open beam" in message
+
+    @pytest.mark.parametrize("value", [0.0, -2.0])
+    def test_non_strict_lets_a_non_positive_mean_through(self, value):
+        """A zero or negative mean is a real measurement in a numerator — full absorption, or
+        dark-subtracted counts scattering below zero — so ``strict=False`` must return it unchanged
+        rather than raise or clamp it.
+        """
+        result = roi_mean_spectrum(self._flat(value), _RECT, strict=False)
+
+        np.testing.assert_allclose(result.values, np.full(_NT, value))
+
+
+class TestStructuralErrors:
+    """Malformed input always raises, whatever ``strict`` says: ``strict`` only governs the
+    non-positive-mean guard, never whether the region actually fits the data."""
+
+    @pytest.mark.parametrize("strict", [True, False])
+    def test_rectangle_outside_the_detector_raises(self, strict):
+        with pytest.raises(ValueError, match="exceeds"):
+            roi_mean_spectrum(_stack(), (0, 0, _NX + 4, 3), strict=strict)
+
+    @pytest.mark.parametrize("strict", [True, False])
+    def test_inverted_rectangle_raises(self, strict):
+        with pytest.raises(ValueError, match="need 0 <= x0 < x1"):
+            roi_mean_spectrum(_stack(), (3, 1, 2, 3), strict=strict)
+
+    @pytest.mark.parametrize("strict", [True, False])
+    def test_maskroi_of_the_wrong_shape_raises(self, strict):
+        """A selection sized for a different detector (or a pre-crop frame) must not be broadcast
+        or silently padded — its pixels do not correspond to these pixels."""
+        wrong = MaskROI(selection=np.ones((_NY - 1, _NX - 1), dtype=bool))
+
+        with pytest.raises(ValueError, match="does not match data size"):
+            roi_mean_spectrum(_stack(), wrong, strict=strict)
+
+    @pytest.mark.parametrize("strict", [True, False])
+    def test_input_without_x_and_y_dims_raises(self, strict):
+        """Region indices are resolved against ``x``/``y`` by name, so differently named spatial
+        dims are refused rather than guessed at."""
+        renamed = sc.DataArray(sc.array(dims=["tof", "row", "col"], values=_counts(), unit="counts"))
+
+        with pytest.raises(ValueError, match="must have 'x' and 'y' dimensions"):
+            roi_mean_spectrum(renamed, _RECT, strict=strict)
+
+    @pytest.mark.parametrize("strict", [True, False])
+    def test_empty_region_list_raises(self, strict):
+        with pytest.raises(ValueError, match="at least one ROI"):
+            roi_mean_spectrum(_stack(), [], strict=strict)

--- a/tests/unit/test_spectrum_frame_binning.py
+++ b/tests/unit/test_spectrum_frame_binning.py
@@ -1,0 +1,627 @@
+"""Frame-index binning of an ROI spectrum: where the two possible orders agree, and where they do not.
+
+An ROI spectrum can be built two ways, and only one of them is what the pipelines do:
+
+* **Order A (the settled order).** Bin both stacks with ``rebin_tof``, collapse each side's region to
+  a pooled mean per bin, divide once. This mirrors the image mode exactly — the pipelines already
+  call ``rebin_tof(sample); rebin_tof(ob); normalize_transmission(...)`` — so resonance mode
+  introduces no second convention.
+* **Order B.** Collapse each stack to a 1-D spectrum first, bin the two spectra, divide once.
+
+The two are the same quantity only under conditions that are easy to lose sight of, so they are
+measured here rather than assumed:
+
+* with a purely spatial ``(y, x)`` mask they agree exactly for ``sum`` and for ``mean``, at every
+  binning tried (a factor of 2, a factor of 3, and an explicit non-uniform contiguous bin list);
+* with a per-frame ``(tof, y, x)`` mask they **diverge**, because binning consumes the mask and
+  leaves every bin with the full region as its denominator while order B keeps a different unmasked
+  count for each frame;
+* with ``median`` they **diverge** whenever a bin holds three or more frames, because a median does
+  not commute with a mean.
+
+Both divergent cases are pinned to order A, with the other order's numbers written down as well, so
+the choice is recorded as a decision and not left as an accident of call order.
+
+Two mechanical facts about the ``tof`` axis are pinned alongside: a stack carrying no timing
+coordinate cannot be binned at all until an ``N + 1`` index edge coordinate is attached (verified by
+running it — the rebinner raises today), and a representative time per bin survives a sum-mode rebin
+even though :func:`scipp.rebin` cannot produce one, because the reduction rebuilds it from the bin
+edges and refuses to trust a coordinate that a sum has corrupted.
+
+Every expected number below is a literal or is computed with plain numpy from the synthetic input.
+Where the two orders are compared against each other the invariant under test *is* their agreement,
+so that comparison is the point — but each such case additionally pins order A against the numpy
+oracle, so the pair cannot both drift together.
+"""
+
+import numpy as np
+import pytest
+import scipp as sc
+from loguru import logger
+
+from neunorm.processing.normalizer import normalize_transmission
+from neunorm.processing.spectrum_reducer import normalize_roi_spectrum, roi_mean_spectrum
+from neunorm.tof.histogram_rebinner import SPECTRA_TOF_COORD, rebin_tof, reduce_tof_bins
+
+_N_TOF, _NY, _NX = 6, 5, 6
+
+#: ``(x0, y0, x1, y1)`` with EXCLUSIVE stops: x in [1, 5), y in [1, 4) -> 4 x 3 = 12 pixels, away
+#: from the frame edges so an off-by-one in the bounds changes the answer.
+_REGION = (1, 1, 5, 4)
+_X0, _Y0, _X1, _Y1 = _REGION
+
+#: N + 1 TOF bin edges, microseconds; 6 frames so both a factor of 2 and a factor of 3 divide it.
+_EDGES = np.linspace(1000.0, 7000.0, _N_TOF + 1)
+
+#: The three binnings exercised for commutation, as the ``rebin_tof`` ``width`` and the equivalent
+#: half-open frame ranges the numpy oracle uses. The bin list is deliberately non-uniform, so it is
+#: not a restatement of either factor.
+_BINNINGS = [
+    (2, [(0, 2), (2, 4), (4, 6)]),
+    (3, [(0, 3), (3, 6)]),
+    ([[0, 1], [1, 4], [4, 6]], [(0, 1), (1, 4), (4, 6)]),
+]
+
+
+# --------------------------------------------------------------------------------------------
+# synthetic input
+# --------------------------------------------------------------------------------------------
+
+
+def _ramp() -> np.ndarray:
+    """Index ramp the counts and variances are built from."""
+    return np.arange(_N_TOF * _NY * _NX, dtype=float).reshape(_N_TOF, _NY, _NX)
+
+
+def _sample_counts() -> np.ndarray:
+    """Non-monotonic sample counts: a plain ramp averages to its midpoint over any symmetric block,
+    which would let a wrong pixel or frame set produce the right mean."""
+    return (_ramp() % 13) * 7.0 + 30.0
+
+
+def _sample_variances() -> np.ndarray:
+    """Sample variances on a different cycle from the counts, so a values/variances mix-up shows."""
+    return (_ramp() % 11) + 1.0
+
+
+def _ob_counts() -> np.ndarray:
+    """Open-beam counts, everywhere positive so the strict denominator guard is satisfied."""
+    return (_ramp() % 19) * 11.0 + 400.0
+
+
+def _ob_variances() -> np.ndarray:
+    """Open-beam variances, again on their own cycle."""
+    return (_ramp() % 7) * 2.0 + 3.0
+
+
+def _stack(counts: np.ndarray, variances: np.ndarray, *, mask=None, mask_dims=None) -> sc.DataArray:
+    """A ``(tof, y, x)`` counts stack with variances and an ``N + 1`` bin-edge ``tof`` axis."""
+    data = sc.DataArray(
+        sc.array(dims=["tof", "y", "x"], values=counts.copy(), variances=variances.copy(), unit="counts"),
+        coords={"tof": sc.array(dims=["tof"], values=_EDGES.copy(), unit="us")},
+    )
+    if mask is not None:
+        data.masks["spike"] = sc.array(dims=mask_dims, values=mask.copy())
+    return data
+
+
+def _spatial_mask() -> np.ndarray:
+    """A ``(y, x)`` exclusion mask with one pixel inside the region and one outside it."""
+    mask = np.zeros((_NY, _NX), dtype=bool)
+    mask[2, 3] = True  # inside the region
+    mask[0, 0] = True  # outside it, so the region bounds still matter
+    return mask
+
+
+def _per_frame_mask() -> np.ndarray:
+    """A ``(tof, y, x)`` exclusion mask that masks a region pixel in some frames and not others.
+
+    Frame 0 and frame 5 each lose one region pixel; frames 1-4 lose none. Under the factor-2 binning
+    that puts an unequal pair in the first and last bins and a clean pair in the middle one, which is
+    what makes the divergence visible in two bins out of three and absent in the third.
+    """
+    mask = np.zeros((_N_TOF, _NY, _NX), dtype=bool)
+    mask[0, 2, 3] = True
+    mask[5, 1, 2] = True
+    return mask
+
+
+def _capture_warnings():
+    """Return ``(messages, remove)`` capturing loguru WARNING+ lines into ``messages``.
+
+    loguru does not route through stdlib logging, so pytest's ``caplog`` is always empty for it and
+    any assertion made against ``caplog.text`` would pass without testing anything.
+    """
+    messages: list[str] = []
+    handler_id = logger.add(lambda m: messages.append(str(m)), level="WARNING")
+    return messages, lambda: logger.remove(handler_id)
+
+
+# --------------------------------------------------------------------------------------------
+# the two orders, and the numpy oracle
+# --------------------------------------------------------------------------------------------
+
+
+def _order_a(sample: sc.DataArray, ob: sc.DataArray, width, reduction) -> sc.DataArray:
+    """Bin both stacks, then collapse each region, then divide once — the settled order."""
+    return normalize_roi_spectrum(
+        rebin_tof(sample, width, reduction=reduction),
+        rebin_tof(ob, width, reduction=reduction),
+        _REGION,
+    )
+
+
+def _order_b(sample: sc.DataArray, ob: sc.DataArray, width, reduction) -> sc.DataArray:
+    """Collapse each region, then bin the two 1-D spectra, then divide once — the other order.
+
+    The division is the same ``normalize_transmission`` call ``normalize_roi_spectrum`` makes
+    internally, so the only difference between this and :func:`_order_a` is where the binning sits.
+    """
+    sample_spectrum = rebin_tof(roi_mean_spectrum(sample, _REGION, strict=False), width, reduction=reduction)
+    ob_spectrum = rebin_tof(roi_mean_spectrum(ob, _REGION, strict=True), width, reduction=reduction)
+    return normalize_transmission(sample=sample_spectrum, ob=ob_spectrum)
+
+
+def _region(values: np.ndarray) -> np.ndarray:
+    """The region's pixels, in numpy order (y before x, exclusive stops)."""
+    return values[:, _Y0:_Y1, _X0:_X1]
+
+
+def _reduce_frames(values: np.ndarray, variances: np.ndarray, ranges, reduction):
+    """Combine the frames of each half-open range with plain numpy, per pixel."""
+    if reduction == "sum":
+        out = np.stack([values[a:b].sum(axis=0) for a, b in ranges])
+        out_var = np.stack([variances[a:b].sum(axis=0) for a, b in ranges])
+    elif reduction == "mean":
+        out = np.stack([values[a:b].mean(axis=0) for a, b in ranges])
+        out_var = np.stack([variances[a:b].sum(axis=0) / (b - a) ** 2 for a, b in ranges])
+    else:  # pragma: no cover - the median oracle is written out explicitly where it is needed
+        raise AssertionError(f"no numpy oracle for reduction {reduction!r}")
+    return out, out_var
+
+
+def _pooled(values: np.ndarray, variances: np.ndarray, selected: np.ndarray):
+    """Pooled region mean and its variance over the selected pixels: sum / n, and sum(Var) / n**2."""
+    n = int(selected.sum())
+    return (values * selected).sum(axis=(-2, -1)) / n, (variances * selected).sum(axis=(-2, -1)) / n**2
+
+
+def _transmission(sample_mean, sample_var, ob_mean, ob_var):
+    """``T = S / O`` with the propagated variance scipp's division produces.
+
+    ``Var(T) = Var(S)/O**2 + S**2 * Var(O)/O**4`` — written out here rather than taken from the
+    library, so a change to the propagation is a test failure and not a silently moved oracle.
+    """
+    return sample_mean / ob_mean, sample_var / ob_mean**2 + sample_mean**2 * ob_var / ob_mean**4
+
+
+def _oracle_order_a(ranges, reduction, selected):
+    """Order A computed entirely in numpy: reduce frames, then pool the region, then divide."""
+    sample_binned, sample_binned_var = _reduce_frames(
+        _region(_sample_counts()), _region(_sample_variances()), ranges, reduction
+    )
+    ob_binned, ob_binned_var = _reduce_frames(_region(_ob_counts()), _region(_ob_variances()), ranges, reduction)
+    sample_mean, sample_var = _pooled(sample_binned, sample_binned_var, selected)
+    ob_mean, ob_var = _pooled(ob_binned, ob_binned_var, selected)
+    return _transmission(sample_mean, sample_var, ob_mean, ob_var)
+
+
+# --------------------------------------------------------------------------------------------
+# 1. sum and mean commute with the region collapse under a purely spatial mask
+# --------------------------------------------------------------------------------------------
+
+
+class TestSumAndMeanCommuteUnderASpatialMask:
+    """Both orders give the same spectrum for ``sum`` and ``mean``, so choosing order A costs nothing.
+
+    That is the whole justification for matching the image mode: if the orders disagreed, the choice
+    would be a numerical decision rather than a consistency one. A purely spatial mask is the
+    condition under which it holds — every bin then divides by the same unmasked pixel count, so the
+    count cancels out of the ratio no matter when the collapse happens.
+    """
+
+    @pytest.mark.parametrize("reduction", ["sum", "mean"])
+    @pytest.mark.parametrize("width,ranges", _BINNINGS, ids=["factor2", "factor3", "explicit_bin_list"])
+    def test_both_orders_agree_and_match_the_numpy_oracle(self, reduction, width, ranges):
+        """Values and variances agree between the orders, and order A matches hand-computed numpy.
+
+        The order-A-versus-numpy leg is what stops the two orders being wrong together: they share
+        every arithmetic primitive, so their agreement alone would survive a broken pooled mean.
+        """
+        mask = _spatial_mask()
+        sample = _stack(_sample_counts(), _sample_variances(), mask=mask, mask_dims=["y", "x"])
+        ob = _stack(_ob_counts(), _ob_variances(), mask=mask, mask_dims=["y", "x"])
+
+        first = _order_a(sample, ob, width, reduction)
+        second = _order_b(sample, ob, width, reduction)
+
+        assert first.sizes == {"tof": len(ranges)}
+        np.testing.assert_allclose(first.values, second.values, rtol=1e-12)
+        np.testing.assert_allclose(first.variances, second.variances, rtol=1e-12)
+
+        expected, expected_var = _oracle_order_a(ranges, reduction, ~mask[_Y0:_Y1, _X0:_X1])
+        np.testing.assert_allclose(first.values, expected, rtol=1e-12)
+        np.testing.assert_allclose(first.variances, expected_var, rtol=1e-12)
+
+    def test_the_pinned_spectrum_is_not_the_unmasked_one(self):
+        """The masked region pixel is genuinely excluded from the pooled sums.
+
+        Without this the commutation tests above would pass on a mask-blind collapse: with a purely
+        spatial mask the unmasked *count* cancels out of the ratio, so only the mask-awareness of the
+        summed counts is observable in the transmission at all.
+        """
+        mask = _spatial_mask()
+        sample = _stack(_sample_counts(), _sample_variances(), mask=mask, mask_dims=["y", "x"])
+        ob = _stack(_ob_counts(), _ob_variances(), mask=mask, mask_dims=["y", "x"])
+        ranges = [(0, 2), (2, 4), (4, 6)]
+
+        result = _order_a(sample, ob, 2, "sum")
+
+        selected = ~mask[_Y0:_Y1, _X0:_X1]
+        masked_aware, _ = _oracle_order_a(ranges, "sum", selected)
+        mask_blind, _ = _oracle_order_a(ranges, "sum", np.ones_like(selected))
+        assert not np.allclose(masked_aware, mask_blind, rtol=1e-6), "the fixture's mask must move the answer"
+        np.testing.assert_allclose(result.values, masked_aware, rtol=1e-12)
+
+
+# --------------------------------------------------------------------------------------------
+# 2. a per-frame mask makes the two orders diverge
+# --------------------------------------------------------------------------------------------
+
+
+class TestPerFrameMaskMakesTheOrdersDiverge:
+    """With a ``(tof, y, x)`` mask the orders are different quantities, and order A is what ships.
+
+    Binning consumes a per-frame mask: ``rebin_tof`` leaves each masked ``(frame, pixel)`` entry out
+    of that pixel's combined value and the output carries no mask at all, so the collapse that follows
+    divides by the **full** region. Order B instead divides each frame by that frame's own unmasked
+    count before combining. The two coincide only when every frame in a bin has the same count.
+
+    The pipelines bin first, so order A's numbers are the ones a user gets. Both are written down.
+    """
+
+    def _inputs(self):
+        mask = _per_frame_mask()
+        return (
+            _stack(_sample_counts(), _sample_variances(), mask=mask, mask_dims=["tof", "y", "x"]),
+            _stack(_ob_counts(), _ob_variances(), mask=mask, mask_dims=["tof", "y", "x"]),
+            mask,
+        )
+
+    @staticmethod
+    def _oracle_bin_first(mask, ranges):
+        """Frames combined mask-aware, then the whole region pooled with no mask left."""
+        keep = ~mask[:, _Y0:_Y1, _X0:_X1]
+        full = np.ones((_Y1 - _Y0, _X1 - _X0), dtype=bool)
+
+        def side(counts, variances):
+            binned = np.stack([(_region(counts) * keep)[a:b].sum(axis=0) for a, b in ranges])
+            binned_var = np.stack([(_region(variances) * keep)[a:b].sum(axis=0) for a, b in ranges])
+            return _pooled(binned, binned_var, full)
+
+        sample_mean, sample_var = side(_sample_counts(), _sample_variances())
+        ob_mean, ob_var = side(_ob_counts(), _ob_variances())
+        return _transmission(sample_mean, sample_var, ob_mean, ob_var)
+
+    @staticmethod
+    def _oracle_collapse_first(mask, ranges):
+        """Each frame pooled over its own unmasked count, then those per-frame means summed."""
+        keep = ~mask[:, _Y0:_Y1, _X0:_X1]
+        per_frame_n = keep.sum(axis=(1, 2))
+
+        def side(counts, variances):
+            mean = (_region(counts) * keep).sum(axis=(1, 2)) / per_frame_n
+            var = (_region(variances) * keep).sum(axis=(1, 2)) / per_frame_n**2
+            return (
+                np.array([mean[a:b].sum() for a, b in ranges]),
+                np.array([var[a:b].sum() for a, b in ranges]),
+            )
+
+        sample_mean, sample_var = side(_sample_counts(), _sample_variances())
+        ob_mean, ob_var = side(_ob_counts(), _ob_variances())
+        return _transmission(sample_mean, sample_var, ob_mean, ob_var)
+
+    def test_the_two_orders_do_not_agree(self):
+        """Both orders are pinned to numpy, and the pair is asserted to be measurably apart."""
+        sample, ob, mask = self._inputs()
+        ranges = [(0, 2), (2, 4), (4, 6)]
+
+        first = _order_a(sample, ob, 2, "sum")
+        second = _order_b(sample, ob, 2, "sum")
+
+        bin_first, bin_first_var = self._oracle_bin_first(mask, ranges)
+        collapse_first, collapse_first_var = self._oracle_collapse_first(mask, ranges)
+
+        np.testing.assert_allclose(first.values, bin_first, rtol=1e-12)
+        np.testing.assert_allclose(first.variances, bin_first_var, rtol=1e-12)
+        np.testing.assert_allclose(second.values, collapse_first, rtol=1e-12)
+        np.testing.assert_allclose(second.variances, collapse_first_var, rtol=1e-12)
+
+        assert not np.allclose(first.values, second.values, rtol=1e-5), (
+            f"a per-frame mask must make the orders diverge; got {first.values} and {second.values}"
+        )
+
+    def test_only_the_bins_holding_an_unequal_pair_diverge(self):
+        """The divergence tracks the per-frame unmasked count, which is the stated mechanism.
+
+        Bins 0 and 2 each pair a frame that lost a region pixel with one that did not; bin 1 pairs
+        two intact frames and therefore agrees. Pinning that pattern is what distinguishes the real
+        cause from an unrelated discrepancy that happens to be the same size.
+        """
+        sample, ob, _ = self._inputs()
+
+        first = _order_a(sample, ob, 2, "sum")
+        second = _order_b(sample, ob, 2, "sum")
+
+        np.testing.assert_allclose(first.values[1], second.values[1], rtol=1e-12)
+        relative = np.abs(first.values - second.values) / first.values
+        assert relative[0] > 1e-4, f"bin 0 should diverge; relative difference {relative[0]:g}"
+        assert relative[2] > 1e-3, f"bin 2 should diverge; relative difference {relative[2]:g}"
+
+
+# --------------------------------------------------------------------------------------------
+# 3. median does not commute, and is pinned to the settled order
+# --------------------------------------------------------------------------------------------
+
+
+class TestMedianIsPinnedToTheSettledOrder:
+    """A median does not commute with a mean, so the order is observable — and it is order A.
+
+    ``median(mean over pixels)`` and ``mean over pixels(median)`` are different statistics for any
+    bin of three or more frames; for two frames the sample median *is* the arithmetic mean, so the
+    divergence only appears once bins are wide enough. Order A — bin the stacks, then collapse — is
+    what the pipelines do, so that is what is pinned, with the other order's numbers recorded to show
+    the size of the choice.
+    """
+
+    #: Two bins of three frames each: wide enough that the median is not the mean.
+    RANGES = [(0, 3), (3, 6)]
+    BIN_LIST = [[0, 3], [3, 6]]
+
+    def _inputs(self):
+        mask = _spatial_mask()
+        return (
+            _stack(_sample_counts(), _sample_variances(), mask=mask, mask_dims=["y", "x"]),
+            _stack(_ob_counts(), _ob_variances(), mask=mask, mask_dims=["y", "x"]),
+            ~mask[_Y0:_Y1, _X0:_X1],
+        )
+
+    def _oracle_bin_first(self, selected):
+        """Per-pixel median over each bin's frames, then the pooled region mean of those medians.
+
+        The median variance is NeuNorm's standard approximation for bins of three or more frames,
+        ``Var(median) = (pi / 2n) * mean(Var)``, written out here rather than read back from the
+        library.
+        """
+
+        def side(counts, variances):
+            region, region_var = _region(counts), _region(variances)
+            median = np.stack([np.median(region[a:b], axis=0) for a, b in self.RANGES])
+            median_var = np.stack([(np.pi / (2 * (b - a))) * region_var[a:b].mean(axis=0) for a, b in self.RANGES])
+            return _pooled(median, median_var, selected)
+
+        sample_mean, sample_var = side(_sample_counts(), _sample_variances())
+        ob_mean, ob_var = side(_ob_counts(), _ob_variances())
+        return _transmission(sample_mean, sample_var, ob_mean, ob_var)
+
+    def _oracle_collapse_first(self, selected):
+        """Pooled region mean per frame, then the median of those per-frame means within each bin."""
+
+        def side(counts, variances):
+            mean, var = _pooled(_region(counts), _region(variances), selected)
+            return (
+                np.array([np.median(mean[a:b]) for a, b in self.RANGES]),
+                np.array([(np.pi / (2 * (b - a))) * var[a:b].mean() for a, b in self.RANGES]),
+            )
+
+        sample_mean, sample_var = side(_sample_counts(), _sample_variances())
+        ob_mean, ob_var = side(_ob_counts(), _ob_variances())
+        return _transmission(sample_mean, sample_var, ob_mean, ob_var)
+
+    def test_median_spectrum_is_the_bin_first_statistic(self):
+        """The shipped result is ``pool(median over frames)``, not ``median(pooled per frame)``."""
+        sample, ob, selected = self._inputs()
+
+        result = _order_a(sample, ob, self.BIN_LIST, "median")
+
+        expected, expected_var = self._oracle_bin_first(selected)
+        np.testing.assert_allclose(result.values, expected, rtol=1e-12)
+        np.testing.assert_allclose(result.variances, expected_var, rtol=1e-12)
+
+    def test_the_other_order_gives_a_measurably_different_spectrum(self):
+        """Both medians are pinned and shown apart, so the settled choice is recorded, not incidental."""
+        sample, ob, selected = self._inputs()
+
+        first = _order_a(sample, ob, self.BIN_LIST, "median")
+        second = _order_b(sample, ob, self.BIN_LIST, "median")
+
+        collapse_first, collapse_first_var = self._oracle_collapse_first(selected)
+        np.testing.assert_allclose(second.values, collapse_first, rtol=1e-12)
+        np.testing.assert_allclose(second.variances, collapse_first_var, rtol=1e-12)
+
+        assert not np.allclose(first.values, second.values, rtol=1e-5), (
+            f"median must not commute with the region mean; got {first.values} and {second.values}"
+        )
+        relative = np.abs(first.values - second.values) / first.values
+        assert np.all(relative > 5e-3), f"the median divergence should be ~1%; got {relative}"
+
+    def test_two_frame_bins_still_commute_because_the_median_is_the_mean_there(self):
+        """The divergence is a property of the statistic, not of the median code path.
+
+        For bins of two frames the sample median equals the arithmetic mean exactly, so the same
+        median reduction commutes. Pinning this keeps the divergence above attributable to the
+        statistic rather than to something incidental in the median branch.
+        """
+        sample, ob, _ = self._inputs()
+
+        first = _order_a(sample, ob, [[0, 2], [2, 4], [4, 6]], "median")
+        second = _order_b(sample, ob, [[0, 2], [2, 4], [4, 6]], "median")
+
+        np.testing.assert_allclose(first.values, second.values, rtol=1e-12)
+        np.testing.assert_allclose(first.variances, second.variances, rtol=1e-12)
+
+
+# --------------------------------------------------------------------------------------------
+# 4. a stack with no timing coordinate
+# --------------------------------------------------------------------------------------------
+
+
+class TestBinningAStackWithNoTimingCoordinate:
+    """Frame-index binning needs an ``N + 1`` edge coordinate; without one the rebinner refuses.
+
+    Verified by running it, not assumed: ``reduce_tof_bins`` rebuilds its output axis from the input
+    edges, so a stack loaded without any timing coordinate (an ``N_image`` axis, as the CCD loaders
+    produce) raises ``ValueError`` naming the missing coordinate. The library does **not** invent an
+    index axis for you. The working route is therefore to attach a synthetic integer edge coordinate
+    of length ``N + 1`` and bin by pure file index, which then behaves exactly like a TOF axis.
+    """
+
+    RANGES = [(0, 2), (2, 4), (4, 6)]
+
+    @staticmethod
+    def _bare(counts, variances, dim):
+        """A stack on ``dim`` carrying no coordinate on that dim at all."""
+        return sc.DataArray(
+            sc.array(dims=[dim, "y", "x"], values=counts.copy(), variances=variances.copy(), unit="counts")
+        )
+
+    @pytest.mark.parametrize("dim", ["N_image", "tof"])
+    def test_reduce_tof_bins_refuses_a_stack_with_no_edge_coordinate(self, dim):
+        """The refusal is a ``ValueError`` that names the coordinate, on both the low-level reducer
+        and the ``rebin_tof`` bin-list entry point."""
+        data = self._bare(_sample_counts(), _sample_variances(), dim)
+
+        with pytest.raises(ValueError, match=f"must carry a '{dim}' coordinate"):
+            reduce_tof_bins(data, self.RANGES, reduction="sum", tof_dim=dim)
+        with pytest.raises(ValueError, match=f"must carry a '{dim}' coordinate"):
+            rebin_tof(data, [[0, 2], [2, 4], [4, 6]], reduction="sum", tof_dim=dim)
+
+    def test_a_synthetic_index_edge_coordinate_bins_by_file_index(self):
+        """With ``0..N`` integer edges attached, the frames bin by file index and the spectrum reduces.
+
+        The rebuilt axis holds the bin boundaries as file indices and ``spectra_tof`` holds each bin's
+        mean member index — 0.5, 2.5, 4.5 for pairs of frames — which is what says on the data itself
+        which files a point came from once the frames are combined.
+        """
+        index_edges = sc.arange("N_image", 0, _N_TOF + 1, unit=None)
+        mask = _spatial_mask()
+        sample = self._bare(_sample_counts(), _sample_variances(), "N_image")
+        ob = self._bare(_ob_counts(), _ob_variances(), "N_image")
+        for side in (sample, ob):
+            side.coords["N_image"] = index_edges
+            side.masks["spike"] = sc.array(dims=["y", "x"], values=mask.copy())
+
+        binned_sample = reduce_tof_bins(sample, self.RANGES, reduction="sum", tof_dim="N_image")
+        binned_ob = reduce_tof_bins(ob, self.RANGES, reduction="sum", tof_dim="N_image")
+        result = normalize_roi_spectrum(binned_sample, binned_ob, _REGION, tof_dim="N_image")
+
+        assert result.dims == ("N_image",)
+        assert result.sizes == {"N_image": 3}
+        np.testing.assert_equal(result.coords["N_image"].values, np.array([0, 2, 4, 6]))
+        np.testing.assert_allclose(result.coords[SPECTRA_TOF_COORD].values, [0.5, 2.5, 4.5], rtol=1e-12)
+
+        expected, expected_var = _oracle_order_a(self.RANGES, "sum", ~mask[_Y0:_Y1, _X0:_X1])
+        np.testing.assert_allclose(result.values, expected, rtol=1e-12)
+        np.testing.assert_allclose(result.variances, expected_var, rtol=1e-12)
+
+
+# --------------------------------------------------------------------------------------------
+# 5. a representative time per bin survives a sum-mode rebin
+# --------------------------------------------------------------------------------------------
+
+
+class TestRepresentativeTimeSurvivesASumModeRebin:
+    """Every bin gets a time inside its own bin, even though a sum-mode rebin cannot supply one.
+
+    :func:`scipp.rebin` sums. An aligned ``spectra_tof`` is dropped by it; an unaligned one is
+    carried through and **summed**, which makes it roughly the rebinning factor too large and puts it
+    outside the bin it labels. The reduction therefore checks containment before trusting the
+    coordinate and falls back to the bin's left edge, so the representative time a downstream time
+    axis is reconstructed from is never a summed one.
+    """
+
+    def _stacks(self, *, bin_times=None, aligned=True):
+        sample = _stack(_sample_counts(), _sample_variances())
+        ob = _stack(_ob_counts(), _ob_variances())
+        if bin_times is not None:
+            for side in (sample, ob):
+                side.coords[SPECTRA_TOF_COORD] = sc.array(dims=["tof"], values=bin_times.copy(), unit="us")
+                side.coords.set_aligned(SPECTRA_TOF_COORD, aligned)
+        return sample, ob
+
+    def test_every_time_lies_inside_its_own_bin_after_a_sum_rebin(self):
+        """A factor-2 sum rebin of an input with no ``spectra_tof`` still yields one per bin.
+
+        Its values are the rebinned bins' left edges, and each is inside ``[left, right)``. That
+        containment is the whole test: a time that labels a bin it does not fall in is not a
+        representative time, and it is what a downstream time axis would be rebuilt from. The
+        three-column ASCII file does not carry the column itself — the coordinate on the returned array
+        is where it lives.
+        """
+        sample, ob = self._stacks()
+
+        result = normalize_roi_spectrum(
+            rebin_tof(sample, 2, reduction="sum"), rebin_tof(ob, 2, reduction="sum"), _REGION
+        )
+
+        assert SPECTRA_TOF_COORD in result.coords
+        times = result.coords[SPECTRA_TOF_COORD]
+        assert times.unit == sc.Unit("us")
+        edges = result.coords["tof"].values
+        np.testing.assert_allclose(edges, _EDGES[::2], rtol=1e-12)
+        np.testing.assert_allclose(times.values, [1000.0, 3000.0, 5000.0], rtol=1e-12)
+        assert np.all(times.values >= edges[:-1]) and np.all(times.values < edges[1:]), (
+            f"every representative time must lie in its own bin; got {times.values} for edges {edges}"
+        )
+
+    def test_a_summed_spectra_tof_is_detected_and_replaced_by_the_bin_left_edge(self):
+        """An unaligned ``spectra_tof`` survives the sum rebin as a SUM of times, and is rejected.
+
+        The rebinned coordinate is first pinned to the numpy sum of each bin's member times, which is
+        the corruption itself: 3000 us for a bin spanning [1000, 3000) us. The reduction then detects
+        that the value is outside its bin, warns, and substitutes the left edge — so the output is the
+        left edges, not the summed times, and the discrepancy is reported rather than silent.
+        """
+        per_frame_times = _EDGES[:_N_TOF]  # each frame's left-edge time, the VENUS spectra convention
+        sample, ob = self._stacks(bin_times=per_frame_times, aligned=False)
+
+        binned_sample = rebin_tof(sample, 2, reduction="sum")
+        binned_ob = rebin_tof(ob, 2, reduction="sum")
+
+        summed = np.array([per_frame_times[a:b].sum() for a, b in [(0, 2), (2, 4), (4, 6)]])
+        np.testing.assert_allclose(binned_sample.coords[SPECTRA_TOF_COORD].values, summed, rtol=1e-12)
+        left, right = _EDGES[::2][:-1], _EDGES[::2][1:]
+        assert np.any(summed >= right), f"the summed times must fall outside their bins; got {summed}"
+
+        messages, remove = _capture_warnings()
+        try:
+            result = normalize_roi_spectrum(binned_sample, binned_ob, _REGION)
+        finally:
+            remove()
+
+        np.testing.assert_allclose(result.coords[SPECTRA_TOF_COORD].values, left, rtol=1e-12)
+        np.testing.assert_allclose(result.coords[SPECTRA_TOF_COORD].values, [1000.0, 3000.0, 5000.0], rtol=1e-12)
+        warned = "\n".join(messages)
+        assert SPECTRA_TOF_COORD in warned, f"the substitution must be logged; captured:\n{warned}"
+        assert "does not lie within its own TOF bins" in warned, f"captured:\n{warned}"
+
+    def test_an_aligned_spectra_tof_is_dropped_by_the_rebin_and_rebuilt_without_a_warning(self):
+        """The other survival mode: dropped rather than corrupted, so no warning is warranted.
+
+        ``scipp.rebin`` carries only unaligned coordinates, so an aligned ``spectra_tof`` simply does
+        not reach the reduction. Rebuilding from the edges is then the ordinary path, and warning
+        about it would train users to ignore the warning that matters.
+        """
+        sample, ob = self._stacks(bin_times=_EDGES[:_N_TOF], aligned=True)
+
+        binned_sample = rebin_tof(sample, 2, reduction="sum")
+        assert SPECTRA_TOF_COORD not in binned_sample.coords
+
+        messages, remove = _capture_warnings()
+        try:
+            result = normalize_roi_spectrum(binned_sample, rebin_tof(ob, 2, reduction="sum"), _REGION)
+        finally:
+            remove()
+
+        np.testing.assert_allclose(result.coords[SPECTRA_TOF_COORD].values, [1000.0, 3000.0, 5000.0], rtol=1e-12)
+        assert not [m for m in messages if SPECTRA_TOF_COORD in m], f"unexpected warning:\n{messages}"

--- a/tests/unit/test_spectrum_mode_pipelines.py
+++ b/tests/unit/test_spectrum_mode_pipelines.py
@@ -1,0 +1,648 @@
+"""End-to-end tests for resonance mode on the three VENUS TOF pipelines.
+
+The unit tests elsewhere pin the reduction and the writer in isolation. This file runs the whole
+pipeline and then **reads the file off disk**, because that is the deliverable a user actually gets and
+because a spectrum can be wrong in ways a DataArray assertion does not see — a plausible-looking number
+in the wrong pixel frame, a bin_index column that has been renumbered, or a TIFF full of 1x1-pixel
+images written where an error was due.
+
+Expected transmissions are literal arithmetic over the synthetic frame values, never a second call into
+the pipeline. The frames are uniform per image, so ``(sample_value / pc_sample) / (ob_value / pc_ob)``
+is exact.
+"""
+
+import re
+
+import h5py
+import numpy as np
+import pytest
+from loguru import logger
+from test_progress_pipelines import (
+    _ccd_tiffs,
+    _spectra_file,
+    _tpx3_event_file,
+    _venus_metadata_nexus,
+)
+
+from neunorm.data_models.tof import BinningConfig
+from neunorm.pipelines.venus_tpx1 import run_venus_tpx1_pipeline
+from neunorm.pipelines.venus_tpx3_event import run_venus_tpx3_event_pipeline
+from neunorm.pipelines.venus_tpx3_histogram import run_venus_tpx3_histogram_pipeline
+from neunorm.utils.progress import STAGE_EXPORT, STAGE_REDUCE_SPECTRUM
+
+_DETECTOR = 32
+_FRAMES = 6
+_SAMPLE_BASE = 81.0
+_OB_BASE = 99.0
+_PC_SAMPLE = 12345.0
+_PC_OB = 24690.0
+_REGION = (10, 10, 26, 26)
+
+#: Frame i holds a uniform ``base + i``. ``combine_runs`` normalizes each run by its proton charge, so
+#: the transmission of frame i is ``((81+i)/12345) / ((99+i)/24690)`` = ``2*(81+i)/(99+i)``.
+_EXPECTED = 2.0 * (_SAMPLE_BASE + np.arange(_FRAMES)) / (_OB_BASE + np.arange(_FRAMES))
+
+#: The ASCII columns are written at six decimal places, so a value read back from the file matches the
+#: array to half of the last digit. This is the settled format's precision, not slack in the writer.
+_ASCII_ATOL = 5e-7
+
+
+def _collect_logs():
+    """Capture loguru records, returning ``(messages, remove)``."""
+    messages: list[str] = []
+    sink_id = logger.add(lambda record: messages.append(record), level="WARNING")
+    return messages, lambda: logger.remove(sink_id)
+
+
+def _events():
+    """Progress events plus the sink to hand a pipeline."""
+    captured = []
+    return captured, captured.append
+
+
+# --------------------------------------------------------------------------------------------
+# inputs
+# --------------------------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tpx1_inputs(tmp_path):
+    """TIFF frames plus the co-located ``*_Spectra.txt`` sidecars and NeXus metadata TPX1 reads."""
+    sample_dir, ob_dir = tmp_path / "sample", tmp_path / "ob"
+    sample_dir.mkdir()
+    ob_dir.mkdir()
+    left_edges = [round(0.1 * (i + 1), 1) for i in range(_FRAMES)]
+    _spectra_file(sample_dir / "sample_Spectra.txt", left_edges)
+    _spectra_file(ob_dir / "ob_Spectra.txt", left_edges)
+    return {
+        "sample_hdf5_paths": [_venus_metadata_nexus(tmp_path / "nx" / "s.h5", _PC_SAMPLE, das_image_path=b"auto")],
+        "ob_hdf5_paths": [_venus_metadata_nexus(tmp_path / "nx" / "o.h5", _PC_OB, das_image_path=b"auto")],
+        "sample_tiff_paths": [_ccd_tiffs(sample_dir, "s", _FRAMES, _SAMPLE_BASE, proton_charge=_PC_SAMPLE)],
+        "ob_tiff_paths": [_ccd_tiffs(ob_dir, "o", _FRAMES, _OB_BASE, proton_charge=_PC_OB)],
+    }
+
+
+@pytest.fixture
+def histogram_inputs(tmp_path):
+    """TIFF frames plus the NeXus TOF binning the histogram pipeline builds its axis from."""
+    return {
+        "sample_hdf5_paths": [_venus_metadata_nexus(tmp_path / "nx" / "hs.h5", _PC_SAMPLE, tof_bins=_FRAMES)],
+        "ob_hdf5_paths": [_venus_metadata_nexus(tmp_path / "nx" / "ho.h5", _PC_OB, tof_bins=_FRAMES)],
+        "sample_tiff_paths": [_ccd_tiffs(tmp_path, "hs", _FRAMES, _SAMPLE_BASE, proton_charge=_PC_SAMPLE)],
+        "ob_tiff_paths": [_ccd_tiffs(tmp_path, "ho", _FRAMES, _OB_BASE, proton_charge=_PC_OB)],
+    }
+
+
+@pytest.fixture
+def event_inputs(tmp_path):
+    """Flood-illuminated event files.
+
+    ``tof_range`` is in NANOSECONDS while ``event_time_offset`` is read as microseconds and scaled up
+    by the loader, so events at 100..125 us need a range of (100000, 125000). A range in microseconds
+    gives an EMPTY histogram and every assertion below would pass vacuously — the counts are checked
+    in :func:`test_event_histogram_is_not_empty` so that cannot happen silently.
+    """
+    return {
+        "binning": BinningConfig(bins=5, bin_space="tof", tof_range=(100000, 125000), use_log_bin=False),
+        "sample_paths": [
+            _tpx3_event_file(
+                tmp_path / "es.h5", 3, bank="bank100_events", offset=1_000_000, proton_charge=_PC_SAMPLE, n_tof=5
+            )
+        ],
+        "ob_paths": [
+            _tpx3_event_file(
+                tmp_path / "eo.h5", 6, bank="bank100_events", offset=1_000_000, proton_charge=_PC_OB, n_tof=5
+            )
+        ],
+        "detector_shape": (_DETECTOR, _DETECTOR),
+    }
+
+
+def _run_tpx1(inputs, output_path, **kwargs):
+    return run_venus_tpx1_pipeline(output_path=output_path, **inputs, **kwargs)
+
+
+def _run_histogram(inputs, output_path, **kwargs):
+    return run_venus_tpx3_histogram_pipeline(output_path=output_path, **inputs, **kwargs)
+
+
+def _run_event(inputs, output_path, **kwargs):
+    return run_venus_tpx3_event_pipeline(output_path=output_path, **inputs, **kwargs)
+
+
+_RUNNERS = {"venus_tpx1": _run_tpx1, "venus_tpx3_histogram": _run_histogram, "venus_tpx3_event": _run_event}
+
+
+@pytest.fixture
+def pipeline(request, tpx1_inputs, histogram_inputs, event_inputs):
+    """A ``(name, callable(output_path, **kwargs))`` pair for the pipeline named by the parametrization."""
+    name = request.param
+    inputs = {"venus_tpx1": tpx1_inputs, "venus_tpx3_histogram": histogram_inputs, "venus_tpx3_event": event_inputs}[
+        name
+    ]
+    runner = _RUNNERS[name]
+    return name, lambda output_path, **kwargs: runner(inputs, output_path, **kwargs)
+
+
+_ALL = pytest.mark.parametrize("pipeline", list(_RUNNERS), indirect=True)
+
+
+# --------------------------------------------------------------------------------------------
+# the setup is not vacuous
+# --------------------------------------------------------------------------------------------
+
+
+def test_event_histogram_is_not_empty(event_inputs, tmp_path):
+    """Guards every event assertion below.
+
+    A ``tof_range`` in the wrong unit yields a histogram with no counts, which makes a transmission of
+    NaN and an assertion on "the file exists" pass while proving nothing. Checked here once, loudly.
+    """
+    spectrum = _run_event(event_inputs, tmp_path / "probe.hdf5", spectrum_roi=_REGION)
+
+    assert np.all(np.isfinite(spectrum.values)), f"empty event histogram: {spectrum.values}"
+    assert np.all(spectrum.values > 0.0)
+
+
+# --------------------------------------------------------------------------------------------
+# 1-2. end to end, on every pipeline
+# --------------------------------------------------------------------------------------------
+
+
+@_ALL
+def test_spectrum_mode_writes_the_three_column_file_and_an_hdf5_sibling(pipeline, tmp_path):
+    """Each pipeline produces the ASCII spectrum plus the HDF5 that carries what three columns cannot.
+
+    Read as text, not as a DataArray: the header line and the row count are the format contract, and
+    the HDF5 sibling is where the time axis and the provenance live.
+    """
+    name, run = pipeline
+    output_path = tmp_path / f"{name}.txt"
+
+    spectrum = run(output_path, spectrum_roi=_REGION)
+
+    assert spectrum.dims == ("tof",), "a spectrum, not an image stack"
+    assert spectrum.unit == "dimensionless"
+    assert spectrum.variances is not None
+
+    lines = output_path.read_text().splitlines()
+    assert lines[0] == "bin_index,transmission,uncertainty"
+    assert len(lines) - 1 == spectrum.sizes["tof"], "one row per bin, plus the single header line"
+
+    # The settled format writes six decimal places, so the file agrees with the array to half of the
+    # last written digit and no closer. A tighter tolerance here would be testing the format's
+    # precision rather than the writer's correctness.
+    table = np.loadtxt(output_path, skiprows=1, delimiter=",")
+    np.testing.assert_allclose(table[:, 1], spectrum.values, atol=_ASCII_ATOL, rtol=0)
+    np.testing.assert_allclose(table[:, 2], np.sqrt(spectrum.variances), atol=_ASCII_ATOL, rtol=0)
+
+    sibling = output_path.with_suffix(".hdf5")
+    assert sibling.exists(), "the ASCII run must write an HDF5 alongside it"
+    with h5py.File(sibling) as f:
+        for dataset in ("transmission", "uncertainty", "tof", "spectra_tof"):
+            assert dataset in f, f"/{dataset} missing"
+        assert f["tof"].shape[0] == spectrum.sizes["tof"] + 1, "N+1 bin edges, so it can be rebinned again"
+        np.testing.assert_array_equal(f["metadata/spectrum_roi"][()], np.array(_REGION))
+
+
+def test_the_transmission_is_the_hand_computed_ratio_of_region_means(tpx1_inputs, tmp_path):
+    """The number, not merely the file.
+
+    Uniform frames make the expectation exact arithmetic: frame i is a flat ``81 + i`` against a flat
+    ``99 + i``, and each run is divided by its own proton charge, so every bin is
+    ``((81+i)/12345) / ((99+i)/24690)``. Any region of a uniform frame has that same mean, so this also
+    confirms the region collapse is a mean and not a sum.
+    """
+    output_path = tmp_path / "pinned.txt"
+
+    spectrum = _run_tpx1(tpx1_inputs, output_path, spectrum_roi=_REGION)
+
+    np.testing.assert_allclose(spectrum.values, _EXPECTED, rtol=1e-9)
+    table = np.loadtxt(output_path, skiprows=1, delimiter=",")
+    np.testing.assert_allclose(table[:, 1], _EXPECTED, rtol=1e-5)
+
+
+# --------------------------------------------------------------------------------------------
+# 3-4. output format selection
+# --------------------------------------------------------------------------------------------
+
+
+@_ALL
+def test_an_hdf5_output_path_writes_only_hdf5(pipeline, tmp_path):
+    """``.hdf5`` asks for HDF5 only; no stray ASCII file appears beside it."""
+    name, run = pipeline
+    output_path = tmp_path / f"{name}.hdf5"
+
+    run(output_path, spectrum_roi=_REGION)
+
+    assert output_path.exists()
+    assert not output_path.with_suffix(".txt").exists()
+    with h5py.File(output_path) as f:
+        assert "transmission" in f
+
+
+@_ALL
+def test_a_tiff_output_path_is_refused_and_writes_nothing(pipeline, tmp_path):
+    """A spectrum must not be written as a TIFF, and the pipeline must say so rather than let it happen.
+
+    This is not a theoretical guard. Handed a 1-D spectrum after the pipelines' usual ``tof`` -> ``t``
+    rename, ``write_tiff_stack`` does NOT fail — it writes a multi-page TIFF of 1x1-pixel images that
+    even reads back cleanly, so nothing downstream would flag it. Hence the check that the directory
+    is still empty.
+    """
+    name, run = pipeline
+    # An OWN directory: the synthetic input TIFFs live in tmp_path, so globbing there would find those
+    # and the check would pass for the wrong reason.
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    output_path = out_dir / f"{name}.tiff"
+
+    with pytest.raises(ValueError, match="cannot be written as a TIFF"):
+        run(output_path, spectrum_roi=_REGION)
+
+    assert not output_path.exists()
+    assert list(out_dir.iterdir()) == [], "no file may be written, not even a partial one"
+
+
+def test_an_unsupported_suffix_is_refused(tpx1_inputs, tmp_path):
+    """An unknown extension is an error, as it is in image mode."""
+    with pytest.raises(ValueError, match="Unsupported output file format"):
+        _run_tpx1(tpx1_inputs, tmp_path / "spectrum.fits", spectrum_roi=_REGION)
+
+
+# --------------------------------------------------------------------------------------------
+# 5. arguments that make no sense for a spectrum
+# --------------------------------------------------------------------------------------------
+
+
+def test_air_roi_cannot_be_combined_with_spectrum_roi(tpx1_inputs, tmp_path):
+    """The air correction rescales an image so its air region reads 1.0, which is meaningless for one
+    value per bin. Refused explicitly rather than applied to a scalar."""
+    with pytest.raises(ValueError, match="air_roi and spectrum_roi cannot be combined"):
+        _run_tpx1(tpx1_inputs, tmp_path / "s.txt", spectrum_roi=_REGION, air_roi=(0, 0, 5, 5))
+
+
+def test_tiff_one_file_per_image_cannot_be_combined_with_spectrum_roi(tpx1_inputs, tmp_path):
+    """A per-image TIFF option cannot apply to output that has no images."""
+    with pytest.raises(ValueError, match="tiff_one_file_per_image"):
+        _run_tpx1(tpx1_inputs, tmp_path / "s.txt", spectrum_roi=_REGION, tiff_one_file_per_image=True)
+
+
+# --------------------------------------------------------------------------------------------
+# 6. frame-index binning through the pipeline
+# --------------------------------------------------------------------------------------------
+
+
+def test_an_integer_rebin_factor_halves_the_rows_and_labels_them_by_first_frame(tpx1_inputs, tmp_path):
+    """``rebin_by_tof=2`` over six frames gives three rows indexed 0, 2, 4 — each bin's FIRST frame.
+
+    Not the row index. The column is documented as "the same as the file index if no binning", and the
+    only reading of that which survives binning is the first input frame of each bin.
+    """
+    output_path = tmp_path / "binned.txt"
+
+    spectrum = _run_tpx1(tpx1_inputs, output_path, spectrum_roi=_REGION, rebin_by_tof=2)
+
+    assert spectrum.sizes["tof"] == 3
+    table = np.loadtxt(output_path, skiprows=1, delimiter=",")
+    np.testing.assert_array_equal(table[:, 0].astype(int), np.array([0, 2, 4]))
+
+    # a sum-mode rebin adds the frames, so each bin's transmission is the ratio of the summed pairs
+    sample_pairs = (_SAMPLE_BASE + np.arange(_FRAMES)).reshape(3, 2).sum(axis=1)
+    ob_pairs = (_OB_BASE + np.arange(_FRAMES)).reshape(3, 2).sum(axis=1)
+    np.testing.assert_allclose(table[:, 1], 2.0 * sample_pairs / ob_pairs, rtol=1e-5)
+
+
+def test_no_binning_makes_the_index_column_the_file_index(tpx1_inputs, tmp_path):
+    """The issue's own words: bin_index is the file index when nothing is binned."""
+    output_path = tmp_path / "unbinned.txt"
+
+    _run_tpx1(tpx1_inputs, output_path, spectrum_roi=_REGION)
+
+    table = np.loadtxt(output_path, skiprows=1, delimiter=",")
+    np.testing.assert_array_equal(table[:, 0].astype(int), np.arange(_FRAMES))
+
+
+def test_a_gapped_bin_list_leaves_the_index_column_gapped_and_omits_the_dropped_span(tpx1_inputs, tmp_path):
+    """``[[0, 2], [4, 6]]`` gives rows indexed 0 and 4, and frames 2-3 get no row at all.
+
+    The file therefore has gaps rather than renumbered rows, which is what keeps a point traceable back
+    to the files it came from. The full mapping is recorded in the HDF5 provenance.
+    """
+    output_path = tmp_path / "gapped.txt"
+
+    spectrum = _run_tpx1(tpx1_inputs, output_path, spectrum_roi=_REGION, rebin_by_tof=[[0, 2], [4, 6]])
+
+    assert spectrum.sizes["tof"] == 2, "one output bin per requested range, none for the dropped span"
+    table = np.loadtxt(output_path, skiprows=1, delimiter=",")
+    indices = table[:, 0].astype(int)
+    np.testing.assert_array_equal(indices, np.array([0, 4]))
+    assert 2 not in indices, "the dropped 2-3 span must not be renumbered into a row"
+
+    with h5py.File(output_path.with_suffix(".hdf5")) as f:
+        np.testing.assert_array_equal(f["metadata/spectrum_bin_first_frame"][()], np.array([0, 4]))
+
+
+# --------------------------------------------------------------------------------------------
+# 7. the coordinate frame the region is resolved in
+# --------------------------------------------------------------------------------------------
+
+
+def test_a_crop_and_a_spatial_rebin_place_the_region_in_the_post_transform_frame(tmp_path):
+    """A crop and a spatial rebin both run before the collapse, so the region selects the pixels the
+    transformed array holds — and the run warns, because the numbers look plausible either way.
+
+    Pinned with a NON-UNIFORM sample: only a known block carries a raised value, so a region resolved
+    in the wrong frame would select different pixels and give a different, still-plausible number. The
+    expectation is computed with plain numpy over the detector pixels the transformed region covers.
+    """
+    sample_dir, ob_dir = tmp_path / "s", tmp_path / "o"
+    sample_dir.mkdir()
+    ob_dir.mkdir()
+    left_edges = [round(0.1 * (i + 1), 1) for i in range(_FRAMES)]
+    _spectra_file(sample_dir / "s_Spectra.txt", left_edges)
+    _spectra_file(ob_dir / "o_Spectra.txt", left_edges)
+
+    # A raised 8x8 block at detector rows/cols 8..15. Everything else is the flat base.
+    raised = np.full((_DETECTOR, _DETECTOR), _SAMPLE_BASE)
+    raised[8:16, 8:16] = _SAMPLE_BASE * 2.0
+    sample_tiffs = _ccd_tiffs_with_pattern(sample_dir, "s", _FRAMES, raised, _PC_SAMPLE)
+    ob_tiffs = _ccd_tiffs(ob_dir, "o", _FRAMES, _OB_BASE, proton_charge=_PC_OB)
+
+    inputs = {
+        "sample_hdf5_paths": [_venus_metadata_nexus(tmp_path / "nx" / "s.h5", _PC_SAMPLE, das_image_path=b"a")],
+        "ob_hdf5_paths": [_venus_metadata_nexus(tmp_path / "nx" / "o.h5", _PC_OB, das_image_path=b"a")],
+        "sample_tiff_paths": [sample_tiffs],
+        "ob_tiff_paths": [ob_tiffs],
+    }
+
+    # crop to detector x,y in [4, 28); then rebin 2x2. The raised block at detector 8..15 lands at
+    # cropped 4..11, and at post-rebin 2..5. A spectrum_roi of (2, 2, 6, 6) therefore covers exactly
+    # the raised block and nothing else.
+    crop = (4, 4, 28, 28)
+    spectrum_roi = (2, 2, 6, 6)
+
+    messages, remove = _collect_logs()
+    try:
+        spectrum = _run_tpx1(inputs, tmp_path / "framed.txt", roi=crop, rebin_by_spatial=2, spectrum_roi=spectrum_roi)
+    finally:
+        remove()
+
+    # Every detector pixel the region covers lies inside the raised block, so the sample region mean is
+    # 2*base, and frame i adds i to every pixel (raised block included). The open beam is the flat base.
+    expected = 2.0 * (2.0 * _SAMPLE_BASE + np.arange(_FRAMES)) / (_OB_BASE + np.arange(_FRAMES))
+    np.testing.assert_allclose(spectrum.values, expected, rtol=1e-9)
+
+    warnings = " ".join(str(m) for m in messages)
+    assert "resolved AFTER the roi=" in warnings, "the crop's effect on the frame must be said out loud"
+    assert "resolved AFTER rebin_by_spatial" in warnings, "the rebin's effect must be said out loud"
+
+
+def _ccd_tiffs_with_pattern(directory, prefix, count, pattern, proton_charge):
+    """TIFF frames carrying an arbitrary per-pixel pattern, plus ``i`` added to frame ``i``."""
+    from PIL import Image
+
+    paths = []
+    for index in range(count):
+        image = Image.fromarray((pattern + index).astype(np.float32))
+        exif = image.getexif()
+        exif[65027] = "ExposureTime:30.000000"
+        exif[65022] = f"RunNo:{1000 + index}"
+        exif[65025] = "ManufacturerStr:DW936_BV"
+        exif[65024] = f"IntegratedPCharge:{proton_charge}"
+        path = directory / f"{prefix}_{index:05}.tiff"
+        image.save(path, exif=exif)
+        paths.append(path)
+    return paths
+
+
+# --------------------------------------------------------------------------------------------
+# 8. progress
+# --------------------------------------------------------------------------------------------
+
+
+@_ALL
+def test_spectrum_mode_reports_the_reduce_and_export_stages_to_completion(pipeline, tmp_path):
+    """The new stage appears, and every stage reaches the total the pipeline declared for it."""
+    name, run = pipeline
+    events, sink = _events()
+
+    run(tmp_path / f"{name}.txt", spectrum_roi=_REGION, progress=sink)
+
+    by_stage: dict[str, list] = {}
+    for event in events:
+        by_stage.setdefault(event.stage, []).append(event)
+
+    assert STAGE_REDUCE_SPECTRUM in by_stage, "the spectrum reduction must be a named stage"
+    assert STAGE_EXPORT in by_stage
+
+    for stage, stage_events in by_stage.items():
+        totals = {e.total for e in stage_events}
+        assert len(totals) == 1, f"{stage} declared more than one total: {totals}"
+        total = totals.pop()
+        if total is None:
+            continue
+        completed = [e.completed for e in stage_events]
+        assert completed == sorted(completed), f"{stage} counted backwards: {completed}"
+        assert max(completed) == total, f"{stage} stopped at {max(completed)} of {total}"
+
+
+def test_the_new_stage_does_not_fire_in_image_mode(tpx1_inputs, tmp_path):
+    """Image mode's reported stages must be exactly what they were, or every existing progress
+    expectation for these pipelines silently changes."""
+    events, sink = _events()
+
+    _run_tpx1(tpx1_inputs, tmp_path / "image.hdf5", progress=sink)
+
+    assert STAGE_REDUCE_SPECTRUM not in {e.stage for e in events}
+
+
+@_ALL
+def test_progress_reporting_does_not_change_the_spectrum(pipeline, tmp_path):
+    """Reporting is observation, so the numbers must be identical with and without it."""
+    name, run = pipeline
+    _events_list, sink = _events()
+
+    without = run(tmp_path / "a.txt", spectrum_roi=_REGION)
+    with_reporting = run(tmp_path / "b.txt", spectrum_roi=_REGION, progress=sink)
+
+    np.testing.assert_array_equal(without.values, with_reporting.values)
+    np.testing.assert_array_equal(without.variances, with_reporting.variances)
+
+
+# --------------------------------------------------------------------------------------------
+# 9. image mode is untouched
+# --------------------------------------------------------------------------------------------
+
+
+@_ALL
+def test_without_spectrum_roi_the_pipeline_still_returns_an_image_stack(pipeline, tmp_path):
+    """The mode is opt-in. Omitting ``spectrum_roi`` must give the image stack it always gave."""
+    name, run = pipeline
+    output_path = tmp_path / f"{name}_image.hdf5"
+
+    transmission = run(output_path, roi=None)
+
+    assert "x" in transmission.dims and "y" in transmission.dims
+    assert len(transmission.dims) == 3
+    with h5py.File(output_path) as f:
+        assert f["transmission"].ndim == 3
+
+
+@_ALL
+def test_the_strict_flag_is_accepted_in_spectrum_mode(pipeline, tmp_path):
+    """``spectrum_roi_strict`` reaches the reduction on every pipeline. The synthetic open beam is
+    positive everywhere, so both settings give the same spectrum here — this pins the wiring, and
+    ``test_spectrum_uncertainty.py`` pins the policy itself."""
+    name, run = pipeline
+
+    strict = run(tmp_path / f"{name}_strict.txt", spectrum_roi=_REGION, spectrum_roi_strict=True)
+    legacy = run(tmp_path / f"{name}_legacy.txt", spectrum_roi=_REGION, spectrum_roi_strict=False)
+
+    np.testing.assert_allclose(strict.values, legacy.values, rtol=1e-12)
+
+
+def test_a_maskroi_selection_works_end_to_end(tpx1_inputs, tmp_path):
+    """An arbitrary-shape region reduces like a rectangle, all the way to the file."""
+    from neunorm.data_models.roi import MaskROI
+
+    selection = np.zeros((_DETECTOR, _DETECTOR), dtype=bool)
+    selection[10:26, 10:26] = True
+    output_path = tmp_path / "mask.txt"
+
+    spectrum = _run_tpx1(tpx1_inputs, output_path, spectrum_roi=MaskROI(selection=selection))
+
+    np.testing.assert_allclose(spectrum.values, _EXPECTED, rtol=1e-9)
+    with h5py.File(output_path.with_suffix(".hdf5")) as f:
+        recorded = f["metadata/spectrum_roi"][()]
+    assert b"mask" in recorded if isinstance(recorded, bytes) else "mask" in str(recorded)
+
+
+def test_the_completion_log_names_both_written_files(tpx1_inputs, tmp_path):
+    """A run that writes two files must report both, or a user looking for the HDF5 will not find it."""
+    messages: list[str] = []
+    sink_id = logger.add(lambda record: messages.append(record.record["message"]), level="SUCCESS")
+    try:
+        _run_tpx1(tpx1_inputs, tmp_path / "both.txt", spectrum_roi=_REGION)
+    finally:
+        logger.remove(sink_id)
+
+    completion = [m for m in messages if "completed successfully" in m]
+    assert completion, f"no completion line among {messages}"
+    assert "both.txt" in completion[-1]
+    assert re.search(r"both\.hdf5", completion[-1]), f"the HDF5 sibling is unreported: {completion[-1]}"
+
+
+# --------------------------------------------------------------------------------------------
+# 10. the HDF5 sibling must never destroy an input
+# --------------------------------------------------------------------------------------------
+
+
+def test_the_hdf5_sibling_refuses_to_overwrite_one_of_the_runs_own_inputs(tmp_path):
+    """A ``.txt`` output also writes ``<stem>.hdf5``, and that must not land on an input file.
+
+    This is the only place in the package that writes a path the user did not name, and ``write_hdf5``
+    opens with mode ``"w"``, which truncates. A VENUS metadata file called ``run_1234.hdf5`` sitting
+    where a user would plausibly ask for ``run_1234.txt`` would therefore be destroyed, so the derived
+    path is checked against the run's own inputs before anything is written.
+    """
+    sample_dir, ob_dir = tmp_path / "s", tmp_path / "o"
+    sample_dir.mkdir()
+    ob_dir.mkdir()
+    left_edges = [round(0.1 * (i + 1), 1) for i in range(_FRAMES)]
+    _spectra_file(sample_dir / "s_Spectra.txt", left_edges)
+    _spectra_file(ob_dir / "o_Spectra.txt", left_edges)
+    # the metadata file is named run_1234.hdf5, in the directory the user will write into
+    meta = _venus_metadata_nexus(tmp_path / "run_1234.hdf5", _PC_SAMPLE, tof_bins=_FRAMES, das_image_path=b"a")
+    ob_meta = _venus_metadata_nexus(tmp_path / "ob_1234.hdf5", _PC_OB, tof_bins=_FRAMES, das_image_path=b"a")
+    inputs = {
+        "sample_hdf5_paths": [meta],
+        "ob_hdf5_paths": [ob_meta],
+        "sample_tiff_paths": [_ccd_tiffs(sample_dir, "s", _FRAMES, _SAMPLE_BASE, proton_charge=_PC_SAMPLE)],
+        "ob_tiff_paths": [_ccd_tiffs(ob_dir, "o", _FRAMES, _OB_BASE, proton_charge=_PC_OB)],
+    }
+    with h5py.File(meta) as f:
+        keys_before = sorted(f.keys())
+
+    with pytest.raises(ValueError, match="would overwrite one of this run's own input files"):
+        _run_tpx1(inputs, tmp_path / "run_1234.txt", spectrum_roi=_REGION)
+
+    with h5py.File(meta) as f:
+        assert sorted(f.keys()) == keys_before, "the input was modified despite the refusal"
+    assert "entry" in keys_before
+
+
+def test_overwriting_a_previous_output_of_our_own_is_still_allowed(tpx1_inputs, tmp_path):
+    """The guard is about inputs, not about re-runs.
+
+    Replacing your own previous output is normal and is what every other writer in the package does, so
+    a second run over the same output path must succeed rather than be caught by the guard above.
+    """
+    output_path = tmp_path / "again.txt"
+
+    first = _run_tpx1(tpx1_inputs, output_path, spectrum_roi=_REGION)
+    second = _run_tpx1(tpx1_inputs, output_path, spectrum_roi=_REGION)
+
+    np.testing.assert_allclose(second.values, first.values, rtol=1e-12)
+    assert output_path.with_suffix(".hdf5").exists()
+
+
+def test_provenance_records_the_factor_that_ran_not_the_request(tpx1_inputs, tmp_path):
+    """``rebin_by_tof=True`` asks the statistics analysis for a factor; the file must record the ANSWER.
+
+    Recording the literal ``True`` would leave a reader unable to say how many frames went into a
+    point. The effective reduction is recorded too, because the default flips with the argument type —
+    a factor sums, a bin list averages — so the file would otherwise be silent about which happened.
+    """
+    output_path = tmp_path / "recommended.txt"
+
+    spectrum = _run_tpx1(tpx1_inputs, output_path, spectrum_roi=_REGION, rebin_by_tof=True)
+
+    with h5py.File(output_path.with_suffix(".hdf5")) as f:
+        recorded = f["metadata/rebin_by_tof"][()]
+        reduction = f["metadata/rebin_reduction"][()]
+        first_frames = f["metadata/spectrum_bin_first_frame"][()]
+    recorded = recorded.decode() if isinstance(recorded, bytes) else str(recorded)
+    reduction = reduction.decode() if isinstance(reduction, bytes) else str(reduction)
+
+    assert recorded != "True", "the request was recorded instead of the factor that ran"
+    assert recorded.isdigit(), f"expected the resolved integer factor, got {recorded!r}"
+    assert reduction == "sum", "an integer factor sums, and the file must say so"
+    # the recorded first-frame indices must be consistent with the recorded factor and the bin count
+    factor = int(recorded)
+    assert len(first_frames) == spectrum.sizes["tof"]
+    np.testing.assert_array_equal(first_frames, np.arange(0, _FRAMES, factor)[: spectrum.sizes["tof"]])
+
+
+def test_a_gapped_bin_list_warns_that_the_axis_is_no_longer_a_spectrum(tpx1_inputs, tmp_path):
+    """Dropping frames leaves an axis the fitting tools must not be pointed at, and that is said aloud.
+
+    The workflow guides and the rebinner already warn that a gapped axis invalidates resonance and
+    Bragg-edge fitting. It matters more in spectrum mode, because a spectrum is exactly what those tools
+    fit — and the file looks entirely well-formed either way. Warned, not refused: dropping frames
+    between bins is deliberate and a user may want it for something other than fitting.
+    """
+    messages, remove = _collect_logs()
+    try:
+        _run_tpx1(tpx1_inputs, tmp_path / "gapped.txt", spectrum_roi=_REGION, rebin_by_tof=[[0, 2], [4, 6]])
+    finally:
+        remove()
+
+    warned = " ".join(str(m) for m in messages)
+    assert "NOT a continuous spectrum" in warned, f"no gap warning among {warned[:400]}"
+    assert "2-3" in warned, "the warning must name the frames that were dropped"
+
+
+def test_a_contiguous_bin_list_does_not_warn(tpx1_inputs, tmp_path):
+    """The warning must not cry wolf: a list that covers every frame is a continuous spectrum.
+
+    Without this, the gap warning above would pass just as well if the code warned unconditionally.
+    """
+    messages, remove = _collect_logs()
+    try:
+        _run_tpx1(tpx1_inputs, tmp_path / "contiguous.txt", spectrum_roi=_REGION, rebin_by_tof=[[0, 3], [3, 6]])
+    finally:
+        remove()
+
+    warned = " ".join(str(m) for m in messages)
+    assert "NOT a continuous spectrum" not in warned, f"warned about a contiguous list: {warned[:300]}"

--- a/tests/unit/test_spectrum_reduction.py
+++ b/tests/unit/test_spectrum_reduction.py
@@ -560,3 +560,36 @@ def test_provenance_records_the_binning_that_produced_the_spectrum():
 
     # rebin_by_tof=False is "no binning", not a binning of False
     assert "rebin_by_tof" not in spectrum_reduction_provenance(as_region_list(_REGION), rebin_by_tof=False)
+
+
+def test_a_disagreeing_non_numeric_axis_gives_the_diagnostic_not_a_numpy_error():
+    """A string coord must not turn this function's own message into an AttributeError.
+
+    The message carries a max deviation as a convenience, and that convenience must never be the thing
+    that raises. An aligned string coord — a ``detector`` label, say — matches on sizes, unit and dtype,
+    so those three checks alone let it reach ``.astype`` and fail while the f-string is being built,
+    replacing the guard's explanation with a numpy error. Reachable through this public function, which
+    the docs show being called on hand-built stacks; the pipelines set metadata coords unaligned, so it
+    does not arise there.
+    """
+    counts = _poisson_counts(12.0, seed=11)
+    sample, ob = _stack(counts), _stack(counts * 2.0)
+    sample.coords["detector"] = sc.scalar("MCP TPX3")  # aligned by default
+    ob.coords["detector"] = sc.scalar("MCP TPX1")
+    assert sample.coords["detector"].aligned, "the case only arises for an ALIGNED coord"
+
+    with pytest.raises(ValueError, match="disagree on the aligned 'detector' axis"):
+        normalize_roi_spectrum(sample, ob, _REGION)
+
+
+def test_a_disagreeing_numeric_axis_still_reports_the_deviation():
+    """Restricting the deviation to numeric dtypes must not drop it from the axes that have one.
+
+    Without this, the numeric guard could silently remove the number from every message and nothing
+    would notice.
+    """
+    counts = _poisson_counts(12.0, seed=12)
+    sample, ob = _stack(counts), _stack(counts, edges=_EDGES + 0.5)
+
+    with pytest.raises(ValueError, match=r"max deviation 0\.5"):
+        normalize_roi_spectrum(sample, ob, _REGION)

--- a/tests/unit/test_spectrum_reduction.py
+++ b/tests/unit/test_spectrum_reduction.py
@@ -1,0 +1,562 @@
+"""Collapse-then-divide invariants of ``normalize_roi_spectrum``.
+
+The reduction behind resonance mode returns one transmission point per spectral bin, and its
+correctness is almost entirely a question of ORDER: each side's region must be collapsed to a
+mask-aware pooled mean *before* the division, because ``(Σ sample) / (Σ ob)`` is not
+``Σ (sample / ob)``. The central test therefore computes both forms with plain numpy and pins the
+reduction to the first while proving it is measurably far from the second.
+
+Every expected number in this file is a literal or is computed with plain numpy from the synthetic
+input. None comes from a second call of the code under test, so a regression cannot move the oracle
+along with the result.
+
+Also pinned here: the ``N + 1`` bin edges that keep the spectrum rebinnable, the per-bin
+representative time, the variance formula on the collapsed means, the proton-charge systematic, the
+diagnosable error raised when the two acquisitions sit on different time axes, the deliberately
+one-sided zero guard (a zero open beam is a fault, a zero sample is a measurement), the open-beam
+denominator bias an asymmetric pixel mask introduces, and that progress reporting moves no numbers.
+"""
+
+import numpy as np
+import pytest
+import scipp as sc
+
+from neunorm.processing.spectrum_reducer import (
+    normalize_roi_spectrum,
+    normalize_roi_spectrum_step_count,
+)
+from neunorm.tof.histogram_rebinner import SPECTRA_TOF_COORD, rebin_tof
+from neunorm.utils.progress import STAGE_REDUCE_SPECTRUM
+
+_N_TOF = 5
+_DETECTOR = 8
+#: ``(x0, y0, x1, y1)`` with exclusive stops: a 4 x 4 = 16-pixel region away from the frame edges.
+_REGION = (2, 1, 6, 5)
+_PIXELS = (_REGION[2] - _REGION[0]) * (_REGION[3] - _REGION[1])
+#: N + 1 TOF bin edges, microseconds.
+_EDGES = np.linspace(1000.0, 6000.0, _N_TOF + 1)
+
+
+# --------------------------------------------------------------------------------------
+# synthetic inputs and the numpy oracle
+# --------------------------------------------------------------------------------------
+
+
+def _stack(counts, *, mask=None, edges=_EDGES, bin_times=None):
+    """A ``(tof, x, y)`` counts stack carrying Poisson variances and an ``N + 1`` bin-edge axis."""
+    counts = np.asarray(counts, dtype=float)
+    data = sc.DataArray(sc.array(dims=["tof", "x", "y"], values=counts.copy(), unit="counts", variances=counts.copy()))
+    data.coords["tof"] = sc.array(dims=["tof"], values=np.asarray(edges, dtype=float), unit="us")
+    if bin_times is not None:
+        data.coords[SPECTRA_TOF_COORD] = sc.array(dims=["tof"], values=np.asarray(bin_times, dtype=float), unit="us")
+    if mask is not None:
+        data.masks["hot_pixels"] = sc.array(dims=["x", "y"], values=np.asarray(mask, dtype=bool))
+    return data
+
+
+def _poisson_counts(rate, seed):
+    """Counting statistics with real spread, so the ratio of means and the mean of ratios differ."""
+    return np.random.default_rng(seed).poisson(rate, size=(_N_TOF, _DETECTOR, _DETECTOR)).astype(float)
+
+
+def _in_region(counts):
+    """The region's pixels, flattened per bin — the oracle's view of the ROI."""
+    x0, y0, x1, y1 = _REGION
+    return np.asarray(counts, dtype=float)[:, x0:x1, y0:y1].reshape(_N_TOF, -1)
+
+
+def _pooled_mean(counts):
+    """``sum(region counts) / pixel count`` per bin, the collapse the reduction must perform."""
+    return _in_region(counts).sum(axis=1) / _PIXELS
+
+
+def _pooled_mean_variance(counts):
+    """Variance of that pooled mean for Poisson counts (``Var = counts``): ``Σ Var / n²``."""
+    return _in_region(counts).sum(axis=1) / _PIXELS**2
+
+
+def _collect():
+    """A progress sink and the list it appends every event to."""
+    events = []
+    return events, events.append
+
+
+# --------------------------------------------------------------------------------------
+# the order of operations — the whole point of the mode
+# --------------------------------------------------------------------------------------
+
+
+def test_spectrum_is_the_ratio_of_means_and_not_the_mean_of_ratios():
+    """One point per bin equals ``mean(sample[roi]) / mean(ob[roi])``, never ``mean(sample/ob)``.
+
+    The two are different quantities, and on these Poisson counts (16 pixels, rates 12 and 20) they
+    disagree bin by bin by between 4.1% and 14.4% — the per-pixel form biased high, as Jensen's
+    inequality requires. A reduction that divided the stacks first and collapsed second would land on
+    the wrong one of those two numbers while still looking like a plausible transmission spectrum,
+    which is why both are computed here and the result is held away from the wrong one.
+    """
+    sample_counts = _poisson_counts(12.0, seed=1)
+    ob_counts = _poisson_counts(20.0, seed=2)
+    in_sample, in_ob = _in_region(sample_counts), _in_region(ob_counts)
+
+    ratio_of_means = in_sample.mean(axis=1) / in_ob.mean(axis=1)
+    mean_of_ratios = (in_sample / in_ob).mean(axis=1)
+    gap = (mean_of_ratios - ratio_of_means) / ratio_of_means
+    # no zero open-beam pixel, so the wrong form is finite and the comparison is meaningful
+    assert in_ob.min() > 0.0
+    assert np.all(gap > 0.0), f"the per-pixel form must sit above the ratio of means; got {gap}"
+    assert gap.min() > 0.04, f"the two forms must differ measurably; got {gap}"
+    assert gap.max() < 0.15, f"gap unexpectedly large, oracle drifted: {gap}"
+
+    spectrum = normalize_roi_spectrum(_stack(sample_counts), _stack(ob_counts), _REGION)
+
+    assert spectrum.dims == ("tof",)
+    assert spectrum.unit == "dimensionless"
+    np.testing.assert_allclose(spectrum.values, ratio_of_means, rtol=1e-12)
+    assert not np.allclose(spectrum.values, mean_of_ratios, rtol=0.02)
+
+
+# --------------------------------------------------------------------------------------
+# what the output carries
+# --------------------------------------------------------------------------------------
+
+
+def test_output_keeps_the_n_plus_one_bin_edges_and_one_time_per_bin():
+    """The spectrum carries bin EDGES, not just a point coord, so it can still be rebinned.
+
+    A 1-D result with only ``N`` point times would be a dead end: ``rebin_tof`` needs the ``N + 1``
+    edge coordinate on the dimension it bins, and so does any later conversion to wavelength or
+    energy. The rebin is exercised rather than asserted about, since only that proves the surviving
+    coordinate is usable and not merely present.
+    """
+    sample_counts = _poisson_counts(12.0, seed=1)
+    ob_counts = _poisson_counts(20.0, seed=2)
+    ratio_of_means = _in_region(sample_counts).mean(axis=1) / _in_region(ob_counts).mean(axis=1)
+
+    spectrum = normalize_roi_spectrum(_stack(sample_counts), _stack(ob_counts), _REGION)
+
+    assert spectrum.sizes == {"tof": _N_TOF}
+    assert spectrum.coords["tof"].sizes["tof"] == _N_TOF + 1
+    np.testing.assert_allclose(spectrum.coords["tof"].values, _EDGES, rtol=1e-12)
+
+    times = spectrum.coords[SPECTRA_TOF_COORD]
+    assert times.sizes["tof"] == _N_TOF
+    np.testing.assert_allclose(times.values, _EDGES[:-1], rtol=1e-12)
+
+    # the edges are load-bearing: summing all five bins into one must still work on the output
+    rebinned = rebin_tof(spectrum, width=_N_TOF)
+    assert rebinned.sizes == {"tof": 1}
+    np.testing.assert_allclose(rebinned.values, [ratio_of_means.sum()], rtol=1e-12)
+
+
+def test_an_existing_per_bin_mean_time_is_kept_rather_than_replaced_by_the_left_edge():
+    """A ``spectra_tof`` that lies inside its own bins is the better time and survives the reduction.
+
+    The left edge is only the fallback. When the inputs carry the per-bin mean of their member
+    frames' times — what a mean-mode frame rebin attaches — that is the column the ASCII consumers
+    want, and overwriting it with the left edge would silently coarsen the time axis.
+    """
+    midpoints = 0.5 * (_EDGES[:-1] + _EDGES[1:])
+    sample = _stack(_poisson_counts(12.0, seed=1), bin_times=midpoints)
+    ob = _stack(_poisson_counts(20.0, seed=2), bin_times=midpoints)
+
+    spectrum = normalize_roi_spectrum(sample, ob, _REGION)
+
+    np.testing.assert_allclose(spectrum.coords[SPECTRA_TOF_COORD].values, midpoints, rtol=1e-12)
+
+
+# --------------------------------------------------------------------------------------
+# uncertainty
+# --------------------------------------------------------------------------------------
+
+
+def test_variance_is_propagated_from_the_collapsed_means():
+    """``Var(T) = Var(S)/O² + S²·Var(O)/O⁴`` evaluated on the POOLED MEANS, not on pixels.
+
+    The uncertainty column of the ASCII file is the square root of this. Propagating from per-pixel
+    variances and then averaging would overstate it by roughly the pixel count, so the variance has
+    to travel through the same collapse-then-divide path the values do.
+    """
+    sample_counts = _poisson_counts(12.0, seed=1)
+    ob_counts = _poisson_counts(20.0, seed=2)
+    s, o = _pooled_mean(sample_counts), _pooled_mean(ob_counts)
+    var_s, var_o = _pooled_mean_variance(sample_counts), _pooled_mean_variance(ob_counts)
+    expected = var_s / o**2 + s**2 * var_o / o**4
+
+    spectrum = normalize_roi_spectrum(_stack(sample_counts), _stack(ob_counts), _REGION)
+
+    assert spectrum.variances is not None
+    np.testing.assert_allclose(spectrum.variances, expected, rtol=1e-12)
+
+
+def test_proton_charge_rescales_the_spectrum_and_adds_its_systematic():
+    """A spectrum carries the same flux correction and the same 0.5% systematic as an image.
+
+    Values follow ``(S/pc_s) / (O/pc_o)``, so an unequal charge pair rescales the whole spectrum by
+    ``pc_ob / pc_sample``; the relative charge uncertainty then enters each side's variance before
+    the division and can only make the result less certain. Both are pinned against the hand
+    computation, and the ``pc_uncertainty=0`` run is the control that shows the systematic is
+    actually applied rather than merely accepted as an argument.
+    """
+    sample_counts = _poisson_counts(12.0, seed=1)
+    ob_counts = _poisson_counts(20.0, seed=2)
+    pc_sample, pc_ob, pc_rel = 400.0, 500.0, 0.005
+
+    s = _pooled_mean(sample_counts) / pc_sample
+    o = _pooled_mean(ob_counts) / pc_ob
+    var_s = _pooled_mean_variance(sample_counts) / pc_sample**2
+    var_o = _pooled_mean_variance(ob_counts) / pc_ob**2
+    expected_values = s / o
+    expected_var_plain = var_s / o**2 + s**2 * var_o / o**4
+    var_s_sys = var_s + (pc_rel * s) ** 2
+    var_o_sys = var_o + (pc_rel * o) ** 2
+    expected_var_sys = var_s_sys / o**2 + s**2 * var_o_sys / o**4
+
+    corrected = normalize_roi_spectrum(
+        _stack(sample_counts),
+        _stack(ob_counts),
+        _REGION,
+        proton_charge_sample=pc_sample,
+        proton_charge_ob=pc_ob,
+    )
+    without_systematic = normalize_roi_spectrum(
+        _stack(sample_counts),
+        _stack(ob_counts),
+        _REGION,
+        proton_charge_sample=pc_sample,
+        proton_charge_ob=pc_ob,
+        pc_uncertainty=0.0,
+    )
+
+    assert corrected.unit == "dimensionless"
+    np.testing.assert_allclose(corrected.values, expected_values, rtol=1e-12)
+    np.testing.assert_allclose(corrected.variances, expected_var_sys, rtol=1e-12)
+    np.testing.assert_allclose(without_systematic.values, expected_values, rtol=1e-12)
+    np.testing.assert_allclose(without_systematic.variances, expected_var_plain, rtol=1e-12)
+    # the correction is a rescaling by the charge ratio, and the systematic strictly widens sigma
+    uncorrected = _pooled_mean(sample_counts) / _pooled_mean(ob_counts)
+    np.testing.assert_allclose(corrected.values, uncorrected * (pc_ob / pc_sample), rtol=1e-12)
+    assert np.all(np.sqrt(corrected.variances) > np.sqrt(without_systematic.variances))
+
+
+# --------------------------------------------------------------------------------------
+# the two axes must be the same axis
+# --------------------------------------------------------------------------------------
+
+
+def test_disagreeing_time_axes_raise_a_diagnosable_error_rather_than_a_scipp_mismatch():
+    """Two acquisitions on different time axes are refused with an error that names the cause.
+
+    TPX1 reads a separate ``*_Spectra.txt`` beside each directory, so a stale sidecar is the ordinary
+    way this happens — and scipp's own refusal (``Mismatch in coordinate 'tof' in operation
+    'divide'``) is accurate but tells the user nothing about which two files to look at. What is
+    pinned is that the raised error is a ``ValueError`` naming the coordinate, both labels and the
+    size of the disagreement, and that scipp's wording is NOT what reaches the user.
+    """
+    sample = _stack(_poisson_counts(12.0, seed=1))
+    ob = _stack(_poisson_counts(20.0, seed=2), edges=_EDGES + 3.0)
+
+    # what the user would see without the guard: a scipp error, and not even a ValueError
+    with pytest.raises(sc.DatasetError, match="Mismatch in coordinate"):
+        _ = sample / ob
+    assert not issubclass(sc.DatasetError, ValueError)
+
+    with pytest.raises(ValueError) as raised:
+        normalize_roi_spectrum(
+            sample,
+            ob,
+            _REGION,
+            sample_label="run_1/img_00000_Spectra.txt",
+            ob_label="ob_run/img_00000_Spectra.txt",
+        )
+
+    message = str(raised.value)
+    assert "'tof'" in message, message
+    assert "run_1/img_00000_Spectra.txt" in message, message
+    assert "ob_run/img_00000_Spectra.txt" in message, message
+    assert "max deviation 3" in message, message
+    assert "Mismatch in coordinate" not in message, message
+
+
+def test_matching_edges_but_disagreeing_per_bin_times_are_still_refused():
+    """The guard covers every aligned coordinate, not just the binning axis.
+
+    ``spectra_tof`` is written aligned, so a sample and an open beam whose bin EDGES agree while
+    their per-bin mean times do not are still two different acquisitions — the case a stale TPX1
+    sidecar actually produces. scipp would refuse the division on that coordinate instead, with the
+    same unusable wording, so the same diagnosable error has to cover it.
+    """
+    midpoints = 0.5 * (_EDGES[:-1] + _EDGES[1:])
+    sample = _stack(_poisson_counts(12.0, seed=1), bin_times=midpoints)
+    ob = _stack(_poisson_counts(20.0, seed=2), bin_times=midpoints + 7.0)
+
+    with pytest.raises(ValueError) as raised:
+        normalize_roi_spectrum(sample, ob, _REGION, sample_label="sample_dir", ob_label="ob_dir")
+
+    message = str(raised.value)
+    assert f"'{SPECTRA_TOF_COORD}'" in message, message
+    assert "sample_dir" in message and "ob_dir" in message, message
+    assert "max deviation 7" in message, message
+    assert "Mismatch in coordinate" not in message, message
+
+
+# --------------------------------------------------------------------------------------
+# the zero guard, and why it is one-sided
+# --------------------------------------------------------------------------------------
+
+
+def test_zero_open_beam_bin_raises_under_strict_and_propagates_inf_without():
+    """A bin with no open beam is a fault in the DENOMINATOR: strict refuses, legacy propagates.
+
+    An open-beam region mean of zero cannot produce a transmission, only ``inf``/``nan``. The default
+    stops there and names the argument; ``spectrum_roi_strict=False`` reproduces 1.x, which emitted
+    the non-finite value, and is kept for downstreams reproducing legacy output. Either way the other
+    bins are untouched.
+    """
+    sample_counts = _poisson_counts(12.0, seed=1)
+    ob_counts = _poisson_counts(20.0, seed=2)
+    x0, y0, x1, y1 = _REGION
+    dead_bin = 2
+    ob_counts[dead_bin, x0:x1, y0:y1] = 0.0
+    with np.errstate(divide="ignore"):  # the oracle's own dead bin is 1/0 by construction
+        expected = _pooled_mean(sample_counts) / _pooled_mean(ob_counts)
+
+    with pytest.raises(ValueError) as raised:
+        normalize_roi_spectrum(_stack(sample_counts), _stack(ob_counts), _REGION)
+    assert "spectrum_roi" in str(raised.value), str(raised.value)
+    assert "strictly positive" in str(raised.value), str(raised.value)
+
+    legacy = normalize_roi_spectrum(_stack(sample_counts), _stack(ob_counts), _REGION, spectrum_roi_strict=False)
+    assert np.isinf(legacy.values[dead_bin])
+    assert not np.isfinite(legacy.variances[dead_bin])
+    surviving = [i for i in range(_N_TOF) if i != dead_bin]
+    np.testing.assert_allclose(legacy.values[surviving], expected[surviving], rtol=1e-12)
+
+
+def test_a_fully_absorbing_sample_bin_is_zero_transmission_even_under_strict():
+    """Zero counts in the NUMERATOR are a measurement, not a fault — a black resonance reads 0.
+
+    This asymmetry is deliberate: ``spectrum_roi_strict`` guards the open beam alone. Raising on a
+    zero sample region would reject exactly the feature the mode exists to measure, so the strict
+    default must still return 0.0 for that bin and finite values everywhere else.
+    """
+    sample_counts = _poisson_counts(12.0, seed=1)
+    ob_counts = _poisson_counts(20.0, seed=2)
+    x0, y0, x1, y1 = _REGION
+    black_bin = 3
+    sample_counts[black_bin, x0:x1, y0:y1] = 0.0
+    expected = _pooled_mean(sample_counts) / _pooled_mean(ob_counts)
+
+    spectrum = normalize_roi_spectrum(_stack(sample_counts), _stack(ob_counts), _REGION)
+
+    np.testing.assert_allclose(spectrum.values[black_bin], 0.0, atol=0.0)
+    np.testing.assert_allclose(spectrum.values, expected, rtol=1e-12)
+    assert np.all(np.isfinite(spectrum.values))
+
+
+# --------------------------------------------------------------------------------------
+# masks: a region mean divides by its own pixel count
+# --------------------------------------------------------------------------------------
+
+
+def test_mask_symmetrization_removes_the_open_beam_denominator_bias():
+    """A pixel masked on the sample only must be excluded from the open beam's mean as well.
+
+    The pipelines attach the dead/hot masks to the sample and leave the open beam unmasked. Under a
+    per-pixel division that is harmless, but a region MEAN divides by its own count of unmasked
+    pixels, so the two sides would average over different pixel sets and the open beam's mean would
+    keep a pixel known to be untrustworthy.
+
+    Constructed to be non-vacuous: the masked pixel is three times as bright as the rest of the
+    region in the open beam, so excluding it moves the denominator from 22.5 to 20.0 — a 12.5% bias
+    that a uniform flux would have hidden entirely, both branches then agreeing.
+    """
+    levels = np.array([10.0, 12.0, 8.0, 9.0, 11.0])
+    sample_counts = np.broadcast_to(levels[:, None, None], (_N_TOF, _DETECTOR, _DETECTOR)).copy()
+    ob_counts = np.full((_N_TOF, _DETECTOR, _DETECTOR), 20.0)
+    hot = np.zeros((_DETECTOR, _DETECTOR), dtype=bool)
+    hot[3, 2] = True  # inside _REGION
+    sample_counts[:, 3, 2] = levels * 3.0
+    ob_counts[:, 3, 2] = 60.0
+
+    kept = ~_in_region(np.broadcast_to(hot, (_N_TOF, _DETECTOR, _DETECTOR)))[0].astype(bool)
+    assert kept.sum() == _PIXELS - 1
+    sample_mean = _in_region(sample_counts)[:, kept].mean(axis=1)
+    ob_mean_kept = _in_region(ob_counts)[:, kept].mean(axis=1)
+    ob_mean_all = _in_region(ob_counts).mean(axis=1)
+    # not vacuous: the two denominators genuinely differ
+    assert np.all(np.abs(ob_mean_all - ob_mean_kept) / ob_mean_kept > 0.1)
+    unbiased = sample_mean / ob_mean_kept
+    biased = sample_mean / ob_mean_all
+
+    sample, ob = _stack(sample_counts, mask=hot), _stack(ob_counts)
+    symmetrized = normalize_roi_spectrum(sample, ob, _REGION)
+    asymmetric = normalize_roi_spectrum(
+        _stack(sample_counts, mask=hot), _stack(ob_counts), _REGION, symmetrize_masks=False
+    )
+
+    np.testing.assert_allclose(symmetrized.values, unbiased, rtol=1e-12)
+    np.testing.assert_allclose(asymmetric.values, biased, rtol=1e-12)
+    assert np.all(asymmetric.values < symmetrized.values)
+    # the union of the masks is applied to copies: the caller's open beam does not acquire a mask
+    assert list(ob.masks) == []
+    assert list(sample.masks) == ["hot_pixels"]
+
+
+# --------------------------------------------------------------------------------------
+# progress reporting
+# --------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("proton_charge", "declared"),
+    [(None, 3), (400.0, 5)],
+    ids=["no_proton_charge", "with_proton_charge"],
+)
+def test_step_count_predicts_the_events_actually_emitted(proton_charge, declared):
+    """The declared total matches what is emitted on BOTH argument branches.
+
+    A caller sizing a bar with ``normalize_roi_spectrum_step_count`` must get a bar that finishes:
+    the two region collapses plus whatever the division reports, which is one step without a proton
+    charge and three with it (each side's charge correction counts). Every event carries that same
+    total, and the count only moves forwards, so a borrowed reporter cannot restart it mid-reduction.
+    """
+    assert normalize_roi_spectrum_step_count(proton_charge) == declared
+
+    events, sink = _collect()
+    charges = {} if proton_charge is None else {"proton_charge_sample": proton_charge, "proton_charge_ob": 500.0}
+    normalize_roi_spectrum(
+        _stack(_poisson_counts(12.0, seed=1)),
+        _stack(_poisson_counts(20.0, seed=2)),
+        _REGION,
+        progress=sink,
+        **charges,
+    )
+
+    assert events, "a callable sink must receive events"
+    completed = [event.completed for event in events]
+    assert max(completed) == declared, completed
+    assert completed == sorted(completed), completed
+    assert {event.total for event in events} == {declared}
+    assert {event.stage for event in events} == {STAGE_REDUCE_SPECTRUM}
+
+
+def test_progress_reporting_does_not_change_the_numbers():
+    """Reporting is observation only: the spectrum is the same with and without a sink.
+
+    Worth pinning because the reduction hands its reporter down to the normalization rather than
+    opening a second count, so the progress argument reaches the arithmetic path itself.
+    """
+    sample_counts = _poisson_counts(12.0, seed=1)
+    ob_counts = _poisson_counts(20.0, seed=2)
+    hot = np.zeros((_DETECTOR, _DETECTOR), dtype=bool)
+    hot[3, 2] = True  # exercises the mask-symmetrization note as well
+
+    silent = normalize_roi_spectrum(_stack(sample_counts, mask=hot), _stack(ob_counts), _REGION)
+    events, sink = _collect()
+    reported = normalize_roi_spectrum(_stack(sample_counts, mask=hot), _stack(ob_counts), _REGION, progress=sink)
+
+    assert events
+    assert reported.dims == silent.dims
+    np.testing.assert_allclose(reported.values, silent.values, rtol=1e-12)
+    np.testing.assert_allclose(reported.variances, silent.variances, rtol=1e-12)
+    np.testing.assert_allclose(reported.coords["tof"].values, silent.coords["tof"].values, rtol=1e-12)
+    np.testing.assert_allclose(
+        reported.coords[SPECTRA_TOF_COORD].values, silent.coords[SPECTRA_TOF_COORD].values, rtol=1e-12
+    )
+
+
+# --------------------------------------------------------------------------------------
+# mask symmetrization: the branches the pipelines do not reach, but a direct caller can
+# --------------------------------------------------------------------------------------
+
+
+def test_masks_already_identical_on_both_sides_are_left_alone():
+    """Symmetrization is a no-op when both sides already carry the same mask under the same name.
+
+    The union of a mask with itself is that mask, so the numbers must match a run where only one side
+    carried it — pinned against the hand-computed mean over the surviving pixels either way, so this
+    cannot pass by both paths being equally wrong.
+    """
+    sample_counts = _poisson_counts(12.0, seed=5)
+    ob_counts = _poisson_counts(20.0, seed=6)
+    dead = np.zeros((_DETECTOR, _DETECTOR), dtype=bool)
+    dead[2, 3] = True
+
+    both = normalize_roi_spectrum(_stack(sample_counts, mask=dead), _stack(ob_counts, mask=dead), _REGION)
+    one_side = normalize_roi_spectrum(_stack(sample_counts, mask=dead), _stack(ob_counts), _REGION)
+
+    # the stack is (tof, x, y) and the mask is (x, y), so the region slice is [:, x0:x1, y0:y1] —
+    # matching _in_region, which is reused here rather than re-derived
+    x0, y0, x1, y1 = _REGION
+    keep = ~dead[x0:x1, y0:y1].reshape(-1)
+    n_keep = int(keep.sum())
+    assert n_keep == _PIXELS - 1, "the dead pixel must fall inside the region, or this pins nothing"
+    expected = (_in_region(sample_counts)[:, keep].sum(axis=1) / n_keep) / (
+        _in_region(ob_counts)[:, keep].sum(axis=1) / n_keep
+    )
+
+    np.testing.assert_allclose(both.values, expected, rtol=1e-12)
+    np.testing.assert_allclose(one_side.values, expected, rtol=1e-12)
+
+
+def test_differently_shaped_stacks_are_refused_rather_than_collapsed_into_a_plausible_spectrum():
+    """A shape mismatch the image mode catches for free must not slip through the region collapse.
+
+    Dividing two differently-sized stacks per pixel raises a scipp ``DimensionError``. A region collapse
+    removes the spatial dims BEFORE the division, so as long as the region fits in both, two different
+    detectors would divide happily into a spectrum that looks entirely reasonable — the worst kind of
+    wrong. Coordinate equality does not cover it, because a hand-built stack carries no x/y coords.
+    """
+    counts = _poisson_counts(12.0, seed=7)
+    taller = np.repeat(counts, 2, axis=2)[:, :, : _DETECTOR + 2]
+
+    with pytest.raises(ValueError, match="different shapes"):
+        normalize_roi_spectrum(_stack(counts), _stack(taller), _REGION)
+
+    # and the message names the inputs when they were labelled
+    with pytest.raises(ValueError, match="sampleA"):
+        normalize_roi_spectrum(_stack(counts), _stack(taller), _REGION, sample_label="sampleA", ob_label="obB")
+
+
+def test_a_mask_whose_dims_the_other_side_lacks_is_refused():
+    """Symmetrizing needs both sides on the same dims, and says so rather than raising from scipp.
+
+    Reached through :func:`~neunorm.tof.resonance.detect_resonances`, which symmetrizes without the
+    shape check above — so this guard is what stands between a caller and a ``DimensionError`` three
+    frames down. Exercised on the helper directly, because ``normalize_roi_spectrum`` now rejects the
+    shape mismatch first and would never get here.
+    """
+    from neunorm.processing.spectrum_reducer import _symmetrize_masks
+
+    counts = _poisson_counts(12.0, seed=7)
+    sample = _stack(counts)
+    sample.masks["per_frame"] = sc.array(
+        dims=["tof", "x", "y"], values=np.zeros((_N_TOF, _DETECTOR, _DETECTOR), dtype=bool)
+    )
+    flat = sc.DataArray(sc.array(dims=["x", "y"], values=counts[0].copy(), variances=counts[0].copy(), unit="counts"))
+
+    with pytest.raises(ValueError, match="cannot symmetrize mask 'per_frame'"):
+        _symmetrize_masks(sample, flat)
+
+
+def test_provenance_records_the_binning_that_produced_the_spectrum():
+    """The record has to name the reduction and the bin spec, or a gapped spectrum cannot be traced.
+
+    Values are pinned as literals; ``spectrum_reduction_provenance`` is JSON-writer-safe, so the bin
+    spec is stringified rather than left as a nested list the TIFF metadata writer would reject.
+    """
+    from neunorm.data_models.roi import as_region_list
+    from neunorm.processing.spectrum_reducer import spectrum_reduction_provenance
+
+    plain = spectrum_reduction_provenance(as_region_list(_REGION))
+    assert plain == {"spectrum_roi": list(_REGION)}
+    assert "rebin_by_tof" not in plain, "no binning was requested, so none is recorded"
+
+    binned = spectrum_reduction_provenance(as_region_list(_REGION), reduction="median", rebin_by_tof=[[0, 2], [4, 6]])
+    assert binned["spectrum_roi"] == list(_REGION)
+    assert binned["rebin_by_tof"] == "[[0, 2], [4, 6]]"
+    assert binned["rebin_reduction"] == "median"
+
+    # rebin_by_tof=False is "no binning", not a binning of False
+    assert "rebin_by_tof" not in spectrum_reduction_provenance(as_region_list(_REGION), rebin_by_tof=False)

--- a/tests/unit/test_spectrum_uncertainty.py
+++ b/tests/unit/test_spectrum_uncertainty.py
@@ -1,0 +1,447 @@
+"""Uncertainty correctness for the ROI transmission spectrum (the "resonance mode" reduction).
+
+Three things are pinned here. Two are confirmations; the first is a **finding**, and it is written
+down as behaviour rather than repaired, because repairing it means changing the propagation and that
+is the maintainer's call.
+
+**1. The shared-dark covariance is NOT removed from a spectrum's variance.** When the same averaged
+dark frame is subtracted from both stacks before the region is collapsed, the sample and open-beam
+region means share it, so they are positively correlated::
+
+    Cov(Sbar, Obar) = Var(Dbar over the region) = sum(Var(D) over the region) / n**2
+
+and the honest variance of their ratio is
+
+    Var(T) / T**2 = Var(Sbar)/Sbar**2 + Var(Obar)/Obar**2 - 2 Cov / (Sbar Obar)
+
+``normalize_roi_spectrum`` divides through :func:`neunorm.processing.normalizer.normalize_transmission`,
+which has no dark-covariance term, so what it emits is the first two terms alone — the **independent**
+form. The spectrum therefore OVERSTATES its uncertainty. The tests below pin the size of that
+overstatement (about 11% of the variance, 6% of the 1-sigma bar, for a warm dark) instead of asserting
+a correctness that is not there, and one of them shows the pixel-level path
+(:func:`neunorm.processing.normalizer.normalize_with_dark`) already removing exactly the term the
+spectrum path keeps. If the correction is ever added here, these tests fail on purpose: the expected
+value moves from the independent form to the covariance-corrected one, both of which each test
+computes with plain numpy.
+
+**2. The zero-open-beam policy**, on both settings. ``spectrum_roi_strict=True`` refuses a bin whose
+open-beam region mean is not strictly positive and finite; ``spectrum_roi_strict=False`` lets it
+propagate, which is the legacy 1.x behaviour. The numerator is deliberately unguarded on either
+setting, because a fully absorbing bin is a measurement and not a fault.
+
+**3. The exported uncertainty column is 1 sigma** of the returned spectrum, and the variance scales
+with counting statistics as Poisson statistics require.
+"""
+
+import numpy as np
+import pytest
+import scipp as sc
+
+from neunorm.exporters.ascii_writer import ASCII_SPECTRUM_HEADER, write_ascii_spectrum
+from neunorm.processing.dark_corrector import subtract_dark
+from neunorm.processing.normalizer import normalize_with_dark
+from neunorm.processing.spectrum_reducer import normalize_roi_spectrum
+
+#: x 1:5, y 1:4 with exclusive stops — a 4 x 3 = 12 pixel region, offset from the frame edge so a
+#: reduction that quietly used the whole frame would be caught by the values, not just the shapes.
+_ROI = (1, 1, 5, 4)
+_ROI_PIXELS = 12
+
+
+def _poisson(values, dims, unit="counts"):
+    """A counts DataArray whose variance equals its value — the Poisson case the pipelines produce."""
+    values = np.asarray(values, dtype=float)
+    return sc.DataArray(sc.array(dims=list(dims), values=values.copy(), variances=values.copy(), unit=unit))
+
+
+def _stack(values, *, mask=None):
+    """A ``(tof, y, x)`` Poisson stack carrying N+1 tof bin edges, optionally a spatial mask."""
+    data = _poisson(values, ["tof", "y", "x"])
+    n_bins = np.shape(values)[0]
+    data.coords["tof"] = sc.array(dims=["tof"], values=np.arange(n_bins + 1, dtype=float) * 1.0e-3, unit="s")
+    if mask is not None:
+        data.masks["dead_pixels"] = sc.array(dims=["y", "x"], values=np.asarray(mask, dtype=bool))
+    return data
+
+
+def _dark_corrected(s_raw, o_raw, d_raw, *, sample_mask=None):
+    """The two dark-subtracted stacks a pipeline would hand the reduction, plus the dark itself."""
+    dark = _poisson(d_raw, ["y", "x"])
+    sample = subtract_dark(_stack(s_raw, mask=sample_mask), dark)
+    ob = subtract_dark(_stack(o_raw), dark)
+    return sample, ob, dark
+
+
+def _analytic(s_raw, o_raw, d_raw, *, keep=None):
+    """Both variance forms for the ratio of two dark-correlated region means, by plain numpy.
+
+    Returns ``(T, var_independent, var_covariance_corrected, cov_fraction_of_var)`` over ``_ROI``,
+    where ``keep`` is the boolean ``(y, x)`` selection of region pixels that survive masking.
+    ``var_independent`` is what treating the two means as uncorrelated gives; the corrected form
+    subtracts ``2 Cov / (Sbar Obar)`` from the relative variance.
+    """
+    x0, y0, x1, y1 = _ROI
+    s_box = np.asarray(s_raw, dtype=float)[:, y0:y1, x0:x1]
+    o_box = np.asarray(o_raw, dtype=float)[:, y0:y1, x0:x1]
+    d_box = np.broadcast_to(np.asarray(d_raw, dtype=float)[y0:y1, x0:x1], s_box.shape)
+    # subtract_dark clips negatives to zero; an oracle built on the unclipped difference is only the
+    # same arithmetic while the dark is strictly smaller than both stacks.
+    assert np.all(s_box > d_box) and np.all(o_box > d_box)
+    if keep is None:
+        keep = np.ones(s_box.shape[1:], dtype=bool)
+    n = int(np.count_nonzero(keep))
+    sbar = (s_box - d_box)[:, keep].sum(axis=1) / n
+    obar = (o_box - d_box)[:, keep].sum(axis=1) / n
+    # Var(S - D) = Var(S) + Var(D) per pixel, and Var(mean) = sum(Var) / n**2.
+    var_sbar = (s_box + d_box)[:, keep].sum(axis=1) / n**2
+    var_obar = (o_box + d_box)[:, keep].sum(axis=1) / n**2
+    cov = d_box[:, keep].sum(axis=1) / n**2
+    transmission = sbar / obar
+    rel_independent = var_sbar / sbar**2 + var_obar / obar**2
+    cov_term = 2.0 * cov / (sbar * obar)
+    return (
+        transmission,
+        transmission**2 * rel_independent,
+        transmission**2 * (rel_independent - cov_term),
+        cov_term / rel_independent,
+    )
+
+
+class TestSharedDarkCovariance:
+    """What the spectrum's variance is when sample and open beam share a dark frame."""
+
+    def test_variance_is_the_independent_form_not_the_covariance_corrected_one(self):
+        """The emitted variance matches the UNCORRELATED analytic form, to the last bit.
+
+        Both references are computed from the raw counts with numpy. The code lands exactly on the
+        independent one, which is the finding: the shared dark makes Sbar and Obar correlated, and
+        that correlation is not subtracted, so the reported variance is too large. Should the
+        correction ever be added, this test fails and the expected value is the second reference the
+        assertions below already carry.
+        """
+        n_bins, ny, nx = 3, 6, 6
+        s_raw = np.full((n_bins, ny, nx), 500.0)
+        o_raw = np.full((n_bins, ny, nx), 1000.0)
+        d_raw = np.full((ny, nx), 100.0)
+        sample, ob, _ = _dark_corrected(s_raw, o_raw, d_raw)
+
+        spectrum = normalize_roi_spectrum(sample, ob, _ROI)
+
+        t, var_independent, var_corrected, _ = _analytic(s_raw, o_raw, d_raw)
+        # Uniform counts, so the whole reference is hand-checkable: Sbar = 400, Obar = 900,
+        # Var(Sbar) = (500 + 100)/12 = 50, Var(Obar) = (1000 + 100)/12 = 1100/12, Cov = 100/12.
+        np.testing.assert_allclose(t, 400.0 / 900.0, rtol=1e-14)
+        np.testing.assert_allclose(var_independent, 8.408271096885638e-05, rtol=1e-12)
+        np.testing.assert_allclose(var_corrected, 7.493776355230402e-05, rtol=1e-12)
+
+        np.testing.assert_allclose(spectrum.values, t, rtol=1e-13)
+        np.testing.assert_allclose(spectrum.variances, var_independent, rtol=1e-13)
+        # The gap is real, not a rounding difference: the two references differ by far more than the
+        # tolerance the assertion above allows.
+        assert np.all(var_corrected < var_independent * 0.95)
+
+    def test_covariance_term_is_over_ten_percent_of_the_variance_for_a_warm_dark(self):
+        """The uncorrected covariance is not a rounding-level omission — it is worth about 6% of sigma.
+
+        500-count sample, 1000-count open beam, a 100-count dark (a long CCD exposure, or a warm
+        detector) over a 12-pixel region. Quantified so the finding is actionable rather than
+        theoretical: the reported variance is ~10.9% high and the reported 1-sigma bar ~5.9% high, in
+        the same direction for every bin, which is a systematic overstatement of the error bars a
+        resonance fit is weighted by.
+        """
+        n_bins, ny, nx = 2, 6, 6
+        s_raw = np.full((n_bins, ny, nx), 500.0)
+        o_raw = np.full((n_bins, ny, nx), 1000.0)
+        d_raw = np.full((ny, nx), 100.0)
+        sample, ob, _ = _dark_corrected(s_raw, o_raw, d_raw)
+
+        spectrum = normalize_roi_spectrum(sample, ob, _ROI)
+
+        _, var_independent, var_corrected, cov_fraction = _analytic(s_raw, o_raw, d_raw)
+        np.testing.assert_allclose(spectrum.variances, var_independent, rtol=1e-13)
+
+        variance_overstatement = 100.0 * (spectrum.variances / var_corrected - 1.0)
+        sigma_overstatement = 100.0 * (np.sqrt(spectrum.variances / var_corrected) - 1.0)
+        np.testing.assert_allclose(100.0 * cov_fraction, 10.876132930513595, rtol=1e-10)
+        np.testing.assert_allclose(variance_overstatement, 12.203389830508481, rtol=1e-8)
+        np.testing.assert_allclose(sigma_overstatement, 5.926101519176319, rtol=1e-8)
+        # Guard the claim in this file's header rather than only the exact numbers above: a dark this
+        # warm costs more than 5% of the variance whatever the surrounding values are.
+        assert np.all(cov_fraction > 0.05)
+
+    def test_one_pixel_region_overstates_by_exactly_normalize_with_dark_s_correction(self):
+        """Over a 1x1 region the two code paths are directly comparable, and they disagree.
+
+        A one-pixel region mean IS the pixel, so ``normalize_roi_spectrum`` on dark-subtracted stacks
+        and ``normalize_with_dark`` on the raw ones compute the same transmission from the same
+        numbers. Their variances differ by exactly ``2 * (sample - dark) * Var(dark) / (ob - dark)**3``
+        — the shared-dark term ``normalize_with_dark`` documents and removes. That identity is what
+        makes this a gap in the spectrum path specifically, and not a disagreement about the physics:
+        the correction is already implemented one module away.
+        """
+        n_bins = 2
+        s_raw = np.full((n_bins, 1, 1), 500.0)
+        o_raw = np.full((n_bins, 1, 1), 1000.0)
+        d_raw = np.full((1, 1), 100.0)
+        dark = _poisson(d_raw, ["y", "x"])
+
+        pixel = normalize_with_dark(_stack(s_raw), _stack(o_raw), dark)
+        spectrum = normalize_roi_spectrum(
+            subtract_dark(_stack(s_raw), dark), subtract_dark(_stack(o_raw), dark), (0, 0, 1, 1)
+        )
+
+        s, o, var_d = 500.0 - 100.0, 1000.0 - 100.0, 100.0
+        correction = 2.0 * s * var_d / o**3
+        np.testing.assert_allclose(correction, 1.0973936899862826e-04, rtol=1e-12)
+
+        np.testing.assert_allclose(spectrum.values, pixel.values.ravel(), rtol=1e-13)
+        np.testing.assert_allclose(spectrum.variances - pixel.variances.ravel(), correction, rtol=1e-9)
+        # And the pixel path's own variance is the covariance-corrected form, so the direction is not
+        # ambiguous: the spectrum is the one that is too large.
+        assert np.all(pixel.variances.ravel() < spectrum.variances)
+
+    def test_masked_nonuniform_region_still_lands_on_the_independent_form(self):
+        """The overstatement is not an artefact of uniform counts or of an unmasked region.
+
+        Varied counts, a varied dark, and two dead pixels masked on the sample only. Mask
+        symmetrization gives both sides the same exclusions, so the analytic reference divides both
+        means by the same 10 surviving pixels; without symmetrization the open beam would average over
+        12 and the values below would not match either.
+        """
+        n_bins, ny, nx = 3, 5, 5
+        rng = np.random.default_rng(11)
+        s_raw = rng.integers(300, 600, size=(n_bins, ny, nx)).astype(float)
+        o_raw = rng.integers(900, 1200, size=(n_bins, ny, nx)).astype(float)
+        d_raw = rng.integers(60, 140, size=(ny, nx)).astype(float)
+        dead = np.zeros((ny, nx), dtype=bool)
+        dead[1, 2] = True  # inside _ROI
+        dead[3, 3] = True  # inside _ROI
+        sample, ob, _ = _dark_corrected(s_raw, o_raw, d_raw, sample_mask=dead)
+
+        spectrum = normalize_roi_spectrum(sample, ob, _ROI)
+
+        x0, y0, x1, y1 = _ROI
+        keep = ~dead[y0:y1, x0:x1]
+        assert int(np.count_nonzero(keep)) == _ROI_PIXELS - 2
+        t, var_independent, var_corrected, cov_fraction = _analytic(s_raw, o_raw, d_raw, keep=keep)
+
+        np.testing.assert_allclose(spectrum.values, t, rtol=1e-13)
+        np.testing.assert_allclose(spectrum.variances, var_independent, rtol=1e-13)
+        assert np.all(cov_fraction > 0.05)
+        assert np.all(var_corrected < var_independent)
+
+
+class TestZeroOpenBeamPolicy:
+    """A bin whose open-beam region mean is zero, on the strict and the legacy setting."""
+
+    @staticmethod
+    def _pair_with_a_dead_bin(n_bins=3, ny=6, nx=6, sample_counts=400.0):
+        """Poisson stacks whose open beam recorded nothing at all in bin 1."""
+        s_raw = np.full((n_bins, ny, nx), sample_counts)
+        o_raw = np.full((n_bins, ny, nx), 800.0)
+        o_raw[1] = 0.0
+        return _stack(s_raw), _stack(o_raw)
+
+    def test_strict_raises_and_the_message_names_the_open_beam_and_the_argument(self):
+        """Strict is the default, and its message has to say which side and which argument failed.
+
+        The denominator's region mean is guarded because a zero there is a fault, not a measurement.
+        The text names the offending side as ``ob`` and the argument as ``spectrum_roi``, so a user who
+        passed several regions knows what to look at; the min it reports is the offending value.
+        """
+        sample, ob = self._pair_with_a_dead_bin()
+
+        with pytest.raises(ValueError, match=r"spectrum_roi ob pooled mean must be strictly positive and finite"):
+            normalize_roi_spectrum(sample, ob, _ROI)
+
+        with pytest.raises(ValueError) as excinfo:
+            normalize_roi_spectrum(sample, ob, _ROI, spectrum_roi_strict=True)
+        message = str(excinfo.value)
+        assert "ob" in message
+        assert "spectrum_roi" in message
+        assert "min=0.0" in message
+
+    def test_legacy_propagates_an_infinite_value_and_a_nan_variance(self):
+        """``spectrum_roi_strict=False`` reproduces 1.x: the bad bin passes through, unflagged.
+
+        The surviving bins are unaffected and keep their hand-computed values, so opting out is not
+        a global loss of precision — it is one poisoned point in an otherwise usable spectrum. The
+        variance of that point comes out **NaN**, not inf: Var(Sbar)/0 is inf while
+        Sbar**2 * 0 / 0 is NaN, and inf + NaN is NaN. So the legacy setting emits a point whose value
+        says "infinite transmission" and whose error bar says nothing at all.
+        """
+        sample, ob = self._pair_with_a_dead_bin()
+
+        spectrum = normalize_roi_spectrum(sample, ob, _ROI, spectrum_roi_strict=False)
+
+        assert np.isinf(spectrum.values[1])
+        assert np.isnan(spectrum.variances[1])
+        # good bins: T = 400/800, Var(T)/T**2 = (400/12)/400**2 + (800/12)/800**2
+        rel_var = (400.0 / 12.0) / 400.0**2 + (800.0 / 12.0) / 800.0**2
+        good = np.array([0, 2])
+        np.testing.assert_allclose(spectrum.values[good], 0.5, rtol=1e-14)
+        np.testing.assert_allclose(spectrum.variances[good], 0.25 * rel_var, rtol=1e-13)
+
+    def test_legacy_zero_on_both_sides_gives_a_nan_value(self):
+        """Zero over zero is NaN rather than inf — the two failure modes are distinguishable.
+
+        Worth pinning separately because a downstream reader that filters on ``isinf`` alone would
+        keep this point.
+        """
+        sample, ob = self._pair_with_a_dead_bin()
+        sample.values[1] = 0.0
+        sample.variances[1] = 0.0
+
+        spectrum = normalize_roi_spectrum(sample, ob, _ROI, spectrum_roi_strict=False)
+
+        assert np.isnan(spectrum.values[1])
+        assert np.isnan(spectrum.variances[1])
+
+    def test_a_zero_sample_region_mean_is_a_measurement_even_under_strict(self):
+        """The numerator is never guarded: a fully absorbing bin must give T = 0, not an exception.
+
+        The sample is dark-subtracted down to zero counts over the region (a black resonance), while
+        the open beam is healthy. Strict still returns, the transmission is exactly 0, and the
+        uncertainty is the one the dark left behind: Var(T) = Var(Sbar) / Obar**2 with
+        Var(Sbar) = sum(Var(D) over the region) / n**2, since the clipped zero still carries the dark's
+        variance. A guard applied to both sides would turn this measurement into a crash.
+        """
+        n_bins, ny, nx = 2, 6, 6
+        d_raw = np.full((ny, nx), 25.0)
+        sample, ob, _ = _dark_corrected(np.zeros((n_bins, ny, nx)) + 25.0, np.full((n_bins, ny, nx), 1000.0), d_raw)
+
+        spectrum = normalize_roi_spectrum(sample, ob, _ROI, spectrum_roi_strict=True)
+
+        obar = 1000.0 - 25.0
+        var_sbar = 2.0 * 25.0 * _ROI_PIXELS / _ROI_PIXELS**2  # Var(S) + Var(D) = 25 + 25 per pixel
+        np.testing.assert_allclose(spectrum.values, 0.0, atol=0.0)
+        np.testing.assert_allclose(spectrum.variances, var_sbar / obar**2, rtol=1e-13)
+
+    def test_a_partly_dead_open_beam_region_does_not_raise_and_unmasked_zeros_still_count(self):
+        """Zero pixels are data; only masked pixels leave the denominator.
+
+        Two open-beam pixels inside the region read zero and are NOT masked, and one further pixel is
+        masked on the sample. The guard looks at the region MEAN, which is still positive, so strict
+        passes. The pooled mean is ``sum / count(unmasked)``: the masked pixel leaves both the sum and
+        the count, the two dead-but-unmasked pixels leave only the sum. Dropping the zeros from the
+        count instead would read 800 where the truth is 693.33 and bias every transmission low.
+        """
+        n_bins, ny, nx = 3, 4, 4
+        s_raw = np.full((n_bins, ny, nx), 400.0)
+        o_raw = np.full((n_bins, ny, nx), 800.0)
+        o_raw[:, 0, 0] = 0.0
+        o_raw[:, 1, 2] = 0.0
+        dead = np.zeros((ny, nx), dtype=bool)
+        dead[3, 3] = True
+        roi = (0, 0, 4, 4)
+
+        spectrum = normalize_roi_spectrum(_stack(s_raw, mask=dead), _stack(o_raw), roi, spectrum_roi_strict=True)
+
+        n = ny * nx - 1  # 15 unmasked pixels, 13 of them with counts
+        obar = 13 * 800.0 / n
+        sbar = 400.0
+        np.testing.assert_allclose(obar, 693.3333333333334, rtol=1e-13)
+        np.testing.assert_allclose(spectrum.values, sbar / obar, rtol=1e-13)
+        var_sbar = n * 400.0 / n**2
+        var_obar = 13 * 800.0 / n**2
+        rel_var = var_sbar / sbar**2 + var_obar / obar**2
+        np.testing.assert_allclose(spectrum.variances, (sbar / obar) ** 2 * rel_var, rtol=1e-13)
+
+
+class TestExportedUncertaintyColumn:
+    """What the third ASCII column contains, given the spectrum it was written from."""
+
+    @staticmethod
+    def _spectrum():
+        """A healthy four-bin dark-corrected spectrum, uncertainty around 1e-2."""
+        n_bins, ny, nx = 4, 6, 6
+        rng = np.random.default_rng(3)
+        s_raw = rng.integers(300, 600, size=(n_bins, ny, nx)).astype(float)
+        o_raw = rng.integers(900, 1200, size=(n_bins, ny, nx)).astype(float)
+        d_raw = rng.integers(60, 140, size=(ny, nx)).astype(float)
+        sample, ob, _ = _dark_corrected(s_raw, o_raw, d_raw)
+        return normalize_roi_spectrum(sample, ob, _ROI)
+
+    def test_third_column_is_one_sigma_of_the_returned_spectrum(self, tmp_path):
+        """The file carries sqrt(variance), not the variance — a squared column would read as tiny.
+
+        Compared against ``np.sqrt(spectrum.variances)`` computed here, at the six decimals the writer
+        formats, so both the sqrt and the column order are pinned. The header is the one plain line
+        the ecosystem's readers expect, which is what lets ``skiprows=1`` find the first data row.
+        """
+        spectrum = self._spectrum()
+        path = tmp_path / "spectrum.txt"
+
+        write_ascii_spectrum(path, spectrum)
+
+        lines = path.read_text().splitlines()
+        assert lines[0] == ASCII_SPECTRUM_HEADER == "bin_index,transmission,uncertainty"
+        table = np.loadtxt(path, skiprows=1, delimiter=",", ndmin=2)
+        assert table.shape == (spectrum.sizes["tof"], 3)
+        np.testing.assert_array_equal(table[:, 0].astype(int), np.arange(spectrum.sizes["tof"]))
+        # %.6f rounds to the nearest 1e-6, so the residual is bounded absolutely, not relatively.
+        np.testing.assert_allclose(table[:, 1], spectrum.values, atol=5.1e-7, rtol=0.0)
+        one_sigma = np.sqrt(spectrum.variances)
+        np.testing.assert_allclose(table[:, 2], one_sigma, atol=5.1e-7, rtol=0.0)
+        # A sanity floor: sigma here is ~1e-2, so writing the variance instead would be ~1e-4 and the
+        # comparison above would fail by two orders of magnitude rather than by rounding.
+        assert np.all(one_sigma > 1e-3)
+
+    def test_a_legacy_nonfinite_variance_reaches_the_file_as_a_literal_nan(self, tmp_path):
+        """``spectrum_roi_strict=False`` writes ``nan`` into the uncertainty column, unflagged.
+
+        The consequence of the legacy policy at the point where it becomes someone else's problem: the
+        writer neither rejects nor annotates the point, and the row parses back as NaN. Pinned so the
+        cost of opting out is visible in the artefact and not only in the array.
+        """
+        n_bins, ny, nx = 3, 6, 6
+        s_raw = np.full((n_bins, ny, nx), 400.0)
+        o_raw = np.full((n_bins, ny, nx), 800.0)
+        o_raw[1] = 0.0
+        spectrum = normalize_roi_spectrum(_stack(s_raw), _stack(o_raw), _ROI, spectrum_roi_strict=False)
+        path = tmp_path / "legacy.txt"
+
+        write_ascii_spectrum(path, spectrum)
+
+        rows = path.read_text().splitlines()[1:]
+        assert rows[1] == "1,inf,nan"
+        table = np.loadtxt(path, skiprows=1, delimiter=",", ndmin=2)
+        assert np.isinf(table[1, 1])
+        assert np.isnan(table[1, 2])
+
+
+class TestCountingStatisticsScaling:
+    """The variance has to behave like counting statistics, not merely be present."""
+
+    def test_quadrupling_the_counts_on_both_sides_halves_the_relative_uncertainty(self):
+        """Four times the counts, half the relative error bar — the sqrt(N) law, end to end.
+
+        For Poisson pixels ``Var(Sbar) = Sbar / n``, so the relative variance of the ratio is
+        ``(1/Sbar + 1/Obar) / n`` and scaling both sides by 4 divides it by 4 exactly. Run without a
+        proton charge, so the 0.5% systematic floor is absent and the scaling is exact rather than
+        approximate; with proton charge the floor would dominate at high counts, which is a different
+        invariant.
+        """
+        n_bins, ny, nx = 2, 6, 6
+        base_sample, base_ob = 400.0, 800.0
+        one_x = normalize_roi_spectrum(
+            _stack(np.full((n_bins, ny, nx), base_sample)),
+            _stack(np.full((n_bins, ny, nx), base_ob)),
+            _ROI,
+        )
+        four_x = normalize_roi_spectrum(
+            _stack(np.full((n_bins, ny, nx), 4.0 * base_sample)),
+            _stack(np.full((n_bins, ny, nx), 4.0 * base_ob)),
+            _ROI,
+        )
+
+        expected_rel_var = (1.0 / base_sample + 1.0 / base_ob) / _ROI_PIXELS
+        rel_one_x = np.sqrt(one_x.variances) / one_x.values
+        rel_four_x = np.sqrt(four_x.variances) / four_x.values
+
+        # the transmission itself is unchanged by the scaling
+        np.testing.assert_allclose(one_x.values, base_sample / base_ob, rtol=1e-14)
+        np.testing.assert_allclose(four_x.values, base_sample / base_ob, rtol=1e-14)
+        np.testing.assert_allclose(rel_one_x, np.sqrt(expected_rel_var), rtol=1e-13)
+        np.testing.assert_allclose(rel_one_x, np.sqrt(0.00031250), rtol=1e-9)
+        np.testing.assert_allclose(rel_four_x, rel_one_x / 2.0, rtol=1e-12)

--- a/tests/unit/test_spine_profiles.py
+++ b/tests/unit/test_spine_profiles.py
@@ -1,0 +1,436 @@
+"""The per-pipeline differences the shared VENUS TOF spine had to preserve.
+
+``venus_tpx1``, ``venus_tpx3_histogram`` and ``venus_tpx3_event`` now run the same middle
+(``_tof_spine.reduce_tof_stacks``) and differ only through a ``TofPipelineProfile``. A byte-comparison
+harness pins most of that by diffing written HDF5 against the pre-refactor code, but two profile fields
+never reach an HDF5 file: ``tiff_detector_model`` lands only in the scitiff DAQ metadata, and
+``hdf5_hot_pixel_mask`` is unobservable on the one pipeline that leaves it unset. Those two, the mask
+layout each pipeline writes, and the profile table itself are what this file covers.
+
+Every value pinned here is PRESERVED PRE-EXISTING behaviour of the three pipelines, not a choice the
+refactor made, so the tests are change detectors on purpose. Two of the values look like oversights and
+are kept deliberately: ``venus_tpx3_histogram`` re-detects its masks from the SAMPLE after a spatial
+rebin where its own pre-rebin detection and both sibling pipelines read the open beam, and
+``venus_tpx1`` hands the HDF5 writer no ``hot_pixel_mask`` name. Editing an expected value here changes
+what NeuNorm publishes to users.
+
+One further difference is pinned in passing because the written masks expose it: the two TIFF pipelines
+carry spatial dims ``(y, x)`` (the order ``load_tiff_stack`` produces), while the event pipeline
+histograms into ``(tof, x, y)``, so its ``/masks/*`` datasets land TRANSPOSED relative to the other two.
+That one is not in the profile — it comes from the loaders — and it is equally pre-existing.
+"""
+
+import dataclasses
+import re
+
+import h5py
+import numpy as np
+import pytest
+from PIL import Image
+from scitiff.io import load_scitiff
+from test_progress_pipelines import _spectra_file, _venus_metadata_nexus
+
+from neunorm.data_models.tof import BinningConfig
+from neunorm.pipelines.venus_tpx1 import _TPX1_PROFILE, run_venus_tpx1_pipeline
+from neunorm.pipelines.venus_tpx3_event import _TPX3_EVENT_PROFILE, run_venus_tpx3_event_pipeline
+from neunorm.pipelines.venus_tpx3_histogram import _TPX3_HISTOGRAM_PROFILE, run_venus_tpx3_histogram_pipeline
+
+# --------------------------------------------------------------------------------------
+# synthetic detector: small, even-sided so rebin_by_spatial=2 divides it
+# --------------------------------------------------------------------------------------
+
+_SIZE = 8
+_FRAMES = 4
+_SAMPLE_COUNTS = 60.0
+_OB_COUNTS = 100.0
+_HOT_COUNTS = 5000.0
+_SAMPLE_CHARGE = 12345
+_OB_CHARGE = 24690
+
+#: One dead and one hot pixel in the OPEN BEAM, which is the stack all three pipelines detect their
+#: pre-rebin masks from. Both off-diagonal, so a transposed written mask cannot pass.
+_DEAD_PIXEL = (1, 5)
+_HOT_PIXEL = (6, 2)
+
+#: Dead 2x2 blocks, placed so a spatial rebin by 2 collapses each to exactly one superpixel, at
+#: different and non-symmetric positions in the sample and the open beam.
+_SAMPLE_DEAD_BLOCK = (slice(0, 2), slice(2, 4))  # -> superpixel (y=0, x=1)
+_OB_DEAD_BLOCK = (slice(4, 6), slice(0, 2))  # -> superpixel (y=2, x=0)
+
+#: The detector name in the synthetic NeXus metadata (``BL10:Exp:Det``), which two of the three
+#: pipelines write as the TIFF detector model while the event pipeline overrides it.
+_METADATA_DETECTOR = "MCP TPX3"
+
+_PIPELINES = {
+    "venus_tpx1": run_venus_tpx1_pipeline,
+    "venus_tpx3_histogram": run_venus_tpx3_histogram_pipeline,
+    "venus_tpx3_event": run_venus_tpx3_event_pipeline,
+}
+
+#: The event pipeline's spatial dims are (x, y), the TIFF pipelines' are (y, x); expectations below
+#: are written in the (y, x) detector frame and transposed for the event pipeline.
+_XY_AXES = {"venus_tpx1": False, "venus_tpx3_histogram": False, "venus_tpx3_event": True}
+
+
+# --------------------------------------------------------------------------------------
+# synthetic inputs
+# --------------------------------------------------------------------------------------
+
+
+def _frame(counts, *, dead=(), hot=(), dead_block=None):
+    """One detector frame of uniform counts, with the named pixels zeroed or spiked."""
+    frame = np.full((_SIZE, _SIZE), counts, dtype=np.float32)
+    for y, x in dead:
+        frame[y, x] = 0.0
+    for y, x in hot:
+        frame[y, x] = _HOT_COUNTS
+    if dead_block is not None:
+        frame[dead_block] = 0.0
+    return frame
+
+
+def _tiff_stack(directory, prefix, frame):
+    """``_FRAMES`` identical TIFFs of ``frame`` — the pre-binned stack both TIFF pipelines read."""
+    directory.mkdir(parents=True, exist_ok=True)
+    paths = []
+    for index in range(_FRAMES):
+        path = directory / f"{prefix}_{index:03}.tiff"
+        Image.fromarray(frame).save(path)
+        paths.append(path)
+    return paths
+
+
+def _event_file(path, frame, proton_charge):
+    """A TPX3 NeXus event file whose per-pixel event count, in every TOF frame, is ``frame[y, x]``.
+
+    Same structure as the event fixtures elsewhere in the suite, but with a per-pixel count instead of
+    a flat flood, so dead and hot pixels can be planted.
+    """
+    event_ids, tofs = [], []
+    for y in range(_SIZE):
+        for x in range(_SIZE):
+            repeats = int(frame[y, x])
+            if repeats == 0:  # a dead pixel emits nothing
+                continue
+            for tof_frame in range(_FRAMES):
+                event_ids.extend([y * _SIZE + x + 1_000_000] * repeats)
+                tofs.extend([100 + tof_frame * 5] * repeats)  # microseconds
+    with h5py.File(path, "w") as f:
+        entry = f.create_group("entry")
+        entry.create_dataset("proton_charge", data=[proton_charge])
+        entry.create_dataset("duration", data=[60.0])
+        bank = entry.create_group("bank100_events")
+        bank.create_dataset("event_time_offset", data=tofs)
+        bank.create_dataset("event_id", data=event_ids, dtype=np.int32)
+        daslogs = entry.create_group("DASlogs")
+        daslogs.create_group("BL10:Det:TH:DSPT1:TIDelay").create_dataset("average_value", data=[5000])
+        daslogs.create_group("BL10:Exp:Det").create_dataset("value_strings", data=[[_METADATA_DETECTOR.encode()]])
+    return path
+
+
+def _event_kwargs(sample_frame, ob_frame, directory):
+    directory.mkdir(parents=True, exist_ok=True)
+    return {
+        "sample_paths": [_event_file(directory / "event_sample.hdf5", sample_frame, _SAMPLE_CHARGE)],
+        "ob_paths": [_event_file(directory / "event_ob.hdf5", ob_frame, _OB_CHARGE)],
+        "binning": BinningConfig(
+            bins=_FRAMES,
+            bin_space="tof",
+            tof_range=(100_000, 100_000 + _FRAMES * 5_000),
+            use_log_bin=False,
+        ),
+        "detector_shape": (_SIZE, _SIZE),
+    }
+
+
+def _tiff_kwargs(sample_frame, ob_frame, directory, *, spectra_sidecar):
+    """Kwargs for the two TIFF-plus-NeXus pipelines. TPX1 additionally reads a spectra sidecar."""
+    sample_dir = directory / "sample"
+    ob_dir = directory / "ob"
+    sample_tiffs = _tiff_stack(sample_dir, "sample", sample_frame)
+    ob_tiffs = _tiff_stack(ob_dir, "ob", ob_frame)
+    if spectra_sidecar:
+        edges = [round(0.1 * (index + 1), 1) for index in range(_FRAMES)]
+        _spectra_file(sample_dir / "sample_Spectra.txt", edges)
+        _spectra_file(ob_dir / "ob_Spectra.txt", edges)
+    return {
+        "sample_tiff_paths": [sample_tiffs],
+        "ob_tiff_paths": [ob_tiffs],
+        "sample_hdf5_paths": [
+            _venus_metadata_nexus(directory / "nexus" / "sample.nxs.h5", _SAMPLE_CHARGE, tof_bins=_FRAMES)
+        ],
+        "ob_hdf5_paths": [_venus_metadata_nexus(directory / "nexus" / "ob.nxs.h5", _OB_CHARGE, tof_bins=_FRAMES)],
+    }
+
+
+def _inputs_for(root, sample_frame, ob_frame):
+    """The same synthetic sample/open-beam pair, expressed for each of the three pipelines."""
+    return {
+        "venus_tpx1": _tiff_kwargs(sample_frame, ob_frame, root / "tpx1", spectra_sidecar=True),
+        "venus_tpx3_histogram": _tiff_kwargs(sample_frame, ob_frame, root / "histogram", spectra_sidecar=False),
+        "venus_tpx3_event": _event_kwargs(sample_frame, ob_frame, root / "event"),
+    }
+
+
+def _strip_detector_log(source, destination):
+    """Copy a synthetic NeXus metadata file without its ``BL10:Exp:Det`` detector-name log."""
+    with h5py.File(source, "r") as src, h5py.File(destination, "w") as dst:
+        src.copy("entry", dst)
+        del dst["entry/DASlogs/BL10:Exp:Det"]
+    return destination
+
+
+@pytest.fixture(scope="module")
+def flood_inputs(tmp_path_factory):
+    """Uniform counts, with one dead and one hot pixel in the OPEN BEAM.
+
+    A plain flood leaves every mask empty and makes a mask assertion vacuous, so the open beam — the
+    stack all three pipelines detect their pre-rebin masks from — carries both kinds of bad pixel.
+    """
+    root = tmp_path_factory.mktemp("spine_flood")
+    return _inputs_for(
+        root,
+        _frame(_SAMPLE_COUNTS),
+        _frame(_OB_COUNTS, dead=[_DEAD_PIXEL], hot=[_HOT_PIXEL]),
+    )
+
+
+@pytest.fixture(scope="module")
+def split_dead_inputs(tmp_path_factory):
+    """Dead 2x2 blocks in DIFFERENT places in the sample and the open beam.
+
+    This is what makes the post-spatial-rebin re-detection source observable: the two candidate sources
+    disagree, so the written mask says which stack the pipeline read.
+    """
+    root = tmp_path_factory.mktemp("spine_split_dead")
+    return _inputs_for(
+        root,
+        _frame(_SAMPLE_COUNTS, dead_block=_SAMPLE_DEAD_BLOCK),
+        _frame(_OB_COUNTS, dead_block=_OB_DEAD_BLOCK),
+    )
+
+
+# --------------------------------------------------------------------------------------
+# helpers
+# --------------------------------------------------------------------------------------
+
+
+def _run(name, inputs, output_path, **extra):
+    return _PIPELINES[name](output_path=output_path, **inputs[name], **extra)
+
+
+def _mask(size, pixels, *, xy_axes):
+    """A boolean mask with the given ``(y, x)`` positions set, transposed for ``(x, y)`` output."""
+    expected = np.zeros((size, size), dtype=bool)
+    for y, x in pixels:
+        expected[y, x] = True
+    return expected.T if xy_axes else expected
+
+
+def _written_masks(output_path):
+    """The ``/masks`` dataset names in the written HDF5, and their contents."""
+    with h5py.File(output_path, "r") as f:
+        return sorted(f["masks"]), {mask: f[f"masks/{mask}"][()] for mask in f["masks"]}
+
+
+# --------------------------------------------------------------------------------------
+# 1. the TIFF detector model, which only ever reaches the scitiff DAQ metadata
+# --------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("name", "expected_detector_type"),
+    [
+        ("venus_tpx1", _METADATA_DETECTOR),
+        ("venus_tpx3_histogram", _METADATA_DETECTOR),
+        ("venus_tpx3_event", "TPX3"),
+    ],
+)
+def test_tiff_detector_type_is_the_profiles_model(flood_inputs, tmp_path, name, expected_detector_type):
+    """The ``detector_type`` in the written scitiff DAQ block, read back out of the file.
+
+    Read back rather than intercepting the writer call: this is user-visible output, and the round trip
+    covers the whole path from the profile to the bytes on disk. It is also the only route — the DAQ
+    block is not in the HDF5 output the byte-comparison harness diffs, so nothing else reaches it.
+
+    Two pipelines read the model from the sample's ``detector`` coordinate; the event pipeline
+    hard-codes ``"TPX3"`` and therefore writes something DIFFERENT from the coordinate its own metadata
+    carries — the synthetic input names the detector "MCP TPX3" in all three cases, which is what makes
+    the override visible instead of coincidentally equal.
+    """
+    output_path = tmp_path / f"{name}.tiff"
+    _run(name, flood_inputs, output_path)
+
+    daq = load_scitiff(output_path)["daq"]
+    assert daq.detector_type == expected_detector_type
+    assert daq.facility == "SNS"
+    assert daq.instrument == "VENUS"
+
+
+@pytest.mark.parametrize("name", ["venus_tpx1", "venus_tpx3_histogram"])
+def test_tiff_detector_type_falls_back_to_unknown_without_a_detector_coord(flood_inputs, tmp_path, name):
+    """With no ``detector`` in the metadata, the two profiles that read it write "Unknown".
+
+    The event pipeline is excluded on purpose: its model is a literal, so it never reaches this
+    fallback — that asymmetry is what the test above pins.
+    """
+    inputs = dict(flood_inputs[name])
+    for key, tag in (("sample_hdf5_paths", "sample"), ("ob_hdf5_paths", "ob")):
+        inputs[key] = [_strip_detector_log(inputs[key][0], tmp_path / f"{name}_{tag}_no_detector.nxs.h5")]
+
+    output_path = tmp_path / f"{name}_unknown.tiff"
+    _PIPELINES[name](output_path=output_path, **inputs)
+
+    assert load_scitiff(output_path)["daq"].detector_type == "Unknown"
+
+
+# --------------------------------------------------------------------------------------
+# 2. the profile table itself
+# --------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("profile", "expected"),
+    [
+        pytest.param(
+            _TPX1_PROFILE,
+            {
+                "label": "VENUS TPX1",
+                "detect_hot": False,
+                "remask_after_spatial_rebin_from": "ob",
+                "hdf5_hot_pixel_mask": None,
+                "tiff_detector_model": None,
+            },
+            id="venus_tpx1",
+        ),
+        pytest.param(
+            _TPX3_HISTOGRAM_PROFILE,
+            {
+                "label": "VENUS TPX3 histogram",
+                "detect_hot": True,
+                "remask_after_spatial_rebin_from": "sample",
+                "hdf5_hot_pixel_mask": "hot_pixels",
+                "tiff_detector_model": None,
+            },
+            id="venus_tpx3_histogram",
+        ),
+        pytest.param(
+            _TPX3_EVENT_PROFILE,
+            {
+                "label": "VENUS TPX3 event",
+                "detect_hot": True,
+                "remask_after_spatial_rebin_from": "ob",
+                "hdf5_hot_pixel_mask": "hot_pixels",
+                "tiff_detector_model": "TPX3",
+            },
+            id="venus_tpx3_event",
+        ),
+    ],
+)
+def test_profile_values_are_the_preserved_per_pipeline_behaviour(profile, expected):
+    """Every field of every profile, as one table. A deliberate change detector.
+
+    These are the three pipelines' PRE-EXISTING values, carried across the spine refactor unchanged,
+    not decisions the refactor made. Two are surprising and still correct to keep:
+    ``venus_tpx3_histogram`` re-detects post-spatial-rebin masks from the SAMPLE (the other two read
+    the open beam, as does its own pre-rebin detection), and ``venus_tpx1`` passes the HDF5 writer no
+    ``hot_pixel_mask`` name — a mask literally called ``hot_pixels`` would land at
+    ``/masks/hot_pixels`` there and at ``/masks/hot`` in the other two. Changing an expected value here
+    changes published output, so it needs a release note rather than a test update.
+
+    Compared as a whole dict rather than field by field: a field added to ``TofPipelineProfile`` fails
+    here until every pipeline's value for it is recorded.
+    """
+    assert dataclasses.asdict(profile) == expected
+
+
+# --------------------------------------------------------------------------------------
+# 3. the HDF5 mask layout each pipeline writes
+# --------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("name", "expected_masks"),
+    [
+        ("venus_tpx1", ["dead"]),
+        ("venus_tpx3_histogram", ["dead", "hot"]),
+        ("venus_tpx3_event", ["dead", "hot"]),
+    ],
+)
+def test_hdf5_mask_datasets_follow_the_profile(flood_inputs, tmp_path, name, expected_masks):
+    """Which ``/masks/*`` datasets land in the output, and that they hold the planted bad pixels.
+
+    ``venus_tpx1`` detects no hot pixels, so its output carries ``/masks/dead`` alone: a consumer that
+    reads ``/masks/hot`` unconditionally works on the other two and raises on TPX1. That is on-disk
+    layout, and pre-existing, so it is pinned.
+
+    Each mask is compared against the exact pixels planted in the open beam rather than checked for
+    non-emptiness — an all-False mask would satisfy "the dataset exists" while the detection did
+    nothing, and a count would not notice a transposed mask.
+    """
+    output_path = tmp_path / f"{name}_masks.hdf5"
+    _run(name, flood_inputs, output_path)
+
+    xy_axes = _XY_AXES[name]
+    expected = {
+        "dead": _mask(_SIZE, [_DEAD_PIXEL], xy_axes=xy_axes),
+        "hot": _mask(_SIZE, [_HOT_PIXEL], xy_axes=xy_axes),
+    }
+
+    written_names, written = _written_masks(output_path)
+    assert written_names == expected_masks
+    for mask_name in written_names:
+        np.testing.assert_array_equal(written[mask_name], expected[mask_name])
+        assert written[mask_name].any(), f"the {mask_name} mask is empty, so this input proves nothing"
+
+
+# --------------------------------------------------------------------------------------
+# 4. which stack the post-spatial-rebin masks are re-detected from
+# --------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("name", "expected_dead_superpixels"),
+    [
+        # The ob's dead block is at y 4:6, x 0:2 and the sample's at y 0:2, x 2:4, so a rebin by 2
+        # collapses them to superpixels (2, 0) and (0, 1) respectively.
+        #
+        # (2, 0) appears under BOTH re-detection sources, and not by accident: the pre-rebin mask is
+        # detected from the ob but attached to the SAMPLE, and scipp zeroes masked elements when it
+        # sums, so the sample's superpixel over the ob's dead block sums to zero as well. The
+        # sample's OWN dead block at (0, 1) is therefore the discriminating pixel — present only when
+        # the re-detection reads the sample.
+        ("venus_tpx3_histogram", [(0, 1), (2, 0)]),
+        ("venus_tpx1", [(2, 0)]),
+        ("venus_tpx3_event", [(2, 0)]),
+    ],
+)
+def test_post_spatial_rebin_masks_come_from_the_profiles_source(
+    split_dead_inputs, tmp_path, name, expected_dead_superpixels
+):
+    """After a spatial rebin, ``venus_tpx3_histogram`` re-detects from the SAMPLE and the other two
+    from the open beam.
+
+    Pre-existing behaviour, preserved, and it disagrees with the histogram pipeline's own pre-rebin
+    detection, which reads the open beam like its siblings. It is observable only when the two stacks
+    have bad pixels in different places, which is what this input arranges — so this is the test that
+    catches a well-meaning "fix" unifying the three.
+    """
+    output_path = tmp_path / f"{name}_rebin_masks.hdf5"
+    _run(name, split_dead_inputs, output_path, rebin_by_spatial=2)
+
+    expected = _mask(_SIZE // 2, expected_dead_superpixels, xy_axes=_XY_AXES[name])
+    _, written = _written_masks(output_path)
+    np.testing.assert_array_equal(written["dead"], expected)
+    assert written["dead"].any(), "no dead superpixel survived the rebin, so this input proves nothing"
+
+
+# --------------------------------------------------------------------------------------
+# 5. the export dispatch's fallthrough
+# --------------------------------------------------------------------------------------
+
+
+def test_unsupported_output_suffix_is_rejected(flood_inputs, tmp_path):
+    """An unknown suffix raises instead of writing something unreadable under that name."""
+    with pytest.raises(ValueError, match=re.escape("Unsupported output file format: .npy")):
+        _run("venus_tpx3_histogram", flood_inputs, tmp_path / "out.npy")


### PR DESCRIPTION
> Blocked on #199. Based on `feat/progress-reporting-195`; rebase onto `next` and retarget once #199 merges.

## Description

Adds `spectrum_roi` to the three VENUS TOF pipelines. With it, the reduction returns a 1-D transmission
spectrum instead of a stack of images: per TOF bin, the sample's mean counts over the region divided by
the open beam's mean counts over the same region. Written as a three-column ASCII file, with an HDF5
sibling carrying the time axis, masks and provenance.

```text
bin_index,transmission,uncertainty
0,0.448760,0.010663
```

New modules: `processing/spectrum_reducer.py` (`roi_mean_spectrum`, `normalize_roi_spectrum`) and
`exporters/ascii_writer.py` (`write_ascii_spectrum`). `detect_resonances` takes the same `spectrum_roi`.
`rebin_by_tof` applies as in image mode; `bin_index` is each bin's first input frame.

Also extracts the shared middle of the three TOF pipelines into `pipelines/_tof_spine.py`
(409/405/418 -> 275/267/291 lines, three `# noqa: C901` removed). Behaviour-preserving; public signatures
unchanged apart from the two new keyword-only parameters.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor (no behavior change)
- [x] Docs / CI / tooling
- [ ] Breaking change

## Checklist

- [x] Tests added/updated and `pixi run test` passes (osx-arm64 locally; linux-64 pending CI)
- [x] `pixi run pre-commit run --all-files` is clean
- [x] Docs updated (docstrings / `docs/`) if the public API changed
- [x] For refactors: confirmed existing behavior is preserved
- [x] Floating-point array comparisons use `assert_allclose`, not `assert_equal`

## Linked issues

Closes #197. Depends on #199.

## How to test

```bash
pixi install --frozen
pixi run test
pixi run build-docs
```

New suites: `test_spectrum_mode_pipelines.py`, `test_spectrum_reduction.py`, `test_roi_spectrum.py`,
`test_spectrum_frame_binning.py`, `test_spectrum_uncertainty.py`, `test_ascii_spectrum_writer.py`,
`test_spine_profiles.py`, `test_docs_resonance_examples.py`.

Usage and the file format: `docs/resonance_mode.md`.
