### PR TITLE
feat(combine): metadata_match_atol tolerance for metadata match checks

### DIFF
--- a/src/neunorm/pipelines/mars_ccd.py
+++ b/src/neunorm/pipelines/mars_ccd.py
@@ -41,6 +41,7 @@ def run_mars_ccd_pipeline(  # noqa: C901
     roi: Optional[ROILike] = None,
     gamma_filter: bool = True,
     background_roi: Optional[BackgroundROILike] = None,
+    metadata_match_atol: float = 0.0,
 ) -> sc.DataArray:
     """Execute MARS CCD/CMOS normalization pipeline.
 
@@ -83,6 +84,10 @@ def run_mars_ccd_pipeline(  # noqa: C901
         normalization when proton charge is unavailable. Mutually exclusive with proton-charge
         correction. If ``roi`` is also given the detector is cropped first, so ``background_roi``
         indices are resolved in the post-crop frame.
+    metadata_match_atol : float, optional
+        Absolute tolerance for the metadata match check when combining runs
+        (exposure time and MotSlit aperture readback positions), by default
+        0.0 (exact match). Detector names always require an exact match.
 
     Notes
     -----
@@ -125,6 +130,7 @@ def run_mars_ccd_pipeline(  # noqa: C901
             "MotSlitHL.RBV",
         ],
         normalize_by_runs=True,
+        metadata_match_atol=metadata_match_atol,
     )
 
     ob = combine_runs(
@@ -139,6 +145,7 @@ def run_mars_ccd_pipeline(  # noqa: C901
             "MotSlitHL.RBV",
         ],
         normalize_by_runs=True,
+        metadata_match_atol=metadata_match_atol,
     )
 
     # Dark current is optional: only load/combine it when dark paths are provided.
@@ -153,6 +160,7 @@ def run_mars_ccd_pipeline(  # noqa: C901
                 "ManufacturerStr",
             ],
             normalize_by_runs=True,
+            metadata_match_atol=metadata_match_atol,
         )
 
     # Apply ROI if specified

--- a/src/neunorm/processing/run_combiner.py
+++ b/src/neunorm/processing/run_combiner.py
@@ -4,8 +4,24 @@ Module for combining multiple runs of neutron imaging data into a single dataset
 
 from typing import Sequence
 
+import numpy as np
 import scipp as sc
 from loguru import logger
+
+
+def _metadata_matches(a: sc.Variable, b: sc.Variable, atol: float) -> bool:
+    """True when two metadata coords are identical, or — for numeric values of
+    the same unit and shape — differ element-wise by at most ``atol``."""
+    if sc.identical(a, b):
+        return True
+    if atol <= 0 or a.unit != b.unit or a.shape != b.shape:
+        return False
+    try:
+        av = np.asarray(a.value if a.ndim == 0 else a.values, dtype=float)
+        bv = np.asarray(b.value if b.ndim == 0 else b.values, dtype=float)
+    except (TypeError, ValueError):
+        return False  # non-numeric (e.g. string) values must match exactly
+    return bool(np.all(np.abs(av - bv) <= atol))
 
 
 def combine_runs(  # noqa: C901
@@ -13,6 +29,7 @@ def combine_runs(  # noqa: C901
     metadata_keys_to_sum: Sequence[str] = ("acquisition_time", "p_charge"),
     metadata_check_match: Sequence[str] = (),
     normalize_by_runs: bool = False,
+    metadata_match_atol: float = 0.0,
 ) -> sc.DataArray:
     """Combine multiple runs by summing with metadata aggregation.
 
@@ -35,6 +52,12 @@ def combine_runs(  # noqa: C901
         Sequence of metadata keys that must match across all runs for combination, by default ()
     normalize_by_runs : bool, optional
         Whether to normalize the combined data by the number of runs, by default False
+    metadata_match_atol : float, optional
+        Absolute tolerance for the ``metadata_check_match`` comparison of numeric
+        values (same unit and shape required), by default 0.0 (exact match).
+        Non-numeric values (e.g. detector names) always require an exact match.
+        Useful for slit/aperture readback positions that jitter slightly
+        between runs.
 
     Returns
     -------
@@ -77,7 +100,7 @@ def combine_runs(  # noqa: C901
             if key not in run.coords:
                 logger.error("Metadata key '{}' not found in run {} for matching", key, i)
                 raise ValueError(f"Metadata key '{key}' not found in run {i} for matching")
-            if not sc.identical(run.coords[key], base_metadata[key]):
+            if not _metadata_matches(run.coords[key], base_metadata[key], metadata_match_atol):
                 logger.error(
                     "Metadata key '{}' does not match between run {} and base run: {} vs {}",
                     key,
@@ -91,10 +114,20 @@ def combine_runs(  # noqa: C901
                     f" {base_metadata[key].value if base_metadata[key].ndim == 0 else base_metadata[key].values}"
                 )
 
-    # Combine data by summing across runs
+    # Combine data by summing across runs. Coords that matched only within
+    # metadata_match_atol would still fail scipp's exact aligned-coord check
+    # in `+=`, so they are aligned to the base run's value on a shallow copy
+    # (the caller's array is left untouched; metadata_keys_to_sum below still
+    # aggregates the original per-run values).
     combined = runs[0].copy()
     for run in runs[1:]:
-        combined += run
+        patched = None
+        for key in metadata_check_match:
+            if not sc.identical(run.coords[key], base_metadata[key]):
+                if patched is None:
+                    patched = run.copy(deep=False)
+                patched.coords[key] = base_metadata[key]
+        combined += patched if patched is not None else run
 
     if normalize_by_runs:
         combined /= len(runs)

--- a/tests/unit/test_run_combiner.py
+++ b/tests/unit/test_run_combiner.py
@@ -444,3 +444,60 @@ def test_combine_runs_no_masks():
     np.testing.assert_allclose(combined.variances, expected_values)
     # There should be no masks in the combined result
     assert len(combined.masks) == 0
+
+
+def test_combine_runs_metadata_match_atol():
+    """Numeric metadata within metadata_match_atol combines (keeping the base
+    run's value); outside the tolerance, or for string metadata, it still
+    raises. The caller's arrays are never modified."""
+    from neunorm.processing.run_combiner import combine_runs
+
+    def make_run(slit, detector="SBIG"):
+        run = sc.DataArray(
+            data=sc.array(
+                dims=["N_image", "x", "y"],
+                values=np.ones((1, 5, 5)),
+                variances=np.ones((1, 5, 5)),
+                unit="counts",
+            ),
+        )
+        run.coords["MotSlitHR.RBV"] = sc.scalar(slit)
+        run.coords["ManufacturerStr"] = sc.scalar(detector)
+        return run
+
+    keys = ["MotSlitHR.RBV", "ManufacturerStr"]
+
+    # Default (atol=0) keeps the exact-match behavior.
+    with pytest.raises(ValueError, match="does not match"):
+        combine_runs([make_run(10.0), make_run(10.4)], metadata_keys_to_sum=[], metadata_check_match=keys)
+
+    # Within the tolerance the runs combine; the base run's value is kept and
+    # the second run is left untouched.
+    run_b = make_run(10.4)
+    combined = combine_runs(
+        [make_run(10.0), run_b],
+        metadata_keys_to_sum=[],
+        metadata_check_match=keys,
+        metadata_match_atol=1.0,
+    )
+    np.testing.assert_allclose(combined.values, np.full((1, 5, 5), 2.0))
+    assert combined.coords["MotSlitHR.RBV"].value == 10.0
+    assert run_b.coords["MotSlitHR.RBV"].value == 10.4
+
+    # Outside the tolerance it still raises.
+    with pytest.raises(ValueError, match="does not match"):
+        combine_runs(
+            [make_run(10.0), make_run(12.0)],
+            metadata_keys_to_sum=[],
+            metadata_check_match=keys,
+            metadata_match_atol=1.0,
+        )
+
+    # String metadata is never compared with a tolerance.
+    with pytest.raises(ValueError, match="does not match"):
+        combine_runs(
+            [make_run(10.0), make_run(10.0, detector="Andor")],
+            metadata_keys_to_sum=[],
+            metadata_check_match=keys,
+            metadata_match_atol=5.0,
+        )


### PR DESCRIPTION
## Summary

- `combine_runs` gains a `metadata_match_atol` parameter (default `0.0` = exact match, unchanged behavior): numeric metadata of the same unit and shape now matches within ±atol, while non-numeric values (e.g. detector names) still require exact equality.
- Within-tolerance coords are aligned to the base run's value on a shallow copy before summing — scipp's aligned-coord check in `+=` requires exact equality, so the tolerance check alone is not enough. Callers' arrays are left untouched, and `metadata_keys_to_sum` still aggregates the original per-run values.
- `run_mars_ccd_pipeline` exposes the parameter and forwards it to its sample/OB/dark `combine_runs` calls.

## Motivation

The MARS slit readback positions (`MotSlit*.RBV`) jitter slightly between runs. The exact `sc.identical` check aborted the MARS CCD pipeline when combining open-beam runs that the notebook-side matching had already accepted within ±1. With `metadata_match_atol` the caller can pass the same tolerance used for OB/DC selection.

## Test plan

- New unit test `test_combine_runs_metadata_match_atol` covers: default exact behavior unchanged, within-tolerance combination (base run's value kept, caller arrays untouched), outside-tolerance rejection, and string metadata never being compared with a tolerance.
- `tests/unit/test_run_combiner.py` + `tests/unit/test_mars_ccd*.py`: 31 passed.
- End-to-end `run_mars_ccd_pipeline` run on HFIR CG1D IPTS-38679 data (3 OB runs, `metadata_match_atol=1.0`) completes successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
