### PR TITLE
fix(docs): restore the documentation build under Sphinx 9

### DIFF
--- a/.github/workflows/test_and_deploy.yaml
+++ b/.github/workflows/test_and_deploy.yaml
@@ -51,6 +51,34 @@ jobs:
           files: ./coverage.xml
           fail_ci_if_error: false
 
+  docs:
+    # Read the Docs was previously the only consumer of the documentation build, and
+    # its failures are not surfaced on pull requests -- so a dependency update that
+    # broke autodoc could merge with every check green. This job runs the same
+    # warnings-as-errors build that Read the Docs does, on the same linux-64 platform,
+    # so the breakage shows up on the PR instead.
+    name: Build documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Setup pixi
+        uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
+        with:
+          pixi-version: v0.70.1
+          manifest-path: pyproject.toml
+          frozen: true
+          environments: docs
+
+      # Warnings are errors (the build-docs task passes -W --keep-going), matching
+      # the sphinx-build invocation in .readthedocs.yaml.
+      - name: Build documentation
+        run: pixi run -e docs build-docs
+
   conda-build:
     name: Build conda package
     runs-on: ubuntu-latest

--- a/.harness/TASK.anchor
+++ b/.harness/TASK.anchor
@@ -1,0 +1,5 @@
+{
+  "algorithm": "sha256",
+  "lock_sha256": "a0825497fc34f3f3ba86332284821687c195100ce88777fe60618f279e279465",
+  "version": 1
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Documentation build restored under Sphinx 9.** The API reference was silently dropping seven
+  modules — all six `neunorm.pipelines.*` modules and `neunorm.exporters.tiff_writer` — and the
+  Read the Docs build was failing outright. The cause is an upstream Sphinx 9 defect
+  ([sphinx-doc/sphinx#14337](https://github.com/sphinx-doc/sphinx/issues/14337)): its rewritten
+  autodoc walks a documented class's whole MRO and, for each class's module, rebuilds annotations
+  from that module's source and writes them back onto the live classes, including third-party ones
+  and not only the base classes themselves. Reaching pydantic's `BaseModel`
+  restores the `__pydantic_extra__` annotation that pydantic clears at class-creation time, after
+  which the next model declared `extra="allow"` (scitiff's) fails schema generation and every
+  module importing it drops out of the docs. Setting `autodoc_use_type_comments = False` in
+  `docs/conf.py` disables the offending pass; NeuNorm uses no `# type:` comments, so nothing is
+  lost, and this becomes the Sphinx default in version 10. No runtime behaviour was affected — the
+  package imported and the test suite passed throughout. A `docs` job was also added to CI, which
+  runs the same warnings-as-errors build as Read the Docs, so a documentation-breaking dependency
+  update now fails a pull-request check instead of merging unnoticed.
 - **Air-region correction now uses the true (pooled) region mean.** The previous implementation
   averaged with `sc.mean` over a dim list, which reduces sequentially (a mean of row-means): with
   dead/hot-masked pixels in the air region it weighted rows unequally (a slightly wrong estimator

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,6 +41,19 @@ autodoc_default_options = {
     "member-order": "bysource",
 }
 autodoc_typehints = "description"
+
+# Sphinx 9's rewritten autodoc walks a documented class's whole MRO and, for each
+# class's module, rebuilds annotations from that module's source and writes them back
+# onto the live classes -- including third-party ones, and not only the base classes
+# themselves. Reaching pydantic's BaseModel restores the __pydantic_extra__ annotation
+# that pydantic deliberately clears at class-creation time, after which the next model
+# declared extra="allow" (scitiff's) fails schema generation and takes every module
+# that imports it out of the API reference.
+# See https://github.com/sphinx-doc/sphinx/issues/14337.
+# NeuNorm uses no `# type:` comments, so turning this off costs nothing, and it is
+# the default from Sphinx 10 onwards.
+autodoc_use_type_comments = False
+
 napoleon_numpy_docstring = True
 napoleon_google_docstring = False
 


### PR DESCRIPTION
Sphinx 9.1.0 broke autodoc for every module importing scitiff: the API reference lost the six pipeline modules and the TIFF exporter, and Read the Docs failed.

Sets `autodoc_use_type_comments = False` (upstream: sphinx-doc/sphinx#14337); NeuNorm uses no type comments, so nothing is lost. Adds a CI docs job with the same warnings-as-errors gate.

Checks: docs build clean, all seven modules rendered; 619 tests pass.
